### PR TITLE
for development allow unused variables

### DIFF
--- a/simulation/g4simulation/g4eicdirc/configure.ac
+++ b/simulation/g4simulation/g4eicdirc/configure.ac
@@ -9,8 +9,8 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template"
  ;;
- g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror"
+ *g++)
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-unused-variable"
  ;;
 esac
 


### PR DESCRIPTION
This PR is a small fix - from the development there are a lot of currently unused variables, suppress the fatal error with -Wno-unused-variables