### PR TITLE
New separate class for TTL layers

### DIFF
--- a/simulation/g4simulation/g4ttl/Makefile.am
+++ b/simulation/g4simulation/g4ttl/Makefile.am
@@ -1,0 +1,65 @@
+AUTOMAKE_OPTIONS = foreign
+
+lib_LTLIBRARIES = \
+  libttl.la 
+
+AM_CPPFLAGS = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include  \
+  -I$(ROOTSYS)/include \
+  -I$(G4_MAIN)/include
+
+
+AM_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
+  -L$(ROOTSYS)/lib
+
+libttl_la_LIBADD = \
+  -lfun4all \
+  -lphg4hit \
+  -lg4detectors \
+  -ltrackbase_historic_io
+
+pkginclude_HEADERS = \
+  PHG4TTLDetector.h \
+  PHG4TTLSubsystem.h
+
+libttl_la_SOURCES = \
+  PHG4TTLDetector.cc \
+  PHG4TTLDisplayAction.cc \
+  PHG4TTLSteppingAction.cc \
+  PHG4TTLSubsystem.cc
+
+# Rule for generating table CINT dictionaries.
+%_Dict.cc: %.h %LinkDef.h
+	rootcint -f $@ @CINTDEFS@  -c $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
+
+#just to get the dependency
+%_Dict_rdict.pcm: %_Dict.cc ;
+
+################################################
+# linking tests
+
+BUILT_SOURCES = testexternals.cc
+
+noinst_PROGRAMS = \
+  testexternals
+
+testexternals_SOURCES = \
+  testexternals.cc
+
+testexternals_LDADD = \
+  libttl.la
+
+testexternals.cc:
+	echo "//*** this is a generated file. Do not commit, do not edit" > $@
+	echo "int main()" >> $@
+	echo "{" >> $@
+	echo "  return 0;" >> $@
+	echo "}" >> $@
+
+################################################
+
+clean-local:
+	rm -f *Dict* $(BUILT_SOURCES) *.pcm

--- a/simulation/g4simulation/g4ttl/PHG4TTLDetector.cc
+++ b/simulation/g4simulation/g4ttl/PHG4TTLDetector.cc
@@ -1,0 +1,206 @@
+#include "PHG4TTLDetector.h"
+#include "PHG4TTLDisplayAction.h"
+
+#include <g4main/PHG4Detector.h>       // for PHG4Detector
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
+#include <g4main/PHG4Subsystem.h>      // for PHG4Subsystem
+
+#include <phparameter/PHParameters.h>
+
+#include <Geant4/G4Box.hh>
+#include <Geant4/G4Tubs.hh>
+#include <Geant4/G4SubtractionSolid.hh>
+#include <Geant4/G4Cons.hh>
+#include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
+#include <Geant4/G4String.hh>              // for G4String
+#include <Geant4/G4SystemOfUnits.hh>
+#include <Geant4/G4ThreeVector.hh>      // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>      // for G4Transform3D
+#include <Geant4/G4Types.hh>               // for G4double, G4int
+
+#include <map>  // for _Rb_tree_iterator, _Rb_tree_co...
+#include <utility>  // for pair
+#include <algorithm>  // for max
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <sstream>
+#include <climits>
+
+class G4VPhysicalVolume;
+class PHCompositeNode;
+
+using namespace std;
+
+//_______________________________________________________________
+//note this inactive thickness is ~1.5% of a radiation length
+PHG4TTLDetector::PHG4TTLDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters* parameters, const std::string &dnam)
+  : PHG4Detector(subsys, Node, dnam)
+  , name_base(dnam)
+  , m_DisplayAction(dynamic_cast<PHG4TTLDisplayAction *>(subsys->GetDisplayAction()))
+  , m_Params(parameters)
+  , overlapcheck_sector(false)
+{
+}
+
+//_______________________________________________________________
+//_______________________________________________________________
+bool PHG4TTLDetector::IsInSectorActive(G4VPhysicalVolume *physvol)
+{
+  for (map_phy_vol_t::const_iterator it = map_active_phy_vol.begin();
+       it != map_active_phy_vol.end(); ++it)
+  {
+    if (physvol == (*it).second)
+    {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+//_______________________________________________________________
+void PHG4TTLDetector::ConstructMe(G4LogicalVolume *logicWorld)
+{
+
+  const int nLayers = 7;
+  string strLayerName[nLayers] = {
+    "SiliconSensor", "Metalconnection", "HDI", "Cooling", "Support", "Support_Gap", "Support2"
+  };
+  G4Material* materialLayer[nLayers] = {
+    G4Material::GetMaterial("G4_Si"), G4Material::GetMaterial("G4_Al"), G4Material::GetMaterial("G4_KAPTON"), G4Material::GetMaterial("G4_WATER"), G4Material::GetMaterial("G4_GRAPHITE"), G4Material::GetMaterial("G4_AIR"), G4Material::GetMaterial("G4_GRAPHITE")
+  };
+  G4double thicknessLayer[nLayers] = {
+    m_Params->get_double_param("tSilicon"), 100 * um, 20 * um, 100 * um, 50 * um, 1 * cm, 50 * um
+  };
+  bool layerActive[nLayers] = {
+    true, false, false, false, false, false, false
+  };
+
+  G4double thicknessDet = 0;
+  for(int ilay=0; ilay<nLayers; ilay++){
+    thicknessDet += thicknessLayer[ilay]/10;
+  }
+
+  //Create the envelope = 'world volume' for the calorimeter
+  G4Material* Air = G4Material::GetMaterial("G4_AIR");
+
+  G4double rMin = m_Params->get_double_param("rMin");
+  G4double rMax = m_Params->get_double_param("rMax");
+  G4double xoffset = m_Params->get_double_param("offset_x");
+
+  G4VSolid* beampipe_cutout = new G4Cons("ttl_beampipe_cutout",
+                                      0, rMin,
+                                      0, rMin,
+                                      thicknessDet / 2.0,
+                                      0, 2 * M_PI);
+  G4VSolid* ttl_envelope_solid = new G4Cons("ttl_beampipe_cutout",
+                                      0, rMax,
+                                      0, rMax,
+                                      thicknessDet / 2.0,
+                                      0, 2 * M_PI);
+  ttl_envelope_solid = new G4SubtractionSolid(G4String("ttl_envelope_solid"), ttl_envelope_solid, beampipe_cutout
+                                                            , 0 ,G4ThreeVector( xoffset , 0 ,0.));
+
+  const G4Transform3D transform_Det_to_Hall =
+      G4RotateX3D(-m_Params->get_double_param("polar_angle")) * G4TranslateZ3D(
+                                                        m_Params->get_double_param("place_z") + thicknessDet / 2);
+
+  G4LogicalVolume *DetectorLog_Det = new G4LogicalVolume(ttl_envelope_solid,  //
+                                                         Air, name_base + "_Log");
+  RegisterLogicalVolume(DetectorLog_Det);
+
+  RegisterPhysicalVolume(
+        new G4PVPlacement(
+            G4RotateZ3D(2 * pi) * transform_Det_to_Hall, DetectorLog_Det,
+            name_base + "_Physical", logicWorld, false, 0, overlapcheck_sector));
+
+  double z_start = -thicknessDet / 2;
+  for(int ilay=0; ilay<nLayers; ilay++){
+    const string layer_name = name_base + "_" + strLayerName[ilay];
+    const string layer_name_Solid = layer_name + "_Sol";
+
+    G4VSolid *Sol_Raw = new G4Tubs(layer_name_Solid + "_Raw",     //const G4String& pName,
+                                  0,                 //      G4double pRMin,
+                                  rMax,  //      G4double pRMax,
+                                  thicknessLayer[ilay] / 10 / 2,     //      G4double pDz,
+                                  0,                 //      G4double pSPhi,
+                                  2 * pi             //      G4double pDPhi
+    );
+
+    G4VSolid *LayerSol_Det = new G4SubtractionSolid(layer_name_Solid.c_str(), Sol_Raw, beampipe_cutout
+                                                            , 0 ,G4ThreeVector( xoffset , 0 ,0.));
+    G4LogicalVolume *LayerLog_Det = new G4LogicalVolume(LayerSol_Det,  //
+                                                        materialLayer[ilay], layer_name + "_Log");
+    RegisterLogicalVolume(LayerLog_Det);
+    RegisterPhysicalVolume(
+        new G4PVPlacement(0, G4ThreeVector(0, 0, z_start + thicknessLayer[ilay] / 10 / 2), LayerLog_Det,
+                          layer_name + "_Physical", DetectorLog_Det, false, 0, overlapcheck_sector),
+        layerActive[ilay]);
+    z_start += thicknessLayer[ilay]/10;
+  }
+
+  m_DisplayAction->AddVolume(DetectorLog_Det, "DetectorBox");
+
+  for (map_log_vol_t::iterator it = map_log_vol.begin(); it != map_log_vol.end(); ++it)
+  {
+    if ((*it).first != G4String(name_base + "_Log"))
+    {
+      // sub layers
+      m_DisplayAction->AddVolume((*it).second, "TTLDetector");
+    }
+  }
+}
+
+
+
+G4LogicalVolume *
+PHG4TTLDetector::RegisterLogicalVolume(G4LogicalVolume *v)
+{
+  if (!v)
+  {
+    std::cout
+        << "PHG4TTLDetector::RegisterVolume - Error - invalid volume!"
+        << std::endl;
+    return v;
+  }
+  if (map_log_vol.find(v->GetName()) != map_log_vol.end())
+  {
+    std::cout << "PHG4TTLDetector::RegisterVolume - Warning - replacing " << v->GetName() << std::endl;
+  }
+
+  map_log_vol[v->GetName()] = v;
+
+  return v;
+}
+
+G4PVPlacement *
+PHG4TTLDetector::RegisterPhysicalVolume(G4PVPlacement *v,
+                                              const bool active)
+{
+  if (!v)
+  {
+    std::cout
+        << "PHG4TTLDetector::RegisterPhysicalVolume - Error - invalid volume!"
+        << std::endl;
+    return v;
+  }
+
+  phy_vol_idx_t id(v->GetName(), v->GetCopyNo());
+
+  if (map_phy_vol.find(id) != map_phy_vol.end())
+  {
+    std::cout
+        << "PHG4TTLDetector::RegisterPhysicalVolume - Warning - replacing "
+        << v->GetName() << "[" << v->GetCopyNo() << "]" << std::endl;
+  }
+
+  map_phy_vol[id] = v;
+
+  if (active)
+    map_active_phy_vol[id] = v;
+
+  return v;
+}

--- a/simulation/g4simulation/g4ttl/PHG4TTLDetector.h
+++ b/simulation/g4simulation/g4ttl/PHG4TTLDetector.h
@@ -1,0 +1,113 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4TTLDETECTOR_H
+#define G4DETECTORS_PHG4TTLDETECTOR_H
+
+#include <g4main/PHG4Detector.h>
+
+#include <Geant4/G4Box.hh>
+#include <Geant4/G4DisplacedSolid.hh>     // for G4DisplacedSolid
+#include <Geant4/G4ExceptionSeverity.hh>  // for FatalException, JustWarning
+#include <Geant4/G4IntersectionSolid.hh>
+#include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4Material.hh>
+#include <Geant4/G4MaterialTable.hh>  // for G4MaterialTable
+#include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4PhysicalConstants.hh>  // for pi
+#include <Geant4/G4Sphere.hh>
+#include <Geant4/G4SystemOfUnits.hh>  // for cm, um, perCent
+#include <Geant4/G4ThreeVector.hh>    // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>    // for G4Transform3D, G4RotateX3D
+#include <Geant4/G4Tubs.hh>
+#include <Geant4/G4Types.hh>              // for G4int
+#include <Geant4/globals.hh>  // for G4Exception
+#include <Geant4/G4String.hh>  // for G4String
+
+#include <map>
+#include <utility>
+#include <set>
+
+#include <cassert>
+#include <cmath>
+#include <string>
+#include <vector>
+
+class G4LogicalVolume;
+class G4VPhysicalVolume;
+class PHCompositeNode;
+class PHG4TTLDisplayAction;
+class PHG4Subsystem;
+class PHParameters;
+
+
+class PHG4TTLDetector : public PHG4Detector
+{
+ public:
+  //! constructor
+  PHG4TTLDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters* parameters, const std::string &dnam);
+
+  //! destructor
+  ~PHG4TTLDetector(void) override
+  {
+  }
+
+  //! construct
+  void ConstructMe(G4LogicalVolume *world) override;
+
+  //!@name volume accessors
+  //@{
+  bool IsInSectorActive(G4VPhysicalVolume *physvol);
+  //@}
+
+  void SuperDetector(const std::string &name) { superdetector = name; }
+  const std::string SuperDetector() const { return superdetector; }
+
+
+  void OverlapCheck(const bool chk = true) override
+  {
+    PHG4Detector::OverlapCheck(chk);
+    // PHG4SectorConstructor::OverlapCheck(chk);
+  }
+
+  // void Verbosity(int v) override {m_Verbosity = v;}
+  // int Verbosity() const {return m_Verbosity;}
+
+
+ public:
+  // properties
+
+  std::string name_base;
+
+ private:
+  PHG4TTLDisplayAction *m_DisplayAction;
+  int m_Verbosity;
+  std::string superdetector;
+  PHParameters *m_Params = nullptr;
+
+ protected:
+  G4LogicalVolume *
+  RegisterLogicalVolume(G4LogicalVolume *);
+  bool overlapcheck_sector;
+
+  G4VSolid *
+  Construct_Sectors_Plane(           //
+      const std::string &name,       //
+      const double start_z,          //
+      const double thickness,        //
+      G4VSolid *SecConeBoundary_Det  //
+  );
+  typedef std::map<G4String, G4LogicalVolume *> map_log_vol_t;
+  map_log_vol_t map_log_vol;
+
+  G4PVPlacement *
+  RegisterPhysicalVolume(G4PVPlacement *v, const bool active = false);
+
+  typedef std::pair<G4String, G4int> phy_vol_idx_t;
+  typedef std::map<phy_vol_idx_t, G4PVPlacement *> map_phy_vol_t;
+  map_phy_vol_t map_phy_vol;         //! all physics volume
+  map_phy_vol_t map_active_phy_vol;  //! active physics volume
+};
+
+
+
+#endif

--- a/simulation/g4simulation/g4ttl/PHG4TTLDisplayAction.cc
+++ b/simulation/g4simulation/g4ttl/PHG4TTLDisplayAction.cc
@@ -1,0 +1,66 @@
+#include "PHG4TTLDisplayAction.h"
+
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
+#include <g4main/PHG4Utils.h>
+
+#include <Geant4/G4Colour.hh>
+#include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4Material.hh>
+#include <Geant4/G4String.hh>          // for G4String
+#include <Geant4/G4VisAttributes.hh>
+
+#include <TSystem.h>
+
+#include <iostream>
+#include <utility>                     // for pair
+
+using namespace std;
+
+PHG4TTLDisplayAction::PHG4TTLDisplayAction(const std::string &name)
+  : PHG4DisplayAction(name)
+{
+}
+
+PHG4TTLDisplayAction::~PHG4TTLDisplayAction()
+{
+  for (auto &it : m_VisAttVec)
+  {
+    delete it;
+  }
+  m_VisAttVec.clear();
+}
+
+void PHG4TTLDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
+{
+  // check if vis attributes exist, if so someone else has set them and we do nothing
+  for (auto it : m_LogicalVolumeMap)
+  {
+    G4LogicalVolume *logvol = it.first;
+    if (logvol->GetVisAttributes())
+    {
+      continue;
+    }
+    G4VisAttributes *visatt = new G4VisAttributes();
+    visatt->SetVisibility(true);
+    visatt->SetForceSolid(true);
+    m_VisAttVec.push_back(visatt);  // for later deletion
+    if (it.second == "TTLDetector")
+    {
+      PHG4Utils::SetColour(visatt, it.first->GetMaterial()->GetName());
+    }
+    else if (it.second == "DetectorBox")
+    {
+      visatt->SetVisibility(false);
+      // visatt->SetColour(G4Colour::White());
+      // visatt->SetForceWireframe(true);
+      // visatt->SetForceLineSegmentsPerCircle(50);
+    }
+    else
+    {
+      cout << "unknown logical volume " << it.second << endl;
+      gSystem->Exit(1);
+    }
+    logvol->SetVisAttributes(visatt);
+  }
+  return;
+}

--- a/simulation/g4simulation/g4ttl/PHG4TTLDisplayAction.h
+++ b/simulation/g4simulation/g4ttl/PHG4TTLDisplayAction.h
@@ -1,0 +1,31 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4TTLDISPLAYACTION_H
+#define G4DETECTORS_PHG4TTLDISPLAYACTION_H
+
+#include <g4main/PHG4DisplayAction.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+class G4VisAttributes;
+class G4LogicalVolume;
+class G4VPhysicalVolume;
+
+class PHG4TTLDisplayAction : public PHG4DisplayAction
+{
+ public:
+  PHG4TTLDisplayAction(const std::string &name);
+
+  ~PHG4TTLDisplayAction() override;
+
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
+  void AddVolume(G4LogicalVolume *logvol, const std::string &mat) { m_LogicalVolumeMap[logvol] = mat; }
+
+ private:
+  std::map<G4LogicalVolume *, std::string> m_LogicalVolumeMap;
+  std::vector<G4VisAttributes *> m_VisAttVec;
+};
+
+#endif  // G4DETECTORS_PHG4TTLDISPLAYACTION_H

--- a/simulation/g4simulation/g4ttl/PHG4TTLSteppingAction.cc
+++ b/simulation/g4simulation/g4ttl/PHG4TTLSteppingAction.cc
@@ -1,0 +1,211 @@
+#include "PHG4TTLSteppingAction.h"
+#include "PHG4TTLDetector.h"
+
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4Hitv1.h>
+#include <g4main/PHG4Shower.h>
+#include <g4main/PHG4SteppingAction.h>        // for PHG4SteppingAction
+#include <g4main/PHG4TrackUserInfoV1.h>
+
+#include <phool/getClass.h>
+
+#include <Geant4/G4ParticleDefinition.hh>     // for G4ParticleDefinition
+#include <Geant4/G4Step.hh>
+#include <Geant4/G4StepPoint.hh>              // for G4StepPoint
+#include <Geant4/G4StepStatus.hh>             // for fGeomBoundary, fAtRestD...
+#include <Geant4/G4String.hh>                 // for G4String
+#include <Geant4/G4SystemOfUnits.hh>          // for cm, GeV, nanosecond
+#include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
+#include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
+#include <Geant4/G4Track.hh>                  // for G4Track
+#include <Geant4/G4TrackStatus.hh>            // for fStopAndKill
+#include <Geant4/G4Types.hh>                  // for G4double
+#include <Geant4/G4VTouchable.hh>             // for G4VTouchable
+#include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
+
+#include <iostream>
+#include <string>                             // for string, operator+, oper...
+
+class G4VPhysicalVolume;
+class PHCompositeNode;
+
+using namespace std;
+//____________________________________________________________________________..
+PHG4TTLSteppingAction::PHG4TTLSteppingAction(PHG4TTLDetector* detector)
+  : PHG4SteppingAction(detector->GetName())
+  , detector_(detector)
+  , hits_(nullptr)
+  , hit(nullptr)
+  , saveshower(nullptr)
+  , layer_id(-1)
+{
+}
+
+PHG4TTLSteppingAction::~PHG4TTLSteppingAction()
+{
+  // if the last hit was a zero energie deposit hit, it is just reset
+  // and the memory is still allocated, so we need to delete it here
+  // if the last hit was saved, hit is a nullptr pointer which are
+  // legal to delete (it results in a no operation)
+  delete hit;
+}
+
+//____________________________________________________________________________..
+bool PHG4TTLSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
+{
+  // get volume of the current step
+  G4VPhysicalVolume* volume =
+      aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume();
+
+  // collect energy and track length step by step
+  G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
+  G4double eion = (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) / GeV;
+
+  const G4Track* aTrack = aStep->GetTrack();
+
+  // make sure we are in a volume
+  if (detector_->IsInSectorActive(volume))
+  {
+    bool geantino = false;
+    // the check for the pdg code speeds things up, I do not want to make
+    // an expensive string compare for every track when we know
+    // geantino or chargedgeantino has pid=0
+    if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 && aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
+    {
+      geantino = true;
+    }
+    G4StepPoint* prePoint = aStep->GetPreStepPoint();
+    G4StepPoint* postPoint = aStep->GetPostStepPoint();
+    //       cout << "track id " << aTrack->GetTrackID() << endl;
+    //       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
+    //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
+    //layer_id is sector number
+    switch (prePoint->GetStepStatus())
+    {
+    case fGeomBoundary:
+    case fUndefined:
+      if (!hit)
+      {
+        hit = new PHG4Hitv1();
+      }
+      //here we set the entrance values in cm
+      hit->set_x(0, prePoint->GetPosition().x() / cm);
+      hit->set_y(0, prePoint->GetPosition().y() / cm);
+      hit->set_z(0, prePoint->GetPosition().z() / cm);
+      // time in ns
+      hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
+      //set the track ID
+      hit->set_trkid(aTrack->GetTrackID());
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          hit->set_trkid(pp->GetUserTrackId());
+          hit->set_shower_id(pp->GetShower()->get_id());
+          saveshower = pp->GetShower();
+        }
+      }
+
+      //set the initial energy deposit
+      hit->set_edep(0);
+      hit->set_eion(0);  // only implemented for v5 otherwise empty
+      layer_id = aStep->GetPreStepPoint()->GetTouchable()->GetReplicaNumber(1);
+      //        hit->set_light_yield(0);
+
+      break;
+    default:
+      break;
+    }
+    // here we just update the exit values, it will be overwritten
+    // for every step until we leave the volume or the particle
+    // ceases to exist
+    hit->set_x(1, postPoint->GetPosition().x() / cm);
+    hit->set_y(1, postPoint->GetPosition().y() / cm);
+    hit->set_z(1, postPoint->GetPosition().z() / cm);
+
+    hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
+    //sum up the energy to get total deposited
+    hit->set_edep(hit->get_edep() + edep);
+    hit->set_eion(hit->get_eion() + eion);
+    hit->set_path_length(aTrack->GetTrackLength() / cm);
+    if (geantino)
+    {
+      hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+    }
+    if (edep > 0)
+    {
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp =
+                dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          pp->SetKeep(1);  // we want to keep the track
+        }
+      }
+    }
+    // if any of these conditions is true this is the last step in
+    // this volume and we need to save the hit
+    // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
+    // postPoint->GetStepStatus() == fWorldBoundary: track leaves this world
+    // (not sure if this will ever be the case)
+    // aTrack->GetTrackStatus() == fStopAndKill: track ends
+    if (postPoint->GetStepStatus() == fGeomBoundary ||
+        postPoint->GetStepStatus() == fWorldBoundary ||
+        postPoint->GetStepStatus() == fAtRestDoItProc ||
+        aTrack->GetTrackStatus() == fStopAndKill)
+    {
+      // save only hits with energy deposit (or -1 for geantino)
+      if (hit->get_edep())
+      {
+        hits_->AddHit(layer_id, hit);
+        if (saveshower)
+        {
+          saveshower->add_g4hit_id(hits_->GetID(), hit->get_hit_id());
+        }
+        // ownership has been transferred to container, set to null
+        // so we will create a new hit for the next track
+        hit = nullptr;
+      }
+      else
+      {
+        // if this hit has no energy deposit, just reset it for reuse
+        // this means we have to delete it in the dtor. If this was
+        // the last hit we processed the memory is still allocated
+        hit->Reset();
+      }
+    }
+
+    //       hit->identify();
+    // return true to indicate the hit was used
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+//____________________________________________________________________________..
+void PHG4TTLSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
+{
+  string hitnodename;
+  if (detector_->SuperDetector() != "NONE")
+  {
+    hitnodename = "G4HIT_" + detector_->SuperDetector();
+  }
+  else
+  {
+    hitnodename = "G4HIT_" + detector_->GetName();
+  }
+
+  //now look for the map and grab a pointer to it.
+  hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
+
+  // if we do not find the node we need to make it.
+  if (!hits_)
+  {
+    std::cout << "PHG4TTLSteppingAction::SetTopNode - unable to find "
+              << hitnodename << std::endl;
+  }
+}

--- a/simulation/g4simulation/g4ttl/PHG4TTLSteppingAction.h
+++ b/simulation/g4simulation/g4ttl/PHG4TTLSteppingAction.h
@@ -1,0 +1,42 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4TTLSTEPPINGACTION_H
+#define G4DETECTORS_PHG4TTLSTEPPINGACTION_H
+
+#include <g4main/PHG4SteppingAction.h>
+
+class G4Step;
+class PHCompositeNode;
+class PHG4Hit;
+class PHG4HitContainer;
+class PHG4TTLDetector;
+class PHG4Shower;
+
+class PHG4TTLSteppingAction : public PHG4SteppingAction
+{
+ public:
+  //! constructor
+  PHG4TTLSteppingAction(PHG4TTLDetector*);
+
+  //! destructor
+  ~PHG4TTLSteppingAction() override;
+
+  //! stepping action
+  bool UserSteppingAction(const G4Step*, bool) override;
+
+  //! reimplemented from base class
+  void SetInterfacePointers(PHCompositeNode*) override;
+
+ private:
+  //! pointer to the detector
+  PHG4TTLDetector* detector_;
+
+  //! pointer to hit container
+  PHG4HitContainer* hits_;
+  PHG4Hit* hit;
+  PHG4Shower* saveshower;
+
+  int layer_id;
+};
+
+#endif  //__G4PHPHYTHIAREADER_H__

--- a/simulation/g4simulation/g4ttl/PHG4TTLSubsystem.cc
+++ b/simulation/g4simulation/g4ttl/PHG4TTLSubsystem.cc
@@ -1,0 +1,127 @@
+#include "PHG4TTLSubsystem.h"
+#include "PHG4TTLDetector.h"
+#include "PHG4TTLDisplayAction.h"
+#include "PHG4TTLSteppingAction.h"
+
+#include <phparameter/PHParameters.h>
+
+#include <g4main/PHG4DisplayAction.h>   // for PHG4DisplayAction
+#include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
+#include <g4main/PHG4Subsystem.h>       // for PHG4Subsystem
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>         // for PHIODataNode
+#include <phool/PHNode.h>               // for PHNode
+#include <phool/PHNodeIterator.h>       // for PHNodeIterator
+#include <phool/PHObject.h>             // for PHObject
+#include <phool/getClass.h>
+
+#include <sstream>
+
+#include <set>  // for set
+#include <sstream>
+class PHG4Detector;
+
+using namespace std;
+
+//_______________________________________________________________________
+PHG4TTLSubsystem::PHG4TTLSubsystem(const std::string& name)
+  : PHG4DetectorSubsystem(name)
+  , m_Detector(nullptr)
+  , m_SteppingAction(nullptr)
+  , m_DisplayAction(nullptr)
+  , superdetector("NONE")
+{
+  InitializeParameters();
+}
+
+//_______________________________________________________________________
+PHG4TTLSubsystem::~PHG4TTLSubsystem()
+{
+  delete m_DisplayAction;
+}
+
+//_______________________________________________________________________
+int PHG4TTLSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
+{
+  PHNodeIterator iter(topNode);
+  PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst(
+      "PHCompositeNode", "DST"));
+
+  // create display settings before detector
+  m_DisplayAction = new PHG4TTLDisplayAction(Name());
+  // create detector
+  m_Detector = new PHG4TTLDetector(this, topNode, GetParams(), Name());
+  // m_Detector->geom = geom;
+  m_Detector->SuperDetector(superdetector);
+  m_Detector->OverlapCheck(CheckOverlap());
+
+  // if (geom.GetNumActiveLayers())
+  // {
+    ostringstream nodename;
+    if (superdetector != "NONE")
+    {
+      nodename << "G4HIT_" << superdetector;
+    }
+    else
+    {
+      nodename << "G4HIT_" << Name();
+    }
+    // create hit list
+    PHG4HitContainer* block_hits = findNode::getClass<PHG4HitContainer>(
+        topNode, nodename.str().c_str());
+    if (!block_hits)
+    {
+      dstNode->addNode(new PHIODataNode<PHObject>(new PHG4HitContainer(nodename.str()), nodename.str(), "PHObject"));
+    }
+    // create stepping action
+    m_SteppingAction = new PHG4TTLSteppingAction(m_Detector);
+  // }
+  return 0;
+}
+
+//_______________________________________________________________________
+int PHG4TTLSubsystem::process_event(PHCompositeNode* topNode)
+{
+  // pass top node to stepping action so that it gets
+  // relevant nodes needed internally
+  if (m_SteppingAction)
+  {
+    m_SteppingAction->SetInterfacePointers(topNode);
+  }
+  return 0;
+}
+
+//_______________________________________________________________________
+PHG4Detector*
+PHG4TTLSubsystem::GetDetector(void) const
+{
+  return m_Detector;
+}
+
+void PHG4TTLSubsystem::SetDefaultParameters()
+{
+  set_default_double_param("place_x", 0.);
+  set_default_double_param("place_y", 0.);
+  set_default_double_param("place_z", 375. * cm);
+  set_default_double_param("offset_x", 150. * cm);
+  set_default_double_param("rMin", 20. * cm);
+  set_default_double_param("rMax", 220. * cm);
+  set_default_double_param("etaMin", 1.);
+  set_default_double_param("etaMax", 4.);
+  set_default_double_param("polar_angle", 0.);
+  set_default_double_param("total_thickness", 1. * cm);
+  set_default_double_param("tSilicon", 1. * um);
+  // set_default_double_param("wls_dw", 0.3);
+  // set_default_double_param("support_dw", 0.2);
+  set_default_double_param("rot_x", 0.);
+  set_default_double_param("rot_y", 0.);
+  set_default_double_param("rot_z", 0.);
+  // set_default_double_param("thickness_absorber", 2.);
+  // set_default_double_param("thickness_scintillator", 0.231);
+  // set_default_string_param("scintillator", "G4_POLYSTYRENE");
+  // set_default_string_param("absorber", "G4_Fe");
+  // set_default_string_param("support", "G4_Fe");
+  return;
+}

--- a/simulation/g4simulation/g4ttl/PHG4TTLSubsystem.h
+++ b/simulation/g4simulation/g4ttl/PHG4TTLSubsystem.h
@@ -1,0 +1,88 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4DETECTORS_PHG4TTLSUBSYSTEM_H
+#define G4DETECTORS_PHG4TTLSUBSYSTEM_H
+
+// #include "PHG4TTLDetector.h"
+
+#include <g4detectors/PHG4DetectorSubsystem.h>  // for PHG4DetectorSubsystem
+
+#include <string>                   // for string
+
+class PHCompositeNode;
+class PHG4Detector;
+class PHG4DisplayAction;
+class PHG4TTLDetector;
+class PHG4SteppingAction;
+
+class PHG4TTLSubsystem : public PHG4DetectorSubsystem
+{
+ public:
+  //! constructor
+  PHG4TTLSubsystem(const std::string& name = "Sector");
+
+  //! destructor
+  ~PHG4TTLSubsystem() override;
+
+  //! init
+  /*!
+   creates the detector_ object and place it on the node tree, under "DETECTORS" node (or whatever)
+   reates the stepping action and place it on the node tree, under "ACTIONS" node
+   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
+   */
+  int InitRunSubsystem(PHCompositeNode *) override;
+
+  //! event processing
+  /*!
+   get all relevant nodes from top nodes (namely hit list)
+   and pass that to the stepping action
+   */
+  int process_event(PHCompositeNode*) override;
+
+  //! accessors (reimplemented)
+  PHG4Detector*
+  GetDetector(void) const override;
+  PHG4SteppingAction* GetSteppingAction(void) const override { return m_SteppingAction; }
+
+  PHG4DisplayAction* GetDisplayAction() const override { return m_DisplayAction; }
+
+  void
+  SuperDetector(const std::string& name)
+  {
+    superdetector = name;
+  }
+
+  // //! geometry manager PHG4TTL::Sector_Geometry
+  // PHG4TTL::Sector_Geometry&
+  // get_geometry()
+  // {
+  //   return geom;
+  // }
+
+  // //! geometry manager PHG4TTL::Sector_Geometry
+  // void
+  // set_geometry(const PHG4TTL::Sector_Geometry& g)
+  // {
+  //   geom = g;
+  // }
+
+ private:
+  void SetDefaultParameters() override;
+  //! detector geometry
+  /*! defives from PHG4Detector */
+  PHG4TTLDetector* m_Detector;
+
+  //! particle tracking "stepping" action
+  /*! derives from PHG4SteppingActions */
+  PHG4SteppingAction* m_SteppingAction;
+
+  //! display attribute setting
+  /*! derives from PHG4DisplayAction */
+  PHG4DisplayAction* m_DisplayAction;
+
+  std::string superdetector;
+
+  // PHG4TTL::Sector_Geometry geom;
+};
+
+#endif

--- a/simulation/g4simulation/g4ttl/autogen.sh
+++ b/simulation/g4simulation/g4ttl/autogen.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(cd $srcdir; aclocal -I ${OFFLINE_MAIN}/share;\
+libtoolize --force; automake -a --add-missing; autoconf)
+
+$srcdir/configure  "$@"
+

--- a/simulation/g4simulation/g4ttl/configure.ac
+++ b/simulation/g4simulation/g4ttl/configure.ac
@@ -1,0 +1,19 @@
+AC_INIT(g4ttl, [1.00])
+AC_CONFIG_SRCDIR([configure.ac])
+
+AM_INIT_AUTOMAKE
+
+AC_PROG_CXX(CC g++)
+LT_INIT([disable-static])
+
+case $CXX in
+ clang++)
+  CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wno-undefined-var-template"
+ ;;
+ *g++)
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
+ ;;
+esac
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT


### PR DESCRIPTION
The TTL layers have now been separated from the previous usage of the SectorDetector class. This will allow for more freedom for further digitization and clusterization, as well as more flexible geometry creation. The new TTL layers can, for example, have an asymmetric beam pipe cut-out now.