### PR TITLE
addition of FeTungsten absorber material for FHCAL

### DIFF
--- a/simulation/g4simulation/g4drcalo/PHG4ForwardDualReadoutDetector.cc
+++ b/simulation/g4simulation/g4drcalo/PHG4ForwardDualReadoutDetector.cc
@@ -527,7 +527,7 @@ PHG4ForwardDualReadoutDetector::GetScintillatorMaterial()
   tab->AddConstProperty("FASTTIMECONSTANT", 2.8*ns); // was 6
   // tab->AddConstProperty("SCINTILLATIONYIELD", 13.9/keV); // was 200/MEV nominal  10
   tab->AddConstProperty("SCINTILLATIONYIELD", 200/MeV); // was 200/MEV nominal, should maybe be 13.9/keV
-  tab->AddConstProperty("RESOLUTIONSCALE", 1.);
+  tab->AddConstProperty("RESOLUTIONSCALE", 1.0);
 
   G4double opt_en[] =
     { 1.37760*eV, 1.45864*eV, 1.54980*eV, 1.65312*eV, 1.71013*eV, 1.77120*eV, 1.83680*eV, 1.90745*eV, 1.98375*eV, 2.06640*eV,
@@ -558,9 +558,9 @@ PHG4ForwardDualReadoutDetector::GetScintillatorMaterial()
 	G4double density;
 	G4int ncomponents;
   // G4Material* material_G4_POLYSTYRENE = G4Material::GetMaterial(_materialScintillator.c_str());
-  G4Material* material_G4_POLYSTYRENE = new G4Material("G4_POLYSTYRENE", density = 1.032 * g / cm3, ncomponents = 2);
-  material_G4_POLYSTYRENE->AddElement(G4Element::GetElement("C"), 19);
-  material_G4_POLYSTYRENE->AddElement(G4Element::GetElement("H"), 21);
+  G4Material* material_G4_POLYSTYRENE = new G4Material("G4_POLYSTYRENE", density = 1.05 * g / cm3, ncomponents = 2);
+  material_G4_POLYSTYRENE->AddElement(G4Element::GetElement("C"), 8);
+  material_G4_POLYSTYRENE->AddElement(G4Element::GetElement("H"), 8);
   material_G4_POLYSTYRENE->GetIonisation()->SetBirksConstant(0.126*mm/MeV);
   material_G4_POLYSTYRENE->SetMaterialPropertiesTable(tab);
 
@@ -585,9 +585,9 @@ PHG4ForwardDualReadoutDetector::GetPMMAMaterial()
 	G4int ncomponents;
 
   G4Material* material_PMMA = new G4Material("PMMA", density = 1.18 * g / cm3, ncomponents = 3);
-  material_PMMA->AddElement(G4Element::GetElement("C"), 3.6 / (3.6 + 5.7 + 1.4));
-  material_PMMA->AddElement(G4Element::GetElement("H"), 5.7 / (3.6 + 5.7 + 1.4));
-  material_PMMA->AddElement(G4Element::GetElement("O"), 1.4 / (3.6 + 5.7 + 1.4));
+  material_PMMA->AddElement(G4Element::GetElement("C"), 5);
+  material_PMMA->AddElement(G4Element::GetElement("H"), 8);
+  material_PMMA->AddElement(G4Element::GetElement("O"), 2);
 
   const G4int nEntries = 31;
 

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalDetector.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalDetector.cc
@@ -191,6 +191,13 @@ PHG4ForwardHcalDetector::ConstructTower()
   G4Material* material_wls = G4Material::GetMaterial(m_Params->get_string_param("scintillator"));
   G4Material* material_support = G4Material::GetMaterial(m_Params->get_string_param("support"));
 
+  if(m_Params->get_int_param("absorber_FeTungsten")==1){
+    G4double density;
+    G4int natoms;
+    material_absorber = new G4Material("FeTungstenMix",  density =  10.1592*g/cm3, natoms=2);
+    material_absorber->AddMaterial(G4Material::GetMaterial("G4_Fe"), 80*perCent);  // Steel
+    material_absorber->AddMaterial(G4Material::GetMaterial("G4_W"),  20*perCent);  // Tungsten
+  }
   G4LogicalVolume* logic_absorber = new G4LogicalVolume(solid_absorber,
                                                         material_absorber,
                                                         "single_plate_absorber_logic",

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSubsystem.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSubsystem.cc
@@ -143,6 +143,7 @@ void PHG4ForwardHcalSubsystem::SetDefaultParameters()
   set_default_double_param("rot_z", 0.);
   set_default_double_param("thickness_absorber", 2.);
   set_default_double_param("thickness_scintillator", 0.231);
+  set_default_int_param("absorber_FeTungsten", 0);
 
   std::ostringstream mappingfilename;
   const char* calibroot = getenv("CALIBRATIONROOT");

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSubsystem.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSubsystem.h
@@ -48,6 +48,8 @@ class PHG4ForwardHcalSubsystem : public PHG4DetectorSubsystem
    */
   void SetTowerMappingFile(const std::string &filename);
 
+  void SetUseFeTungstenAbsorber(int useTungsten) {set_int_param("absorber_FeTungsten", 1); };
+
  private:
   void SetDefaultParameters() override;
 


### PR DESCRIPTION
This PR adds the option to use a 20% tungsten 80% iron mix for the FHCAL absorber.