### PR TITLE
Use support active

### DIFF
--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalDetector.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalDetector.h
@@ -63,6 +63,7 @@ class PHG4ForwardHcalDetector : public PHG4Detector
 
   int m_ActiveFlag = 1;
   int m_AbsorberActiveFlag = 0;
+  int m_SupportActiveFlag = 0;
   int m_Layer = 0;
 
   std::string m_TowerLogicNamePrefix;
@@ -73,6 +74,7 @@ class PHG4ForwardHcalDetector : public PHG4Detector
 
   std::set<G4LogicalVolume *> m_AbsorberLogicalVolSet;
   std::set<G4LogicalVolume *> m_ScintiLogicalVolSet;
+  std::set<G4LogicalVolume *> m_SupportLogicalVolSet;
 };
 
 #endif

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalDisplayAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalDisplayAction.cc
@@ -9,7 +9,7 @@
 #include <TSystem.h>
 
 #include <iostream>
-#include <utility>                     // for pair
+#include <utility>  // for pair
 
 PHG4ForwardHcalDisplayAction::PHG4ForwardHcalDisplayAction(const std::string &name)
   : PHG4DisplayAction(name)

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalDisplayAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalDisplayAction.cc
@@ -11,8 +11,6 @@
 #include <iostream>
 #include <utility>                     // for pair
 
-using namespace std;
-
 PHG4ForwardHcalDisplayAction::PHG4ForwardHcalDisplayAction(const std::string &name)
   : PHG4DisplayAction(name)
 {
@@ -68,7 +66,7 @@ void PHG4ForwardHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol
     }
     else
     {
-      cout << "unknown logical volume " << it.second << endl;
+      std::cout << "unknown logical volume " << it.second << std::endl;
       gSystem->Exit(1);
     }
     logvol->SetVisAttributes(visatt);

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalDisplayAction.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalDisplayAction.h
@@ -16,11 +16,11 @@ class G4VPhysicalVolume;
 class PHG4ForwardHcalDisplayAction : public PHG4DisplayAction
 {
  public:
-  PHG4ForwardHcalDisplayAction(const std::string &name);
+  explicit PHG4ForwardHcalDisplayAction(const std::string &name);
 
   virtual ~PHG4ForwardHcalDisplayAction();
 
-  void ApplyDisplayAction(G4VPhysicalVolume *physvol);
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
   void AddVolume(G4LogicalVolume *logvol, const std::string &mat) { m_LogicalVolumeMap[logvol] = mat; }
 
  private:

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSteppingAction.cc
@@ -149,15 +149,14 @@ bool PHG4ForwardHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool
       }
       else
       {
-	if (whichactive == -1)
-	{
-        m_SaveHitContainer = m_AbsorberHitContainer;
-	}
-	else
-	{
-	  m_SaveHitContainer = m_SupportHitContainer;
-	}
-
+        if (whichactive == -1)
+        {
+          m_SaveHitContainer = m_AbsorberHitContainer;
+        }
+        else
+        {
+          m_SaveHitContainer = m_SupportHitContainer;
+        }
       }
       if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
       {
@@ -228,8 +227,8 @@ bool PHG4ForwardHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool
       }
     }
     if (edep > 0 && (whichactive > 0 ||
-        (whichactive == -1 && m_AbsorberTruthFlag > 0) ||
-        (whichactive < -1 && m_SupportTruthFlag > 0)))
+                     (whichactive == -1 && m_AbsorberTruthFlag > 0) ||
+                     (whichactive < -1 && m_SupportTruthFlag > 0)))
     {
       if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
       {
@@ -285,7 +284,7 @@ void PHG4ForwardHcalSteppingAction::SetInterfacePointers(PHCompositeNode* topNod
   //now look for the map and grab a pointer to it.
   m_HitContainer = findNode::getClass<PHG4HitContainer>(topNode, m_HitNodeName);
   m_AbsorberHitContainer = findNode::getClass<PHG4HitContainer>(topNode, m_AbsorberNodeName);
-  m_SupportHitContainer  = findNode::getClass<PHG4HitContainer>(topNode, m_SupportNodeName);
+  m_SupportHitContainer = findNode::getClass<PHG4HitContainer>(topNode, m_SupportNodeName);
   // if we do not find the node it's messed up.
   if (!m_HitContainer)
   {

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSteppingAction.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSteppingAction.h
@@ -26,10 +26,14 @@ class PHG4ForwardHcalSteppingAction : public PHG4SteppingAction
   virtual ~PHG4ForwardHcalSteppingAction();
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step*, bool);
+  bool UserSteppingAction(const G4Step*, bool) override;;
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers(PHCompositeNode*);
+  void SetInterfacePointers(PHCompositeNode*) override;
+
+  void SetHitNodeName(const std::string &nam) {m_HitNodeName = nam;}
+  void SetAbsorberNodeName(const std::string &nam) {m_AbsorberNodeName = nam;}
+  void SetSupportNodeName(const std::string &nam) {m_SupportNodeName = nam;}
 
  private:
   //! pointer to the detector
@@ -38,13 +42,19 @@ class PHG4ForwardHcalSteppingAction : public PHG4SteppingAction
   //! pointer to hit container
   PHG4HitContainer* m_HitContainer = nullptr;
   PHG4HitContainer* m_AbsorberHitContainer = nullptr;
+  PHG4HitContainer* m_SupportHitContainer = nullptr;
   PHG4HitContainer* m_SaveHitContainer = nullptr;
   PHG4Hit* m_Hit = nullptr;
   PHG4Shower* m_SaveShower = nullptr;
 
   int m_ActiveFlag = 0;
   int m_AbsorberTruthFlag = 0;
+  int m_SupportTruthFlag = 0;
   int m_BlackHoleFlag = 0;
+
+  std::string m_HitNodeName;
+  std::string m_AbsorberNodeName;
+  std::string m_SupportNodeName;
 };
 
 #endif  // G4DETECTORS_PHG4FORWARDHCALSTEPPINGACTION_H

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSteppingAction.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSteppingAction.h
@@ -26,14 +26,15 @@ class PHG4ForwardHcalSteppingAction : public PHG4SteppingAction
   virtual ~PHG4ForwardHcalSteppingAction();
 
   //! stepping action
-  bool UserSteppingAction(const G4Step*, bool) override;;
+  bool UserSteppingAction(const G4Step*, bool) override;
+  ;
 
   //! reimplemented from base class
   void SetInterfacePointers(PHCompositeNode*) override;
 
-  void SetHitNodeName(const std::string &nam) {m_HitNodeName = nam;}
-  void SetAbsorberNodeName(const std::string &nam) {m_AbsorberNodeName = nam;}
-  void SetSupportNodeName(const std::string &nam) {m_SupportNodeName = nam;}
+  void SetHitNodeName(const std::string& nam) { m_HitNodeName = nam; }
+  void SetAbsorberNodeName(const std::string& nam) { m_AbsorberNodeName = nam; }
+  void SetSupportNodeName(const std::string& nam) { m_SupportNodeName = nam; }
 
  private:
   //! pointer to the detector

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSubsystem.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSubsystem.cc
@@ -95,11 +95,11 @@ int PHG4ForwardHcalSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
       }
     }
     // create stepping action
-   PHG4ForwardHcalSteppingAction *tmp = new PHG4ForwardHcalSteppingAction(m_Detector, GetParams());
-   tmp->SetHitNodeName(m_HitNodeName);
-   tmp->SetAbsorberNodeName(m_AbsorberNodeName);
-   tmp->SetSupportNodeName(m_SupportNodeName);
-   m_SteppingAction = tmp;
+    PHG4ForwardHcalSteppingAction* tmp = new PHG4ForwardHcalSteppingAction(m_Detector, GetParams());
+    tmp->SetHitNodeName(m_HitNodeName);
+    tmp->SetAbsorberNodeName(m_AbsorberNodeName);
+    tmp->SetSupportNodeName(m_SupportNodeName);
+    m_SteppingAction = tmp;
   }
 
   return 0;
@@ -172,7 +172,7 @@ void PHG4ForwardHcalSubsystem::SetTowerMappingFile(const std::string& filename)
   set_string_param("mapping_file_md5", PHG4Utils::md5sum(get_string_param("mapping_file")));
 }
 
-void PHG4ForwardHcalSubsystem::Print(const std::string &what) const
+void PHG4ForwardHcalSubsystem::Print(const std::string& what) const
 {
   std::cout << Name() << " Parameters: " << std::endl;
   if (!BeginRunExecuted())

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSubsystem.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSubsystem.h
@@ -36,7 +36,7 @@ class PHG4ForwardHcalSubsystem : public PHG4DetectorSubsystem
   int process_event(PHCompositeNode *) override;
 
   //! Print info (from SubsysReco)
-  void Print(const std::string& what = "ALL") const override;
+  void Print(const std::string &what = "ALL") const override;
 
   /** Accessors (reimplemented)
    */

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSubsystem.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSubsystem.h
@@ -29,24 +29,27 @@ class PHG4ForwardHcalSubsystem : public PHG4DetectorSubsystem
      Creates the stepping action
      Creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRunSubsystem(PHCompositeNode *);
+  int InitRunSubsystem(PHCompositeNode *) override;
 
   /** Event processing
    */
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
+
+  //! Print info (from SubsysReco)
+  void Print(const std::string& what = "ALL") const override;
 
   /** Accessors (reimplemented)
    */
-  PHG4Detector *GetDetector() const;
-  PHG4SteppingAction *GetSteppingAction() const { return m_SteppingAction; }
-  PHG4DisplayAction *GetDisplayAction() const { return m_DisplayAction; }
+  PHG4Detector *GetDetector() const override;
+  PHG4SteppingAction *GetSteppingAction() const override { return m_SteppingAction; }
+  PHG4DisplayAction *GetDisplayAction() const override { return m_DisplayAction; }
 
   /** Set mapping file for calorimeter towers
    */
   void SetTowerMappingFile(const std::string &filename);
 
  private:
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
   /** Pointer to the Geant4 implementation of the detector
    */
@@ -58,6 +61,10 @@ class PHG4ForwardHcalSubsystem : public PHG4DetectorSubsystem
   //! display attribute setting
   /*! derives from PHG4DisplayAction */
   PHG4DisplayAction *m_DisplayAction = nullptr;
+
+  std::string m_HitNodeName;
+  std::string m_AbsorberNodeName;
+  std::string m_SupportNodeName;
 };
 
 #endif


### PR DESCRIPTION
This PR adds the new support active feature. Up to now every passive volume was labelled absorber - even support structures. In this case you probably would label the support (wls, support plates) as part of the absorber but someone had to be the guinea pig.
The names of the output nodes is set on one place now - the Subsystem. The Stepping Action receives the name from there - no more duplication and possible confusion by figuring the name out a second time