### PR TITLE
Fix nodename

### DIFF
--- a/source/BeastMagnetDetector.cc
+++ b/source/BeastMagnetDetector.cc
@@ -93,8 +93,8 @@ void BeastMagnetDetector::InsertVolumes(G4VPhysicalVolume *physvol)
   G4LogicalVolume *logvol = physvol->GetLogicalVolume();
   m_DisplayAction->AddLogicalVolume(logvol);
   m_PhysicalVolumesSet.insert(physvol);
-// G4 10.06 returns unsigned int for GetNoDaughters()
-// lower version return int, need to cast to avoid compiler error
+  // G4 10.06 returns unsigned int for GetNoDaughters()
+  // lower version return int, need to cast to avoid compiler error
   for (int i = 0; i < (int) logvol->GetNoDaughters(); ++i)
   {
     G4VPhysicalVolume *physvol = logvol->GetDaughter(i);

--- a/source/BeastMagnetSteppingAction.cc
+++ b/source/BeastMagnetSteppingAction.cc
@@ -336,7 +336,6 @@ bool BeastMagnetSteppingAction::UserSteppingAction(const G4Step *aStep, bool was
 //____________________________________________________________________________..
 void BeastMagnetSteppingAction::SetInterfacePointers(PHCompositeNode *topNode)
 {
-
   string hitnodename;
   if (m_Detector->SuperDetector() != "NONE")
   {

--- a/source/BeastMagnetSteppingAction.cc
+++ b/source/BeastMagnetSteppingAction.cc
@@ -336,7 +336,16 @@ bool BeastMagnetSteppingAction::UserSteppingAction(const G4Step *aStep, bool was
 //____________________________________________________________________________..
 void BeastMagnetSteppingAction::SetInterfacePointers(PHCompositeNode *topNode)
 {
-  string hitnodename = "G4HIT_" + m_Detector->GetName();
+
+  string hitnodename;
+  if (m_Detector->SuperDetector() != "NONE")
+  {
+    hitnodename = "G4HIT_" + m_Detector->SuperDetector();
+  }
+  else
+  {
+    hitnodename = "G4HIT_" + m_Detector->GetName();
+  }
   // now look for the map and grab a pointer to it.
   m_HitContainer = findNode::getClass<PHG4HitContainer>(topNode, hitnodename);
   // if we do not find the node we need to make it.

--- a/source/BeastMagnetSubsystem.cc
+++ b/source/BeastMagnetSubsystem.cc
@@ -54,29 +54,36 @@ int BeastMagnetSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   // create display settings before detector
   m_DisplayAction = new BeastMagnetDisplayAction(Name());
 
+  // create detector
+  m_Detector = new BeastMagnetDetector(this, topNode, GetParams(), Name());
+  m_Detector->OverlapCheck(CheckOverlap());
+  m_Detector->SuperDetector(SuperDetector());
+
   PHNodeIterator dstIter(dstNode);
   if (GetParams()->get_int_param("active"))
   {
-    PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstIter.findFirst("PHCompositeNode", Name()));
+    string name;
+    if (SuperDetector() != "NONE")
+    {
+      name = SuperDetector();
+    }
+    else
+    {
+      name = Name();
+    }
+    PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstIter.findFirst("PHCompositeNode", name));
     if (!DetNode)
     {
-      DetNode = new PHCompositeNode(Name());
+      DetNode = new PHCompositeNode(name);
       dstNode->addNode(DetNode);
     }
-    string g4hitnodename = "G4HIT_" + Name();
+    string g4hitnodename = "G4HIT_" + name;
     PHG4HitContainer *g4_hits = findNode::getClass<PHG4HitContainer>(DetNode, g4hitnodename);
     if (!g4_hits)
     {
       g4_hits = new PHG4HitContainer(g4hitnodename);
       DetNode->addNode(new PHIODataNode<PHObject>(g4_hits, g4hitnodename, "PHObject"));
     }
-  }
-  // create detector
-  m_Detector = new BeastMagnetDetector(this, topNode, GetParams(), Name());
-  m_Detector->OverlapCheck(CheckOverlap());
-  // create stepping action if detector is active
-  if (GetParams()->get_int_param("active"))
-  {
     m_SteppingAction = new BeastMagnetSteppingAction(m_Detector, GetParams());
   }
   return 0;


### PR DESCRIPTION
This PR fixes the name of the hit node if SuperDetector is set. This setting was so far ignored - one always had a BeastMagnet_0 node. Now it is consistent with other detectors