### PR TITLE
update to DRCALO with optional different tower design

### DIFF
--- a/analysis/eicevaluator/EventEvaluatorEIC.cc
+++ b/analysis/eicevaluator/EventEvaluatorEIC.cc
@@ -72,6 +72,7 @@ EventEvaluatorEIC::EventEvaluatorEIC(const string& name, const string& filename)
   , _do_EEMC(false)
   , _do_EEMCG(false)
   , _do_DRCALO(false)
+  , _do_FOCAL(false)
   , _do_LFHCAL(false)
   , _do_HITS(false)
   , _do_TRACKS(false)
@@ -81,6 +82,7 @@ EventEvaluatorEIC::EventEvaluatorEIC(const string& name, const string& filename)
   , _do_MCPARTICLES(false)
   , _do_HEPMC(false)
   , _do_GEOMETRY(false)
+  , _do_BLACKHOLE(false)
   , _ievent(0)
   , _cross_section(0)
   , _event_weight(0)
@@ -92,6 +94,7 @@ EventEvaluatorEIC::EventEvaluatorEIC(const string& name, const string& filename)
   , _hits_y(0)
   , _hits_z(0)
   , _hits_t(0)
+  , _hits_edep(0)
 
   , _nTowers_FHCAL(0)
   , _tower_FHCAL_E(0)
@@ -130,6 +133,14 @@ EventEvaluatorEIC::EventEvaluatorEIC(const string& name, const string& filename)
   , _tower_DRCALO_iEta(0)
   , _tower_DRCALO_iPhi(0)
   , _tower_DRCALO_trueID(0)
+
+  , _nTowers_FOCAL(0)
+  , _tower_FOCAL_E(0)
+  , _tower_FOCAL_NScint(0)
+  , _tower_FOCAL_NCerenkov(0)
+  , _tower_FOCAL_iEta(0)
+  , _tower_FOCAL_iPhi(0)
+  , _tower_FOCAL_trueID(0)
 
   , _nTowers_LFHCAL(0)
   , _tower_LFHCAL_E(0)
@@ -295,6 +306,7 @@ EventEvaluatorEIC::EventEvaluatorEIC(const string& name, const string& filename)
   , _caloevalstackHCALOUT(nullptr)
   , _caloevalstackEHCAL(nullptr)
   , _caloevalstackDRCALO(nullptr)
+  , _caloevalstackFOCAL(nullptr)
   , _caloevalstackLFHCAL(nullptr)
   , _caloevalstackFEMC(nullptr)
   , _caloevalstackCEMC(nullptr)
@@ -311,6 +323,7 @@ EventEvaluatorEIC::EventEvaluatorEIC(const string& name, const string& filename)
   _reco_e_threshold[kFHCAL]   = 0.05;
   _reco_e_threshold[kFEMC]    = 0.005;
   _reco_e_threshold[kDRCALO]  = 0.0;
+  _reco_e_threshold[kFOCAL]  = 0.0;
   _reco_e_threshold[kEEMC]    = 0.005;
   _reco_e_threshold[kCEMC]    = 0.01;
   _reco_e_threshold[kEHCAL]   = 0.05;
@@ -326,6 +339,7 @@ EventEvaluatorEIC::EventEvaluatorEIC(const string& name, const string& filename)
   _hits_y = new float[_maxNHits];
   _hits_z = new float[_maxNHits];
   _hits_t = new float[_maxNHits];
+  _hits_edep = new float[_maxNHits];
 
   _tower_FHCAL_E = new float[_maxNTowers];
   _tower_FHCAL_iEta = new int[_maxNTowers];
@@ -378,6 +392,13 @@ EventEvaluatorEIC::EventEvaluatorEIC(const string& name, const string& filename)
   _tower_DRCALO_iEta = new int[_maxNTowersDR];
   _tower_DRCALO_iPhi = new int[_maxNTowersDR];
   _tower_DRCALO_trueID = new int[_maxNTowersDR];
+
+  _tower_FOCAL_E = new float[_maxNTowersDR];
+  _tower_FOCAL_NScint = new int[_maxNTowersDR];
+  _tower_FOCAL_NCerenkov = new int[_maxNTowersDR];
+  _tower_FOCAL_iEta = new int[_maxNTowersDR];
+  _tower_FOCAL_iPhi = new int[_maxNTowersDR];
+  _tower_FOCAL_trueID = new int[_maxNTowersDR];
 
   _tower_LFHCAL_E = new float[_maxNTowers];
   _tower_LFHCAL_iEta = new int[_maxNTowers];
@@ -502,6 +523,7 @@ int EventEvaluatorEIC::Init(PHCompositeNode* topNode)
     _event_tree->Branch("hits_y", _hits_y, "hits_y[nHits]/F");
     _event_tree->Branch("hits_z", _hits_z, "hits_z[nHits]/F");
     _event_tree->Branch("hits_t", _hits_t, "hits_t[nHits]/F");
+    _event_tree->Branch("hits_edep", _hits_edep, "hits_edep[nHits]/F");
   }
   if (_do_TRACKS)
   {
@@ -624,6 +646,17 @@ int EventEvaluatorEIC::Init(PHCompositeNode* topNode)
     _event_tree->Branch("tower_DRCALO_iEta", _tower_DRCALO_iEta, "tower_DRCALO_iEta[tower_DRCALO_N]/I");
     _event_tree->Branch("tower_DRCALO_iPhi", _tower_DRCALO_iPhi, "tower_DRCALO_iPhi[tower_DRCALO_N]/I");
     _event_tree->Branch("tower_DRCALO_trueID", _tower_DRCALO_trueID, "tower_DRCALO_trueID[tower_DRCALO_N]/I");
+  }
+  if (_do_FOCAL)
+  {
+    // towers FOCAL
+    _event_tree->Branch("tower_FOCAL_N", &_nTowers_FOCAL, "tower_FOCAL_N/I");
+    _event_tree->Branch("tower_FOCAL_E", _tower_FOCAL_E, "tower_FOCAL_E[tower_FOCAL_N]/F");
+    _event_tree->Branch("tower_FOCAL_NScint", _tower_FOCAL_NScint, "tower_FOCAL_NScint[tower_FOCAL_N]/I");
+    _event_tree->Branch("tower_FOCAL_NCerenkov", _tower_FOCAL_NCerenkov, "tower_FOCAL_NCerenkov[tower_FOCAL_N]/I");
+    _event_tree->Branch("tower_FOCAL_iEta", _tower_FOCAL_iEta, "tower_FOCAL_iEta[tower_FOCAL_N]/I");
+    _event_tree->Branch("tower_FOCAL_iPhi", _tower_FOCAL_iPhi, "tower_FOCAL_iPhi[tower_FOCAL_N]/I");
+    _event_tree->Branch("tower_FOCAL_trueID", _tower_FOCAL_trueID, "tower_FOCAL_trueID[tower_FOCAL_N]/I");
   }
   if (_do_LFHCAL)
   {
@@ -861,6 +894,19 @@ int EventEvaluatorEIC::process_event(PHCompositeNode* topNode)
       _caloevalstackDRCALO->next_event(topNode);
     }
   }
+  if (_do_FOCAL)
+  {
+    if (!_caloevalstackFOCAL)
+    {
+      _caloevalstackFOCAL = new CaloEvalStack(topNode, "FOCAL");
+      _caloevalstackFOCAL->set_strict(_strict);
+      _caloevalstackFOCAL->set_verbosity(Verbosity() + 1);
+    }
+    else
+    {
+      _caloevalstackFOCAL->next_event(topNode);
+    }
+  }
   if (_do_LFHCAL)
   {
     if (!_caloevalstackLFHCAL)
@@ -1066,14 +1112,15 @@ void EventEvaluatorEIC::fillOutputNtuples(PHCompositeNode* topNode)
     }
     _nHitsLayers = 0;
     PHG4TruthInfoContainer* truthinfocontainerHits = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
-    for (int iIndex = 0; iIndex < 60; ++iIndex)
+    for (int iIndex = 0; iIndex < 100; ++iIndex)
     {
       // you need to add your layer name here to be saved! This has to be done
       // as we do not want to save thousands of calorimeter hits!
       if ((GetProjectionNameFromIndex(iIndex).find("TTL") != std::string::npos) ||
           (GetProjectionNameFromIndex(iIndex).find("LBLVTX") != std::string::npos) ||
           (GetProjectionNameFromIndex(iIndex).find("BARREL") != std::string::npos) ||
-          (GetProjectionNameFromIndex(iIndex).find("FST") != std::string::npos)
+          (GetProjectionNameFromIndex(iIndex).find("FST") != std::string::npos) ||
+          (((GetProjectionNameFromIndex(iIndex).find("BH_1") != std::string::npos) || (GetProjectionNameFromIndex(iIndex).find("BH_FORWARD_PLUS") != std::string::npos) || (GetProjectionNameFromIndex(iIndex).find("BH_FORWARD_NEG") != std::string::npos)) && _do_BLACKHOLE)
       ){
         string nodename = "G4HIT_" + GetProjectionNameFromIndex(iIndex);
         PHG4HitContainer* hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
@@ -1098,6 +1145,7 @@ void EventEvaluatorEIC::fillOutputNtuples(PHCompositeNode* topNode)
             _hits_y[_nHitsLayers] = hit_iter->second->get_y(0);
             _hits_z[_nHitsLayers] = hit_iter->second->get_z(0);
             _hits_t[_nHitsLayers] = hit_iter->second->get_t(0);
+            _hits_edep[_nHitsLayers] = hit_iter->second->get_edep();
             _hits_layerID[_nHitsLayers] = iIndex;
             if (truthinfocontainerHits)
             {
@@ -1759,6 +1807,104 @@ void EventEvaluatorEIC::fillOutputNtuples(PHCompositeNode* topNode)
     }
   }
   //----------------------
+  //    TOWERS FOCAL
+  //----------------------
+  if (_do_FOCAL)
+  {
+    CaloRawTowerEval* towerevalFOCAL = _caloevalstackFOCAL->get_rawtower_eval();
+    _nTowers_FOCAL = 0;
+    string towernodeFOCAL = "TOWER_CALIB_FOCAL";
+    RawTowerContainer* towersFOCAL = findNode::getClass<RawTowerContainer>(topNode, towernodeFOCAL.c_str());
+    if (towersFOCAL)
+    {
+      if (Verbosity() > 0)
+      {
+        cout << "saving FOCAL towers" << endl;
+      }
+      string towergeomnodeFOCAL = "TOWERGEOM_FOCAL";
+      RawTowerGeomContainer* towergeomFOCAL = findNode::getClass<RawTowerGeomContainer>(topNode, towergeomnodeFOCAL.c_str());
+      if (towergeomFOCAL)
+      {
+        if(_do_GEOMETRY && !_geometry_done[kFOCAL]){
+          RawTowerGeomContainer::ConstRange all_towers = towergeomFOCAL->get_tower_geometries();
+          for (RawTowerGeomContainer::ConstIterator it = all_towers.first;
+              it != all_towers.second; ++it)
+          {
+            _calo_ID = kFOCAL;
+            _calo_towers_iEta[_calo_towers_N] = it->second->get_bineta();
+            _calo_towers_iPhi[_calo_towers_N] = it->second->get_binphi();
+            _calo_towers_iL[_calo_towers_N] = -1;
+            _calo_towers_Eta[_calo_towers_N] = it->second->get_eta();
+            _calo_towers_Phi[_calo_towers_N] = it->second->get_phi();
+            _calo_towers_x[_calo_towers_N] = it->second->get_center_x();
+            _calo_towers_y[_calo_towers_N] = it->second->get_center_y();
+            _calo_towers_z[_calo_towers_N] = it->second->get_center_z();
+            _calo_towers_N++;
+          }
+          _geometry_done[kFOCAL] = 1;
+          _geometry_tree->Fill();
+          resetGeometryArrays();
+        }
+        if (Verbosity() > 0)
+        {
+          cout << "found FOCAL geom" << endl;
+        }
+        RawTowerContainer::ConstRange begin_end = towersFOCAL->getTowers();
+        RawTowerContainer::ConstIterator rtiter;
+        for (rtiter = begin_end.first; rtiter != begin_end.second; ++rtiter)
+        {
+          RawTower* tower = rtiter->second;
+          if (tower)
+          {
+            // min energy cut
+            if (tower->get_energy() < _reco_e_threshold[kFOCAL]) continue;
+
+            _tower_FOCAL_iEta[_nTowers_FOCAL] = tower->get_bineta();
+            _tower_FOCAL_iPhi[_nTowers_FOCAL] = tower->get_binphi();
+            _tower_FOCAL_E[_nTowers_FOCAL] = tower->get_energy();
+            _tower_FOCAL_NScint[_nTowers_FOCAL] = tower->get_scint_gammas();
+            _tower_FOCAL_NCerenkov[_nTowers_FOCAL] = tower->get_cerenkov_gammas();
+
+            PHG4Particle* primary = towerevalFOCAL->max_truth_primary_particle_by_energy(tower);
+            if (primary)
+            {
+              _tower_FOCAL_trueID[_nTowers_FOCAL] = primary->get_track_id();
+            }
+            else
+            {
+              _tower_FOCAL_trueID[_nTowers_FOCAL] = -10;
+            }
+            _nTowers_FOCAL++;
+          }
+        }
+        if (Verbosity() > 0)
+        {
+          cout << "finished FOCAL twr loop" << endl;
+        }
+      }
+      else
+      {
+        if (Verbosity() > 0)
+        {
+          cout << PHWHERE << " ERROR: Can't find " << towergeomnodeFOCAL << endl;
+        }
+        // return;
+      }
+      if (Verbosity() > 0)
+      {
+        cout << "saved\t" << _nTowers_FOCAL << "\tFOCAL towers" << endl;
+      }
+    }
+    else
+    {
+      if (Verbosity() > 0)
+      {
+        cout << PHWHERE << " ERROR: Can't find " << towernodeFOCAL << endl;
+      }
+      // return;
+    }
+  }
+  //----------------------
   //    TOWERS LFHCAL
   //----------------------
   if (_do_LFHCAL)
@@ -1802,7 +1948,7 @@ void EventEvaluatorEIC::fillOutputNtuples(PHCompositeNode* topNode)
         }
         if (Verbosity() > 0)
         {
-          cout << "found DRCALO geom" << endl;
+          cout << "found LFHCAL geom" << endl;
         }
 
         RawTowerContainer::ConstRange begin_end = towersLFHCAL->getTowers();
@@ -3103,6 +3249,7 @@ int EventEvaluatorEIC::End(PHCompositeNode* topNode)
   if (_caloevalstackHCALOUT) delete _caloevalstackHCALOUT;
   if (_caloevalstackEHCAL) delete _caloevalstackEHCAL;
   if (_caloevalstackDRCALO) delete _caloevalstackDRCALO;
+  if (_caloevalstackFOCAL) delete _caloevalstackFOCAL;
   if (_caloevalstackLFHCAL) delete _caloevalstackLFHCAL;
   if (_caloevalstackFEMC) delete _caloevalstackFEMC;
   if (_caloevalstackCEMC) delete _caloevalstackCEMC;
@@ -3211,6 +3358,13 @@ int EventEvaluatorEIC::GetProjectionIndex(std::string projname)
   else if (projname.find("LFHCAL") != std::string::npos)
     return 67;
 
+  else if (projname.find("BH_1") != std::string::npos)
+    return 90;
+  else if (projname.find("BH_FORWARD_PLUS") != std::string::npos)
+    return 91;
+  else if (projname.find("BH_FORWARD_NEG") != std::string::npos)
+    return 92;
+
   else
     return -1;
   return -1;
@@ -3317,6 +3471,13 @@ std::string EventEvaluatorEIC::GetProjectionNameFromIndex(int projindex)
   case 67:
     return "LFHCAL";
 
+  case 90:
+    return "BH_1";
+  case 91:
+    return "BH_FORWARD_PLUS";
+  case 92:
+    return "BH_FORWARD_NEG";
+
   default:
     return "NOTHING";
   }
@@ -3369,6 +3530,7 @@ void EventEvaluatorEIC::resetBuffer()
       _hits_y[ihit] = 0;
       _hits_z[ihit] = 0;
       _hits_t[ihit] = 0;
+      _hits_edep[ihit] = 0;
     }
     if (Verbosity() > 0){ cout << "\t... hit variables reset" << endl;}
   }
@@ -3559,6 +3721,21 @@ void EventEvaluatorEIC::resetBuffer()
       _tower_DRCALO_trueID[itow] = 0;
     }
     if (Verbosity() > 0){ cout << "\t... DRCALO variables reset" << endl;}
+  }
+  if (_do_FOCAL)
+  {
+    if (Verbosity() > 0){ cout << "\t... resetting FOCAL variables" << endl;}
+    _nTowers_FOCAL = 0;
+    for (Int_t itow = 0; itow < _maxNTowersDR; itow++)
+    {
+      _tower_FOCAL_E[itow] = 0;
+      _tower_FOCAL_NScint[itow] = 0;
+      _tower_FOCAL_NCerenkov[itow] = 0;
+      _tower_FOCAL_iEta[itow] = 0;
+      _tower_FOCAL_iPhi[itow] = 0;
+      _tower_FOCAL_trueID[itow] = 0;
+    }
+    if (Verbosity() > 0){ cout << "\t... FOCAL variables reset" << endl;}
   }
   if (_do_LFHCAL)
   {

--- a/analysis/eicevaluator/EventEvaluatorEIC.h
+++ b/analysis/eicevaluator/EventEvaluatorEIC.h
@@ -58,6 +58,7 @@ class EventEvaluatorEIC : public SubsysReco
   void set_do_EEMC(bool b) { _do_EEMC = b; }
   void set_do_EEMCG(bool b) { _do_EEMCG = b; }
   void set_do_DRCALO(bool b) { _do_DRCALO = b; }
+  void set_do_FOCAL(bool b) { _do_FOCAL = b; }
   void set_do_LFHCAL(bool b) { _do_LFHCAL = b; }
   void set_do_HITS(bool b) { _do_HITS = b; }
   void set_do_TRACKS(bool b) { _do_TRACKS = b; }
@@ -67,6 +68,7 @@ class EventEvaluatorEIC : public SubsysReco
   void set_do_MCPARTICLES(bool b) { _do_MCPARTICLES = b; }
   void set_do_HEPMC(bool b) { _do_HEPMC = b; }
   void set_do_GEOMETRY(bool b) { _do_GEOMETRY = b; }
+  void set_do_BLACKHOLE(bool b) { _do_BLACKHOLE = b; }
 
   // limit the tracing of towers and clusters back to the truth particles
   // to only those reconstructed objects above a particular energy
@@ -98,6 +100,7 @@ class EventEvaluatorEIC : public SubsysReco
   bool _do_EEMC;
   bool _do_EEMCG;
   bool _do_DRCALO;
+  bool _do_FOCAL;
   bool _do_LFHCAL;
   bool _do_HITS;
   bool _do_TRACKS;
@@ -107,6 +110,7 @@ class EventEvaluatorEIC : public SubsysReco
   bool _do_MCPARTICLES;
   bool _do_HEPMC;
   bool _do_GEOMETRY;
+  bool _do_BLACKHOLE;
   unsigned int _ievent;
 
   // Event level info
@@ -122,6 +126,7 @@ class EventEvaluatorEIC : public SubsysReco
   float* _hits_y;
   float* _hits_z;
   float* _hits_t;
+  float* _hits_edep;
 
   // towers
   int _nTowers_FHCAL;
@@ -164,6 +169,14 @@ class EventEvaluatorEIC : public SubsysReco
   int* _tower_DRCALO_iEta;
   int* _tower_DRCALO_iPhi;
   int* _tower_DRCALO_trueID;
+
+  int _nTowers_FOCAL;
+  float* _tower_FOCAL_E;
+  int* _tower_FOCAL_NScint;
+  int* _tower_FOCAL_NCerenkov;
+  int* _tower_FOCAL_iEta;
+  int* _tower_FOCAL_iPhi;
+  int* _tower_FOCAL_trueID;
 
   int _nTowers_LFHCAL;
   float* _tower_LFHCAL_E;
@@ -336,6 +349,7 @@ class EventEvaluatorEIC : public SubsysReco
   CaloEvalStack* _caloevalstackHCALOUT;
   CaloEvalStack* _caloevalstackEHCAL;
   CaloEvalStack* _caloevalstackDRCALO;
+  CaloEvalStack* _caloevalstackFOCAL;
   CaloEvalStack* _caloevalstackLFHCAL;
   CaloEvalStack* _caloevalstackFEMC;
   CaloEvalStack* _caloevalstackCEMC;
@@ -386,7 +400,8 @@ class EventEvaluatorEIC : public SubsysReco
       kHCALOUT       = 7,
       kLFHCAL        = 8,
       kEEMCG         = 9,
-      kBECAL         = 10
+      kBECAL         = 10,
+      kFOCAL         = 11
   };
 
 };

--- a/simulation/g4simulation/g4drcalo/PHG4ForwardDualReadoutDetector.cc
+++ b/simulation/g4simulation/g4drcalo/PHG4ForwardDualReadoutDetector.cc
@@ -62,6 +62,7 @@ PHG4ForwardDualReadoutDetector::PHG4ForwardDualReadoutDetector(PHG4Subsystem* su
   , _sPhi(0)
   , _dPhi(2 * M_PI)
   , _tower_type(0)
+  , _tower_readout(0.5 * mm)
   , _tower_dx(100 * mm)
   , _tower_dy(100 * mm)
   , _tower_dz(1000.0 * mm)
@@ -183,22 +184,22 @@ void PHG4ForwardDualReadoutDetector::ConstructMe(G4LogicalVolume* logicWorld)
   for(int row=rowNtow;row>=-rowNtow;row--){
     // pythagoras -> get available length in circular mother volume for towers
     // divide given length by tower width -> get number of towers that can be placed
-    int currRowNtow = (int) ( ( 2* sqrt(pow(_rMax1,2)-pow( (abs(row)*_tower_dy) + (_tower_dy/2.0) ,2)) ) / _tower_dy );
+    int currRowNtow = (int) ( ( 2* sqrt(pow(_rMax1,2)-pow( (abs(row)*_tower_dy) ,2)) ) / _tower_dy );
     if(currRowNtow==0) continue;
     // we want an odd number of towers to be symmetrically centered around 0
     if ( currRowNtow % 2 == 0) currRowNtow-=1;
 
-    if( ( (abs(row)*_tower_dy) - (_tower_dy/2.0) ) < _rMin1 ){ // _rMin1
+    if( ( (abs(row)*_tower_dy) ) < _rMin1 ){ // _rMin1
       if(_center_offset_x!=0){
         // pythagoras -> get available length in circular mother volume for towers
         // divide given length by tower width -> get number of towers that can be placed
-        int currRowNtowInner = (int) ( ( 2* sqrt(pow(_rMin1,2)-pow( (abs(row)*_tower_dy) - (_tower_dy/2.0) ,2)) ) / _tower_dy );
+        int currRowNtowInner = (int) ( ( 2* sqrt(pow(_rMin1,2)-pow( (abs(row)*_tower_dy) ,2)) ) / _tower_dy );
         // we want an odd number of towers to be symmetrically centered around 0
         if(_quadratic_detector){
           if ( currRowNtowInner % 2 == 0) currRowNtowInner+=1;
           currRowNtowInner+=1;
         } else {
-          if ( currRowNtowInner % 2 == 0) currRowNtowInner-=1;
+          if ( currRowNtowInner % 2 == 0) currRowNtowInner+=1;
         }
         int offsetrows = (int) ( _center_offset_x / _tower_dy );
         if ( offsetrows % 2 != 1) offsetrows-=1;
@@ -209,10 +210,10 @@ void PHG4ForwardDualReadoutDetector::ConstructMe(G4LogicalVolume* logicWorld)
         }
 
         // create mother volume with space for currRowNtow towers along x-axis
-        auto DRCalRowLeftSolid    = new G4Box("DRCalRowLeftBox", ((currRowNtowMod - currRowNtowInner) / 2 + offsetrows) * _tower_dx / 2.0,_tower_dy / 2.0,_tower_dz / 2.0);
-        auto DRCalRowLeftLogical  = new G4LogicalVolume(DRCalRowLeftSolid,material_air,"DRCalRowLeftLogical");
+        auto DRCalRowLeftSolid    = new G4Box("DRCalRowLeftBox" + std::to_string(row), ((currRowNtowMod - currRowNtowInner) / 2 + offsetrows) * _tower_dx / 2.0,_tower_dy / 2.0,_tower_dz / 2.0);
+        auto DRCalRowLeftLogical  = new G4LogicalVolume(DRCalRowLeftSolid,material_air,"DRCalRowLeftLogical" + std::to_string(row));
         // replicate singletower tower design currRowNtow times along x-axis
-        new G4PVReplica("DRCalRowLeftPhysical",singletower,DRCalRowLeftLogical,
+        new G4PVReplica("DRCalRowLeftPhysical" + std::to_string(row),singletower,DRCalRowLeftLogical,
                         kXAxis,((currRowNtowMod - currRowNtowInner) / 2 + offsetrows),_tower_dx);
 
         ostringstream name_row_twr_left;
@@ -222,10 +223,10 @@ void PHG4ForwardDualReadoutDetector::ConstructMe(G4LogicalVolume* logicWorld)
                       DRCalRowLeftLogical, name_row_twr_left.str().c_str(), drcalo_envelope_log, 0, false, OverlapCheck());
 
         // create mother volume with space for currRowNtow towers along x-axis
-        auto DRCalRowRightSolid    = new G4Box("DRCalRowRightBox", ((currRowNtowMod - currRowNtowInner) / 2 - offsetrows ) * _tower_dx / 2.0,_tower_dy / 2.0,_tower_dz / 2.0);
-        auto DRCalRowRightLogical  = new G4LogicalVolume(DRCalRowRightSolid,material_air,"DRCalRowRightLogical");
+        auto DRCalRowRightSolid    = new G4Box("DRCalRowRightBox" + std::to_string(row), ((currRowNtowMod - currRowNtowInner) / 2 - offsetrows ) * _tower_dx / 2.0,_tower_dy / 2.0,_tower_dz / 2.0);
+        auto DRCalRowRightLogical  = new G4LogicalVolume(DRCalRowRightSolid,material_air,"DRCalRowRightLogical" + std::to_string(row));
         // replicate singletower tower design currRowNtow times along x-axis
-        new G4PVReplica("DRCalRowRightPhysical",singletower,DRCalRowRightLogical,
+        new G4PVReplica("DRCalRowRightPhysical" + std::to_string(row),singletower,DRCalRowRightLogical,
                         kXAxis,((currRowNtowMod - currRowNtowInner) / 2 - offsetrows ),_tower_dx);
 
         ostringstream name_row_twr_right;
@@ -245,10 +246,10 @@ void PHG4ForwardDualReadoutDetector::ConstructMe(G4LogicalVolume* logicWorld)
           currRowNtowMod = rowNtow;
         }
         // create mother volume with space for currRowNtow towers along x-axis
-        auto DRCalRowSolid    = new G4Box("DRCalRowBox", (currRowNtowMod - currRowNtowInner) / 2 * _tower_dx / 2.0,_tower_dy / 2.0,_tower_dz / 2.0);
-        auto DRCalRowLogical  = new G4LogicalVolume(DRCalRowSolid,material_air,"DRCalRowLogical");
+        auto DRCalRowSolid    = new G4Box("DRCalRowBox" + std::to_string(row), (currRowNtowMod - currRowNtowInner) / 2 * _tower_dx / 2.0,_tower_dy / 2.0,_tower_dz / 2.0);
+        auto DRCalRowLogical  = new G4LogicalVolume(DRCalRowSolid,material_air,"DRCalRowLogical" + std::to_string(row));
         // replicate singletower tower design currRowNtow times along x-axis
-        new G4PVReplica("DRCalRowPhysical",singletower,DRCalRowLogical,
+        new G4PVReplica("DRCalRowPhysical" + std::to_string(row),singletower,DRCalRowLogical,
                         kXAxis,(currRowNtowMod - currRowNtowInner) / 2,_tower_dx);
 
         ostringstream name_row_twr;
@@ -268,10 +269,10 @@ void PHG4ForwardDualReadoutDetector::ConstructMe(G4LogicalVolume* logicWorld)
       if(_quadratic_detector){
         // cout << currRowNtow << endl;
         // create mother volume with space for currRowNtow towers along x-axis
-        auto DRCalRowSolid    = new G4Box("DRCalRowBox", 2 * rowNtow * _tower_dx / 2.0,_tower_dy / 2.0,_tower_dz / 2.0);
-        auto DRCalRowLogical  = new G4LogicalVolume(DRCalRowSolid,material_air,"DRCalRowLogical");
+        auto DRCalRowSolid    = new G4Box("DRCalRowBox" + std::to_string(row), 2 * rowNtow * _tower_dx / 2.0,_tower_dy / 2.0,_tower_dz / 2.0);
+        auto DRCalRowLogical  = new G4LogicalVolume(DRCalRowSolid,material_air,"DRCalRowLogical" + std::to_string(row));
         // replicate singletower tower design currRowNtow times along x-axis
-        new G4PVReplica("DRCalRowPhysical",singletower,DRCalRowLogical,
+        new G4PVReplica("DRCalRowPhysical" + std::to_string(row),singletower,DRCalRowLogical,
                         kXAxis,2 * rowNtow,_tower_dx);
 
         ostringstream name_row_twr;
@@ -282,10 +283,10 @@ void PHG4ForwardDualReadoutDetector::ConstructMe(G4LogicalVolume* logicWorld)
       } else {
         // create mother volume with space for currRowNtow towers along x-axis
         // cout << currRowNtow << endl;
-        auto DRCalRowSolid    = new G4Box("DRCalRowBox", currRowNtow * _tower_dx / 2.0,_tower_dy / 2.0,_tower_dz / 2.0);
-        auto DRCalRowLogical  = new G4LogicalVolume(DRCalRowSolid,material_air,"DRCalRowLogical");
+        auto DRCalRowSolid    = new G4Box("DRCalRowBox" + std::to_string(row), currRowNtow * _tower_dx / 2.0,_tower_dy / 2.0,_tower_dz / 2.0);
+        auto DRCalRowLogical  = new G4LogicalVolume(DRCalRowSolid,material_air,"DRCalRowLogical" + std::to_string(row));
         // replicate singletower tower design currRowNtow times along x-axis
-        new G4PVReplica("DRCalRowPhysical",singletower,DRCalRowLogical,
+        new G4PVReplica("DRCalRowPhysical" + std::to_string(row),singletower,DRCalRowLogical,
                         kXAxis,currRowNtow,_tower_dx);
 
         ostringstream name_row_twr;
@@ -311,11 +312,22 @@ PHG4ForwardDualReadoutDetector::ConstructTower(int type)
 
   //create logical volume for single tower
   G4Material* material_air = G4Material::GetMaterial("G4_AIR");
-  float distancing = 1.0;
-  // 2x2 tower base element
-  G4VSolid* single_tower_solid = new G4Box(G4String("single_tower_solid"),
+  // constructed tower base element
+  G4VSolid* base_tower_solid = new G4Box(G4String("base_tower_solid"),
                                           _tower_dx / 2.0,
                                           _tower_dy / 2.0,
+                                          _tower_dz / 2.0);
+
+  G4LogicalVolume* base_tower_logic = new G4LogicalVolume(base_tower_solid,
+                                                            material_air,
+                                                            "base_tower_logic",
+                                                            0, 0, 0);
+  int maxsubtow = (int) ( (_tower_dx) / (_tower_readout));
+  G4double addtowsize = (_tower_dx - (maxsubtow * _tower_readout))/maxsubtow;
+  // 2x2 fiber tower base element
+  G4VSolid* single_tower_solid = new G4Box(G4String("single_tower_solid"),
+                                          (_tower_readout + addtowsize) / 2.0,
+                                          (_tower_readout + addtowsize) / 2.0,
                                           _tower_dz / 2.0);
 
   G4LogicalVolume* single_tower_logic = new G4LogicalVolume(single_tower_solid,
@@ -323,6 +335,7 @@ PHG4ForwardDualReadoutDetector::ConstructTower(int type)
                                                             "single_tower_logic",
                                                             0, 0, 0);
 
+  m_DisplayAction->AddVolume(single_tower_logic, "FdrcaloEnvelope");
   //create geometry volumes to place inside single_tower
 
   G4double diameter_fiber = _scintFiber_diam;
@@ -351,39 +364,39 @@ PHG4ForwardDualReadoutDetector::ConstructTower(int type)
                                           1.03 * _tower_dz / 1.0);
   // absorber base object
   G4VSolid* solid_absorber_temp = new G4Box(G4String("solid_absorber_temp"),
-                                          distancing*_tower_dx / 2.0,
-                                          distancing*_tower_dy / 2.0,
+                                          (_tower_readout + addtowsize) / 2.0,
+                                          (_tower_readout + addtowsize) / 2.0,
                                           _tower_dz / 2.0);
 
   G4VSolid* solid_absorber;
   if(_tower_makeNotched){
     // cut out four fiber holes
     solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_temp_f1"), solid_absorber_temp, single_cutout_tube_cherenkov
-                                                              , 0 ,G4ThreeVector( _tower_dx / 4.0 , ( _tower_dy / 2.0 ) - ( ( diameter_fiber_cherenkov + airgap ) / 2.0 ) ,0.)); // top right
+                                                              , 0 ,G4ThreeVector( _tower_readout / 4.0 , ( _tower_readout / 2.0 ) - ( ( diameter_fiber_cherenkov + airgap ) / 2.0 ) ,0.)); // top right
     solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_temp_f2"), solid_absorber, single_cutout_tube
-                                                              , 0 ,G4ThreeVector( _tower_dx / 4.0 , - ( ( diameter_fiber + airgap ) / 2.0 ) ,0.)); // bottom right
+                                                              , 0 ,G4ThreeVector( _tower_readout / 4.0 , - ( ( diameter_fiber + airgap ) / 2.0 ) ,0.)); // bottom right
     solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_temp_f3"), solid_absorber, single_cutout_tube
-                                                              , 0 ,G4ThreeVector(- _tower_dx / 4.0, ( _tower_dy / 2.0 ) - ( ( diameter_fiber + airgap ) / 2.0 ) ,0.)); // top left
+                                                              , 0 ,G4ThreeVector(- _tower_readout / 4.0, ( _tower_readout / 2.0 ) - ( ( diameter_fiber + airgap ) / 2.0 ) ,0.)); // top left
     solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_temp_f4"), solid_absorber, single_cutout_tube_cherenkov
-                                                              , 0 ,G4ThreeVector(- _tower_dx / 4.0, - ( ( diameter_fiber_cherenkov + airgap ) / 2.0 ) ,0.)); // bottom left
+                                                              , 0 ,G4ThreeVector(- _tower_readout / 4.0, - ( ( diameter_fiber_cherenkov + airgap ) / 2.0 ) ,0.)); // bottom left
     // cut out four notches
     solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_temp_box1"), solid_absorber, single_cutout_box_cherenkov
-                                                              , 0 ,G4ThreeVector( _tower_dx / 4.0  , ( _tower_dy / 2.0 ) - ( ( diameter_fiber_cherenkov + airgap ) / 4.0 ) ,0.));
+                                                              , 0 ,G4ThreeVector( _tower_readout / 4.0  , ( _tower_readout / 2.0 ) - ( ( diameter_fiber_cherenkov + airgap ) / 4.0 ) ,0.));
     solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_temp_box2"), solid_absorber, single_cutout_box
-                                                              , 0 ,G4ThreeVector( _tower_dx / 4.0  , - ( ( diameter_fiber + airgap ) / 4.0 ) ,0.));
+                                                              , 0 ,G4ThreeVector( _tower_readout / 4.0  , - ( ( diameter_fiber + airgap ) / 4.0 ) ,0.));
     solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_temp_box3"), solid_absorber, single_cutout_box
-                                                              , 0 ,G4ThreeVector( - _tower_dx / 4.0, ( _tower_dy / 2.0 ) - ( ( diameter_fiber + airgap ) / 4.0 ) ,0.));
+                                                              , 0 ,G4ThreeVector( - _tower_readout / 4.0, ( _tower_readout / 2.0 ) - ( ( diameter_fiber + airgap ) / 4.0 ) ,0.));
     solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_temp_box4"), solid_absorber, single_cutout_box_cherenkov
-                                                            , 0 ,G4ThreeVector( - _tower_dx / 4.0, - ( ( diameter_fiber_cherenkov + airgap ) / 4.0 ) ,0.));
+                                                            , 0 ,G4ThreeVector( - _tower_readout / 4.0, - ( ( diameter_fiber_cherenkov + airgap ) / 4.0 ) ,0.));
   } else {
     solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_temp_f1"), solid_absorber_temp, single_cutout_tube_cherenkov
-                                                              , 0 ,G4ThreeVector( _tower_dx / 4.0 , _tower_dy / 4.0 ,0.)); // top right
+                                                              , 0 ,G4ThreeVector( _tower_readout / 4.0 , _tower_readout / 4.0 ,0.)); // top right
     solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_temp_f2"), solid_absorber, single_cutout_tube
-                                                              , 0 ,G4ThreeVector( _tower_dx / 4.0 , - _tower_dy / 4.0 ,0.)); // bottom right
+                                                              , 0 ,G4ThreeVector( _tower_readout / 4.0 , - _tower_readout / 4.0 ,0.)); // bottom right
     solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_temp_f3"), solid_absorber, single_cutout_tube
-                                                              , 0 ,G4ThreeVector(- _tower_dx / 4.0, _tower_dy / 4.0 ,0.)); // top left
+                                                              , 0 ,G4ThreeVector(- _tower_readout / 4.0, _tower_readout / 4.0 ,0.)); // top left
     solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_temp_f4"), solid_absorber, single_cutout_tube_cherenkov
-                                                              , 0 ,G4ThreeVector(- _tower_dx / 4.0, - _tower_dy / 4.0 ,0.)); // bottom left
+                                                              , 0 ,G4ThreeVector(- _tower_readout / 4.0, - _tower_readout / 4.0 ,0.)); // bottom left
   }
   G4VSolid* solid_scintillator  = new G4Tubs(G4String("single_scintillator_fiber"),
                                             0,
@@ -457,52 +470,70 @@ PHG4ForwardDualReadoutDetector::ConstructTower(int type)
                     0, 0, OverlapCheck());
   if(_tower_makeNotched){
     // place scintillator fibers (top left, bottom right)
-    new G4PVPlacement(0, G4ThreeVector( -_tower_dx / 4,  ( _tower_dy / 2.0 ) - ( ( diameter_fiber + airgap ) / 2.0 ) , 0),
+    new G4PVPlacement(0, G4ThreeVector( -_tower_readout / 4,  ( _tower_readout / 2.0 ) - ( ( diameter_fiber + airgap ) / 2.0 ) , 0),
                       logic_scint,
                       name_scintillator.str().c_str(),
                       single_tower_logic,
                       0, 0, OverlapCheck());
-    new G4PVPlacement(0, G4ThreeVector( _tower_dx / 4,  - ( ( diameter_fiber + airgap ) / 2.0 ) , 0),
+    new G4PVPlacement(0, G4ThreeVector( _tower_readout / 4,  - ( ( diameter_fiber + airgap ) / 2.0 ) , 0),
                       logic_scint,
                       name_scintillator.str().c_str(),
                       single_tower_logic,
                       0, 0, OverlapCheck());
 
     // place cherenkov fibers (top right, bottom left)
-    new G4PVPlacement(0, G4ThreeVector( _tower_dx / 4 ,  ( _tower_dy / 2.0 ) - ( ( diameter_fiber_cherenkov + airgap ) / 2.0 ) , 0),
+    new G4PVPlacement(0, G4ThreeVector( _tower_readout / 4 ,  ( _tower_readout / 2.0 ) - ( ( diameter_fiber_cherenkov + airgap ) / 2.0 ) , 0),
                       logic_cherenk,
                       name_cherenkov.str().c_str(),
                       single_tower_logic,
                       0, 0, OverlapCheck());
-    new G4PVPlacement(0, G4ThreeVector( -_tower_dx / 4 ,  - ( ( diameter_fiber_cherenkov + airgap ) / 2.0 ) , 0),
+    new G4PVPlacement(0, G4ThreeVector( -_tower_readout / 4 ,  - ( ( diameter_fiber_cherenkov + airgap ) / 2.0 ) , 0),
                       logic_cherenk,
                       name_cherenkov.str().c_str(),
                       single_tower_logic,
                       0, 0, OverlapCheck());
   } else {
     // place scintillator fibers (top left, bottom right)
-    new G4PVPlacement(0, G4ThreeVector( -_tower_dx / 4,  _tower_dy / 4.0 , 0),
+    new G4PVPlacement(0, G4ThreeVector( -_tower_readout / 4,  _tower_readout / 4.0 , 0),
                       logic_scint,
                       name_scintillator.str().c_str(),
                       single_tower_logic,
                       0, 0, OverlapCheck());
-    new G4PVPlacement(0, G4ThreeVector( _tower_dx / 4,  - _tower_dy / 4.0 , 0),
+    new G4PVPlacement(0, G4ThreeVector( _tower_readout / 4,  - _tower_readout / 4.0 , 0),
                       logic_scint,
                       name_scintillator.str().c_str(),
                       single_tower_logic,
                       0, 0, OverlapCheck());
 
     // place cherenkov fibers (top right, bottom left)
-    new G4PVPlacement(0, G4ThreeVector( _tower_dx / 4 ,  _tower_dy / 4.0 , 0),
+    new G4PVPlacement(0, G4ThreeVector( _tower_readout / 4 ,  _tower_readout / 4.0 , 0),
                       logic_cherenk,
                       name_cherenkov.str().c_str(),
                       single_tower_logic,
                       0, 0, OverlapCheck());
-    new G4PVPlacement(0, G4ThreeVector( -_tower_dx / 4 ,  - _tower_dy / 4.0 , 0),
+    new G4PVPlacement(0, G4ThreeVector( -_tower_readout / 4 ,  - _tower_readout / 4.0 , 0),
                       logic_cherenk,
                       name_cherenkov.str().c_str(),
                       single_tower_logic,
                       0, 0, OverlapCheck());
+  }
+
+
+  int rowNtow = (int) ( (_tower_dx) / (_tower_readout + addtowsize));
+  for(int row=(rowNtow / 2);row>=-rowNtow / 2;row--){
+      // create mother volume with space for currRowNtow towers along x-axis
+      auto DRCalRowSolid    = new G4Box("DRCalRowBoxBase" + std::to_string(row), _tower_dx / 2.0, (_tower_readout + addtowsize) / 2.0, _tower_dz / 2.0);
+      auto DRCalRowLogical  = new G4LogicalVolume(DRCalRowSolid,material_air,"DRCalRowLogicalBase" + std::to_string(row));
+      // replicate singletower tower design currRowNtow times along x-axis
+      new G4PVReplica("DRCalRowPhysicalBase" + std::to_string(row),single_tower_logic,DRCalRowLogical,
+                      kXAxis, rowNtow, _tower_readout + addtowsize);
+
+      m_DisplayAction->AddVolume(DRCalRowLogical, "FdrcaloEnvelope");
+      ostringstream name_row_twr;
+      name_row_twr.str("");
+      name_row_twr << _towerlogicnameprefix << "_row_" << row << endl;
+      new G4PVPlacement(0, G4ThreeVector(0, (row * (_tower_readout + addtowsize)), 0),
+                    DRCalRowLogical, name_row_twr.str().c_str(), base_tower_logic, 0, false, OverlapCheck());
   }
 
   if (Verbosity() > 0)
@@ -510,7 +541,7 @@ PHG4ForwardDualReadoutDetector::ConstructTower(int type)
     cout << "PHG4ForwardDualReadoutDetector: Building logical volume for single tower done." << endl;
   }
 
-  return single_tower_logic;
+  return base_tower_logic;
 }
 
 //_______________________________________________________________________
@@ -525,9 +556,22 @@ PHG4ForwardDualReadoutDetector::ConstructTowerFCStyle(int type)
   //create logical volume for single tower
   G4Material* material_air = G4Material::GetMaterial("G4_AIR");
   // 2x2 tower base element
-  G4VSolid* single_tower_solid = new G4Box(G4String("single_tower_solid"),
+  G4VSolid* base_tower_solid = new G4Box(G4String("base_tower_solid"),
                                           _tower_dx / 2.0,
                                           _tower_dy / 2.0,
+                                          _tower_dz / 2.0);
+
+  G4LogicalVolume* base_tower_logic = new G4LogicalVolume(base_tower_solid,
+                                                            material_air,
+                                                            "base_tower_logic",
+                                                            0, 0, 0);
+  G4double copperTubeDiam = _tower_readout / 2;
+  int maxsubtow = (int) ( (_tower_dx) / (2 * copperTubeDiam));
+  G4double addtowsize = (_tower_dx - (maxsubtow * 2 * copperTubeDiam))/maxsubtow;
+  // 2x2 tower base element
+  G4VSolid* single_tower_solid = new G4Box(G4String("single_tower_solid"),
+                                          (2 * copperTubeDiam + addtowsize) / 2.0,
+                                          (2 * copperTubeDiam + addtowsize) / 2.0,
                                           _tower_dz / 2.0);
 
   G4LogicalVolume* single_tower_logic = new G4LogicalVolume(single_tower_solid,
@@ -535,9 +579,9 @@ PHG4ForwardDualReadoutDetector::ConstructTowerFCStyle(int type)
                                                             "single_tower_logic",
                                                             0, 0, 0);
 
+  m_DisplayAction->AddVolume(single_tower_logic, "FdrcaloEnvelope");
   //create geometry volumes to place inside single_tower
 
-  G4double copperTubeDiam = _tower_dx/2;
   G4double diameter_fiber = _scintFiber_diam;
   G4double diameter_fiber_cherenkov = _cerenkovFiber_diam;
 
@@ -612,58 +656,82 @@ PHG4ForwardDualReadoutDetector::ConstructTowerFCStyle(int type)
   name_cherenkov.str("");
   name_cherenkov << _towerlogicnameprefix << "_single_cherenkov_fiber"  << endl;
 
+  // place copper rods
+  new G4PVPlacement(0, G4ThreeVector( -copperTubeDiam/2,  copperTubeDiam/2 , 0),
+                    logic_absorber,
+                    name_absorber.str().c_str(),
+                    single_tower_logic,
+                    0, 0, OverlapCheck());
+  new G4PVPlacement(0, G4ThreeVector( -copperTubeDiam/2,  -copperTubeDiam/2 , 0),
+                    logic_absorber,
+                    name_absorber.str().c_str(),
+                    single_tower_logic,
+                    0, 0, OverlapCheck());
+  new G4PVPlacement(0, G4ThreeVector( copperTubeDiam/2,  copperTubeDiam/2 , 0),
+                    logic_absorber,
+                    name_absorber.str().c_str(),
+                    single_tower_logic,
+                    0, 0, OverlapCheck());
+  new G4PVPlacement(0, G4ThreeVector( copperTubeDiam/2,  -copperTubeDiam/2 , 0),
+                    logic_absorber,
+                    name_absorber.str().c_str(),
+                    single_tower_logic,
+                    0, 0, OverlapCheck());
 
-  new G4PVPlacement(0, G4ThreeVector( -_tower_dx/4,  _tower_dx/4 , 0),
-                    logic_absorber,
-                    name_absorber.str().c_str(),
+  // place scintillator fibers (top left, bottom right)
+  new G4PVPlacement(0, G4ThreeVector( 0,  0 , 0),
+                    logic_scint,
+                    name_scintillator.str().c_str(),
                     single_tower_logic,
                     0, 0, OverlapCheck());
-  new G4PVPlacement(0, G4ThreeVector( -_tower_dx/4,  -_tower_dx/4 , 0),
-                    logic_absorber,
-                    name_absorber.str().c_str(),
-                    single_tower_logic,
-                    0, 0, OverlapCheck());
-  new G4PVPlacement(0, G4ThreeVector( _tower_dx/4,  _tower_dx/4 , 0),
-                    logic_absorber,
-                    name_absorber.str().c_str(),
-                    single_tower_logic,
-                    0, 0, OverlapCheck());
-  new G4PVPlacement(0, G4ThreeVector( _tower_dx/4,  -_tower_dx/4 , 0),
-                    logic_absorber,
-                    name_absorber.str().c_str(),
+  new G4PVPlacement(0, G4ThreeVector( copperTubeDiam, copperTubeDiam , 0),
+                    logic_scint,
+                    name_scintillator.str().c_str(),
                     single_tower_logic,
                     0, 0, OverlapCheck());
 
-    // place scintillator fibers (top left, bottom right)
-    new G4PVPlacement(0, G4ThreeVector( 0,  0 , 0),
-                      logic_scint,
-                      name_scintillator.str().c_str(),
-                      single_tower_logic,
-                      0, 0, OverlapCheck());
-    new G4PVPlacement(0, G4ThreeVector( _tower_dx / 2, _tower_dx / 2 , 0),
-                      logic_scint,
-                      name_scintillator.str().c_str(),
-                      single_tower_logic,
-                      0, 0, OverlapCheck());
+  // place cherenkov fibers (top right, bottom left)
+  new G4PVPlacement(0, G4ThreeVector( copperTubeDiam, 0 , 0),
+                    logic_cherenk,
+                    name_cherenkov.str().c_str(),
+                    single_tower_logic,
+                    0, 0, OverlapCheck());
+  new G4PVPlacement(0, G4ThreeVector( 0, copperTubeDiam , 0),
+                    logic_cherenk,
+                    name_cherenkov.str().c_str(),
+                    single_tower_logic,
+                    0, 0, OverlapCheck());
 
-    // place cherenkov fibers (top right, bottom left)
-    new G4PVPlacement(0, G4ThreeVector( _tower_dx / 2, 0 , 0),
-                      logic_cherenk,
-                      name_cherenkov.str().c_str(),
-                      single_tower_logic,
-                      0, 0, OverlapCheck());
-    new G4PVPlacement(0, G4ThreeVector( 0, _tower_dx / 2 , 0),
-                      logic_cherenk,
-                      name_cherenkov.str().c_str(),
-                      single_tower_logic,
-                      0, 0, OverlapCheck());
+
+  int rowNtow = (int) ( (_tower_dx) / (2 * copperTubeDiam + addtowsize));
+  for(int row=(rowNtow / 2);row>=-rowNtow / 2;row--){
+      // create mother volume with space for currRowNtow towers along x-axis
+      auto DRCalRowSolid    = new G4Box("DRCalRowBox", _tower_dx / 2.0, (2 * copperTubeDiam + addtowsize) / 2.0, _tower_dz / 2.0);
+      auto DRCalRowLogical  = new G4LogicalVolume(DRCalRowSolid,material_air,"DRCalRowLogical");
+      // replicate singletower tower design currRowNtow times along x-axis
+      new G4PVReplica("DRCalRowPhysical",single_tower_logic,DRCalRowLogical,
+                      kXAxis, rowNtow, 2 * copperTubeDiam + addtowsize);
+
+      m_DisplayAction->AddVolume(DRCalRowLogical, "FdrcaloEnvelope");
+      ostringstream name_row_twr;
+      name_row_twr.str("");
+      name_row_twr << _towerlogicnameprefix << "_row_" << row << endl;
+      new G4PVPlacement(0, G4ThreeVector(0, (row * (2 * copperTubeDiam + addtowsize)), 0),
+                    DRCalRowLogical, name_row_twr.str().c_str(), base_tower_logic, 0, false, OverlapCheck());
+  }
+
+  // new G4PVPlacement(0, G4ThreeVector( 0, 0 , 0),
+  //                   single_tower_logic,
+  //                   name_cherenkov.str().c_str(),
+  //                   base_tower_logic,
+  //                   0, 0, OverlapCheck());
 
   if (Verbosity() > 0)
   {
     cout << "PHG4ForwardDualReadoutDetector: Building logical volume for single tower done." << endl;
   }
 
-  return single_tower_logic;
+  return base_tower_logic;
 }
 
 //_______________________________________________________________________
@@ -929,14 +997,19 @@ int PHG4ForwardDualReadoutDetector::ParseParametersFromTable()
     _tower_type = parit->second;
   }
 
-  cout << __LINE__ << endl;
+  parit = m_GlobalParameterMap.find("Gtower_readout");
+  if (parit != m_GlobalParameterMap.end())
+  {
+    _tower_readout = parit->second * cm;
+    m_SteppingAction->SetTowerReadout(_tower_readout);
+  }
+
   parit = m_GlobalParameterMap.find("Gtower_dx");
   if (parit != m_GlobalParameterMap.end())
   {
     _tower_dx = parit->second * cm;
     m_SteppingAction->SetTowerSize(_tower_dx);
   }
-  cout << __LINE__ << endl;
 
   parit = m_GlobalParameterMap.find("Gtower_dy");
   if (parit != m_GlobalParameterMap.end())

--- a/simulation/g4simulation/g4drcalo/PHG4ForwardDualReadoutDetector.h
+++ b/simulation/g4simulation/g4drcalo/PHG4ForwardDualReadoutDetector.h
@@ -129,6 +129,7 @@ class PHG4ForwardDualReadoutDetector : public PHG4Detector
 
   /* DRCALO tower geometry */
   int _tower_type;
+  G4double _tower_readout;
   G4double _tower_dx;
   G4double _tower_dy;
   G4double _tower_dz;

--- a/simulation/g4simulation/g4drcalo/PHG4ForwardDualReadoutSteppingAction.cc
+++ b/simulation/g4simulation/g4drcalo/PHG4ForwardDualReadoutSteppingAction.cc
@@ -64,7 +64,9 @@ PHG4ForwardDualReadoutSteppingAction::PHG4ForwardDualReadoutSteppingAction(PHG4F
   , hitcontainer(nullptr)
   , hit(nullptr)
   , saveshower(nullptr)
+  , _towerdivision(0.0)
   , _tower_size(1.0)
+  , _readout_size(1.0)
   , _detector_size(100)
   , absorbertruth(absorberactive)
   , light_scint_model(1)
@@ -466,8 +468,13 @@ int PHG4ForwardDualReadoutSteppingAction::FindTowerIndexFromPosition(G4StepPoint
 
   // G4VPhysicalVolume* tower = touch->GetVolume(1);  //Get the tower solid
   // ParseG4VolumeName(tower, j_0, k_0);
-  j_0 = (int) ( ( _detector_size + ( prePoint->GetPosition().x() ) ) / _tower_size ); //TODO DRCALO TOWER SIZE
-  k_0 = (int) ( ( _detector_size + ( prePoint->GetPosition().y() ) ) / _tower_size ); //TODO DRCALO TOWER SIZE
+  if(_towerdivision==0.){
+    int maxsubtow = (int) ( (_tower_size) / (_readout_size));
+    _towerdivision = (_tower_size - (maxsubtow * _readout_size))/maxsubtow;
+    _towerdivision+=_readout_size;
+  }
+  j_0 = (int) ( ( _detector_size + ( prePoint->GetPosition().x() ) ) / _towerdivision ); //TODO DRCALO TOWER SIZE
+  k_0 = (int) ( ( _detector_size + ( prePoint->GetPosition().y() ) ) / _towerdivision ); //TODO DRCALO TOWER SIZE
   // if(prePoint->GetPosition().x()>290) cout << prePoint->GetPosition().x() << "\t" << k_0 << endl;
   j = (j_0 * 1);
   k = (k_0 * 1);

--- a/simulation/g4simulation/g4drcalo/PHG4ForwardDualReadoutSteppingAction.h
+++ b/simulation/g4simulation/g4drcalo/PHG4ForwardDualReadoutSteppingAction.h
@@ -34,6 +34,10 @@ class PHG4ForwardDualReadoutSteppingAction : public PHG4SteppingAction
     {
       _tower_size = twrsze;
     }
+  void SetTowerReadout(G4double rdosze)
+    {
+      _readout_size = rdosze;
+    }
   void SetDetectorSize(G4double detsze)
     {
       _detector_size = detsze;
@@ -54,7 +58,9 @@ class PHG4ForwardDualReadoutSteppingAction : public PHG4SteppingAction
   PHG4Hit* hit;
   PHG4Shower* saveshower;
 
+  G4double _towerdivision;
   G4double _tower_size;
+  G4double _readout_size;
   G4double _detector_size;
   int absorbertruth;
   int light_scint_model;

--- a/simulation/g4simulation/g4drcalo/RawTowerBuilderDRCALO.cc
+++ b/simulation/g4simulation/g4drcalo/RawTowerBuilderDRCALO.cc
@@ -326,15 +326,28 @@ bool RawTowerBuilderDRCALO::ReadGeometryFromTable()
     size_z = parit->second * cm;
 
   pos_z = m_GlobalPlaceInZ;
+  G4double twredge = 1.0;//1.2
+  G4double twrreadout = 1.0;//1.2
   G4double twrsize = 1.0;//1.2
   G4double drsize = 220;
   parit = m_GlobalParameterMap.find("Gtower_dx");
   if (parit != m_GlobalParameterMap.end()){
     twrsize = parit->second * cm;
   }
+
+  parit = m_GlobalParameterMap.find("Gtower_readout");
+  if (parit != m_GlobalParameterMap.end())
+  {
+    twrreadout = parit->second * cm;
+  }
   parit = m_GlobalParameterMap.find("Gr1_outer");
   if (parit != m_GlobalParameterMap.end()){
     drsize = parit->second * cm;
+  }
+  int maxsubtow = (int) ( (twrsize) / (twrreadout));
+  twredge = (twrsize - (maxsubtow * twrreadout))/maxsubtow;
+  if(twrsize!=twrreadout){
+    twrsize = twrreadout + twredge;
   }
 
   float scaling = 1.;


### PR DESCRIPTION
This PR adds a new tower geometry for the DRCALO and transitions the DRCALO geometry to have base towers of 5.5x5.5 cm instead of the previously used 2x2 fiber elements. This is made to account for the actual construction of the detector.