### PR TITLE
use wildcard to look for g++ compiler in configure.ac

### DIFF
--- a/simulation/g4simulation/g4drcalo/configure.ac
+++ b/simulation/g4simulation/g4drcalo/configure.ac
@@ -10,7 +10,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wno-undefined-var-template"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/simulation/g4simulation/g4eiccalos/configure.ac
+++ b/simulation/g4simulation/g4eiccalos/configure.ac
@@ -10,7 +10,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wno-undefined-var-template"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/simulation/g4simulation/g4jleic/configure.ac
+++ b/simulation/g4simulation/g4jleic/configure.ac
@@ -9,7 +9,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/simulation/g4simulation/g4mrich/configure.ac
+++ b/simulation/g4simulation/g4mrich/configure.ac
@@ -10,7 +10,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wno-undefined-var-template"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac

--- a/simulation/g4simulation/g4rich/configure.ac
+++ b/simulation/g4simulation/g4rich/configure.ac
@@ -10,7 +10,7 @@ case $CXX in
  clang++)
   CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wno-undefined-var-template"
  ;;
- g++)
+ *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac


### PR DESCRIPTION
This PR unifies the use of g++ compiler flags. The daily build uses a slight modification for the gcc 8.3 setup. The standard setup defines CC COMPILER_PATH CXX FC which interfere with cmake which then breaks the acts compilation in the build environment. So the first thing the build does is "unsetenv CC COMPILER_PATH CXX FC". Addign this to our general setup script has other unwanted side effects, so this stays local to the daily builds.
The consequence of this is that the daily builds uses g++ as compiler name, while users see the full path:
which g++
/cvmfs/eic.opensciencegrid.org/gcc-8.3/opt/fun4all/core/gcc/8.3.0.1-0a5ad/x86_64-centos7/bin/g++  
The configure.ac sets compiler flags according to the detected compiler (where we support g++ and clang). We add -Wall and -Werror to them. For g++ it matched g++ only which triggers only for the daily build since this does not match /cvmfs/eic.opensciencegrid.org/gcc-8.3/opt/fun4all/core/gcc/8.3.0.1-0a5ad/x86_64-centos7/bin/g++
This change matches *g++ which will not also add -Wall -Werror to user compilations.
Just be careful to keep the order of clang and g++, *g++ always second, since *g++ also matches clang++