### PR TITLE
fix for TTL detector overlap check

### DIFF
--- a/simulation/g4simulation/g4drcalo/PHG4ForwardDualReadoutDisplayAction.cc
+++ b/simulation/g4simulation/g4drcalo/PHG4ForwardDualReadoutDisplayAction.cc
@@ -60,10 +60,12 @@ void PHG4ForwardDualReadoutDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *
     else if (it.second == "Scintillator")
     {
       visatt->SetColour(G4Colour::White());
+      visatt->SetVisibility(false);
     }
     else if (it.second == "Cherenkov")
     {
       visatt->SetColour(G4Colour::Yellow());
+      visatt->SetVisibility(false);
     }
     else if (it.second == "SingleTowerAbsorber")
     {

--- a/simulation/g4simulation/g4ttl/PHG4TTLDetector.h
+++ b/simulation/g4simulation/g4ttl/PHG4TTLDetector.h
@@ -63,12 +63,16 @@ class PHG4TTLDetector : public PHG4Detector
   const std::string SuperDetector() const { return superdetector; }
 
 
-  void OverlapCheck(const bool chk = true) override
+  // void OverlapCheck(const bool chk = true) override
+  // {
+  //   PHG4Detector::OverlapCheck(chk);
+  //   // PHG4SectorConstructor::OverlapCheck(chk);
+  // }
+ void
+  OverlapCheck(bool check)
   {
-    PHG4Detector::OverlapCheck(chk);
-    // PHG4SectorConstructor::OverlapCheck(chk);
+    overlapcheck_sector = check;
   }
-
   // void Verbosity(int v) override {m_Verbosity = v;}
   // int Verbosity() const {return m_Verbosity;}
 

--- a/simulation/g4simulation/g4ttl/PHG4TTLDetector.h
+++ b/simulation/g4simulation/g4ttl/PHG4TTLDetector.h
@@ -69,7 +69,7 @@ class PHG4TTLDetector : public PHG4Detector
   //   // PHG4SectorConstructor::OverlapCheck(chk);
   // }
  void
-  OverlapCheck(bool check)
+  OverlapCheck(bool check = true) override
   {
     overlapcheck_sector = check;
   }


### PR DESCRIPTION
the overlap check was previously not settable for the new TTL class. This is now fixed.
In addition, the fibers of the dual readout calorimeter will by default no longer be rendered in the geant4 viewer to improve the time to display the full detector.