### PR TITLE
Introduce Fast PID in reconstruction

### DIFF
--- a/analysis/eicevaluator/EventEvaluatorEIC.cc
+++ b/analysis/eicevaluator/EventEvaluatorEIC.cc
@@ -475,9 +475,9 @@ EventEvaluatorEIC::EventEvaluatorEIC(const string& name, const string& filename)
   _track_TLP_true_y = new float[_maxNProjections];
   _track_TLP_true_z = new float[_maxNProjections];
   _track_TLP_true_t = new float[_maxNProjections];
-  _track_pion_LL.resize(_maxNTracks);
-  _track_kaon_LL.resize(_maxNTracks);
-  _track_proton_LL.resize(_maxNTracks);
+  _track_pion_LL.resize(_maxNTracks, -100);
+  _track_kaon_LL.resize(_maxNTracks, -100);
+  _track_proton_LL.resize(_maxNTracks, -100);
 
   _mcpart_ID = new int[_maxNMCPart];
   _mcpart_ID_parent = new int[_maxNMCPart];

--- a/analysis/eicevaluator/EventEvaluatorEIC.cc
+++ b/analysis/eicevaluator/EventEvaluatorEIC.cc
@@ -30,6 +30,9 @@
 #include <calobase/RawTowerGeomContainer.h>
 #include <calobase/RawTowerv2.h>
 
+#include <eicpidbase/EICPIDParticle.h>
+#include <eicpidbase/EICPIDParticleContainer.h>
+
 #include <HepMC/GenEvent.h>
 #include <HepMC/GenVertex.h>
 #include <phhepmc/PHHepMCGenEvent.h>
@@ -472,6 +475,9 @@ EventEvaluatorEIC::EventEvaluatorEIC(const string& name, const string& filename)
   _track_TLP_true_y = new float[_maxNProjections];
   _track_TLP_true_z = new float[_maxNProjections];
   _track_TLP_true_t = new float[_maxNProjections];
+  _track_pion_LL.resize(_maxNTracks);
+  _track_kaon_LL.resize(_maxNTracks);
+  _track_proton_LL.resize(_maxNTracks);
 
   _mcpart_ID = new int[_maxNMCPart];
   _mcpart_ID_parent = new int[_maxNMCPart];
@@ -549,6 +555,14 @@ int EventEvaluatorEIC::Init(PHCompositeNode* topNode)
     _event_tree->Branch("tracks_dca_2d", _track_dca_2d, "tracks_dca_2d[nTracks]/F");
     _event_tree->Branch("tracks_trueID", _track_trueID, "tracks_trueID[nTracks]/F");
     _event_tree->Branch("tracks_source", _track_source, "tracks_source[nTracks]/s");
+
+    if (_do_PID_LogLikelihood)
+    {
+        // save hadron PID log likelihood
+      _event_tree->Branch("track_pion_LL", _track_pion_LL.data(), "track_pion_LL[nTracks]/F");
+      _event_tree->Branch("track_kaon_LL", _track_kaon_LL.data(), "track_kaon_LL[nTracks]/F");
+      _event_tree->Branch("track_proton_LL", _track_proton_LL.data(), "track_proton_LL[nTracks]/F");
+    }
   }
   if (_do_PROJECTIONS)
   {
@@ -2926,6 +2940,19 @@ void EventEvaluatorEIC::fillOutputNtuples(PHCompositeNode* topNode)
   {
     _nTracks = 0;
     _nProjections = 0;
+
+    EICPIDParticleContainer * pidcontainer (nullptr);
+
+    if (_do_PID_LogLikelihood )
+    {
+      pidcontainer = findNode::getClass<EICPIDParticleContainer>(topNode, "EICPIDParticleMap");
+      if (pidcontainer==nullptr)
+      {
+        cout << __PRETTY_FUNCTION__ << " Error: missing EICPIDParticleMap while _do_PID_LogLikelihood = "
+            << _do_PID_LogLikelihood << endl;
+      }
+    }
+
     // Loop over track maps, identifiy each source.
     // Although this configuration is fixed here, it doesn't require multiple sources.
     // It will only store them if they're available.
@@ -2937,6 +2964,8 @@ void EventEvaluatorEIC::fillOutputNtuples(PHCompositeNode* topNode)
     bool foundAtLeastOneTrackSource = false;
     for (const auto& trackMapInfo : trackMapPairs)
     {
+      if (_nTracks>=_maxNTracks) break;
+
       SvtxTrackMap* trackmap = findNode::getClass<SvtxTrackMap>(topNode, trackMapInfo.first);
       if (trackmap)
       {
@@ -2948,6 +2977,8 @@ void EventEvaluatorEIC::fillOutputNtuples(PHCompositeNode* topNode)
         }
         for (SvtxTrackMap::ConstIter track_itr = trackmap->begin(); track_itr != trackmap->end(); track_itr++)
         {
+          if (_nTracks>=_maxNTracks) break;
+
           SvtxTrack_FastSim* track = dynamic_cast<SvtxTrack_FastSim*>(track_itr->second);
           if (track)
           {
@@ -3029,7 +3060,36 @@ void EventEvaluatorEIC::fillOutputNtuples(PHCompositeNode* topNode)
                   _nProjections++;
                 }
               }
-            }
+            } //             if (_do_PROJECTIONS)
+
+            if (_do_PID_LogLikelihood )
+            {
+              // perform PID matching
+              if (trackMapInfo.second == TrackSource_t::all and pidcontainer != nullptr)
+              {
+                // only do so for the TrackSource_t::all
+                const EICPIDParticle* pid_particle =
+                pidcontainer->findEICPIDParticle(track->get_id());
+
+                if (pid_particle)
+                {
+                  if((unsigned int)_nTracks>= _track_pion_LL.size())
+                  {
+                    cout << __PRETTY_FUNCTION__
+                        << " logical error _nTracks = " << _nTracks
+                        << " logical error _track_pion_LL.size() = " << _track_pion_LL.size()
+                        << endl;
+                    exit(1);
+                  }
+
+                  _track_pion_LL[_nTracks] = pid_particle->get_SumLogLikelyhood(EICPIDDefs::PionCandiate);
+                  _track_kaon_LL[_nTracks] =  pid_particle->get_SumLogLikelyhood(EICPIDDefs::KaonCandiate);
+                  _track_proton_LL[_nTracks] =  pid_particle->get_SumLogLikelyhood(EICPIDDefs::ProtonCandiate);
+                }
+
+              }
+            } // if (_do_PID_LogLikelihood )
+
             _nTracks++;
             nTracksInASource++;
           }
@@ -3819,6 +3879,11 @@ void EventEvaluatorEIC::resetBuffer()
       _track_dca[itrk] = 0;
       _track_dca_2d[itrk] = 0;
       _track_source[itrk] = 0;
+
+      // Default to not performing PID matching. Set default LL to same value for all PIDs
+      _track_pion_LL[itrk] = -100;
+      _track_kaon_LL[itrk] = -100;
+      _track_proton_LL[itrk] = -100;
     }
     if (_do_PROJECTIONS)
     {

--- a/analysis/eicevaluator/EventEvaluatorEIC.h
+++ b/analysis/eicevaluator/EventEvaluatorEIC.h
@@ -11,6 +11,7 @@
 
 #include <set>
 #include <string>
+#include <vector>
 
 class CaloEvalStack;
 class PHCompositeNode;
@@ -63,6 +64,7 @@ class EventEvaluatorEIC : public SubsysReco
   void set_do_LFHCAL(bool b) { _do_LFHCAL = b; }
   void set_do_HITS(bool b) { _do_HITS = b; }
   void set_do_TRACKS(bool b) { _do_TRACKS = b; }
+  void set_do_PID_LogLikelihood(bool b) { _do_PID_LogLikelihood = b; }
   void set_do_CLUSTERS(bool b) { _do_CLUSTERS = b; }
   void set_do_VERTEX(bool b) { _do_VERTEX = b; }
   void set_do_PROJECTIONS(bool b) { _do_PROJECTIONS = b; }
@@ -108,6 +110,7 @@ class EventEvaluatorEIC : public SubsysReco
   bool _do_CLUSTERS;
   bool _do_VERTEX;
   bool _do_PROJECTIONS;
+  bool _do_PID_LogLikelihood = false;
   bool _do_MCPARTICLES;
   bool _do_HEPMC;
   bool _do_GEOMETRY;
@@ -291,6 +294,11 @@ class EventEvaluatorEIC : public SubsysReco
   float* _track_trueID;
   unsigned short* _track_source;
 
+  // log likelihood summary for PID detectors, per track information
+  std::vector<float> _track_pion_LL;
+  std::vector<float> _track_kaon_LL;
+  std::vector<float> _track_proton_LL;
+
   int _nProjections;
   float* _track_ProjTrackID;
   int* _track_ProjLayer;
@@ -392,7 +400,7 @@ class EventEvaluatorEIC : public SubsysReco
   const int _maxNProjections = 2000;
   const int _maxNMCPart = 100000;
   const int _maxNHepmcp = 1000;
-  const int _maxNCalo = 11;
+  const int _maxNCalo = 15;
   
   enum calotype {
       kFHCAL         = 0,

--- a/analysis/eicevaluator/Makefile.am
+++ b/analysis/eicevaluator/Makefile.am
@@ -29,7 +29,8 @@ libeiceval_la_LIBADD = \
   -lmvtx_io \
   -lphhepmc_io \
   -lphg4hit \
-  -lg4eval
+  -lg4eval \
+  -leicpidbase
 
 pkginclude_HEADERS = \
   EventEvaluatorEIC.h \

--- a/reconstruction/eicpidbase/EICPIDDefs.cc
+++ b/reconstruction/eicpidbase/EICPIDDefs.cc
@@ -1,15 +1,18 @@
 #include "EICPIDDefs.h"
 
-#include <tr1/functional>
+#include <boost/algorithm/string.hpp>
+#include <string>
 
 namespace EICPIDDefs
 {
-
-  int get_volume_id(const std::string & nodename)
+PIDDetector getPIDDetector(const std::string& name)
+{
+  for (auto pair : PIDDetectorNameMap)
   {
-    return std::tr1::hash<std::string>()(nodename);
+    if (boost::iequals(pair.first, name))
+      return pair.second;
   }
-
+  return InvalidDetector;
 }
 
-
+}  // namespace EICPIDDefs

--- a/reconstruction/eicpidbase/EICPIDDefs.cc
+++ b/reconstruction/eicpidbase/EICPIDDefs.cc
@@ -1,0 +1,15 @@
+#include "EICPIDDefs.h"
+
+#include <tr1/functional>
+
+namespace EICPIDDefs
+{
+
+  int get_volume_id(const std::string & nodename)
+  {
+    return std::tr1::hash<std::string>()(nodename);
+  }
+
+}
+
+

--- a/reconstruction/eicpidbase/EICPIDDefs.cc
+++ b/reconstruction/eicpidbase/EICPIDDefs.cc
@@ -1,6 +1,7 @@
 #include "EICPIDDefs.h"
 
 #include <boost/algorithm/string.hpp>
+#include <iostream>
 #include <string>
 
 namespace EICPIDDefs
@@ -13,6 +14,30 @@ PIDDetector getPIDDetector(const std::string& name)
       return pair.second;
   }
   return InvalidDetector;
+}
+
+const std::string& getPIDDetectorName(const PIDDetector det)
+{
+  static std::map<PIDDetector, std::string> reverse_map;
+
+  if (reverse_map.size() == 0)
+  {
+    // build reverse map
+
+    for (const auto& pair : PIDDetectorNameMap)
+    {
+      reverse_map[pair.second] = pair.first;
+    }
+  }
+
+  if (reverse_map.find(det) == reverse_map.end())
+  {
+    std::cout << __PRETTY_FUNCTION__
+              << " WARNING:  asking for det = " << det
+              << ", which is not defined in EICPIDDefs::PIDDetectorNameMap" << std::endl;
+  }
+
+  return reverse_map[det];
 }
 
 }  // namespace EICPIDDefs

--- a/reconstruction/eicpidbase/EICPIDDefs.h
+++ b/reconstruction/eicpidbase/EICPIDDefs.h
@@ -18,11 +18,14 @@ enum PIDDetector
   PIDAll = 0,
   mRICH = 1,
   DIRC = 2,
-  dRICH = 3,
-  GasRICH = 4,
+  dRICH_AeroGel = 3,
+  dRICH_Gas = 4,
+  GasRICH = 5,
+
   ETTL = 11,
   CTTL = 12,
   FTTL = 13,
+
   InvalidDetector = -1
 };
 
@@ -30,7 +33,8 @@ const std::map<std::string, PIDDetector> PIDDetectorNameMap = {
     {"PIDAll", PIDAll},
     {"mRICH", mRICH},
     {"DIRC", DIRC},
-    {"dRICH", dRICH},
+    {"dRICH_AeroGel", dRICH_AeroGel},
+    {"dRICH_Gas", dRICH_Gas},
     {"GasRICH", GasRICH},
     {"ETTL", ETTL},
     {"CTTL", CTTL},

--- a/reconstruction/eicpidbase/EICPIDDefs.h
+++ b/reconstruction/eicpidbase/EICPIDDefs.h
@@ -1,22 +1,56 @@
 // Tell emacs that this is a C++ source
 //  -*- C++ -*-.
-#ifndef G4MAIN_EICPIDDefs_H
-#define G4MAIN_EICPIDDefs_H
+#ifndef EICPID_EICPIDDefs_H
+#define EICPID_EICPIDDefs_H
 
+#include <map>
 #include <string>
+#include <climits>
 
 namespace EICPIDDefs
 {
-  typedef unsigned long long keytype;
-  static const unsigned int keybits = 32;
-  static const unsigned int hit_idbits = sizeof(keytype)*8-keybits;
+// sync PID particle keys to the key of tracks
+typedef unsigned int keytype;
+static const keytype INVALID_KEY = UINT_MAX;
 
-  //! convert EICPIDParticleContainer node names in to ID number for the container.
-  //! used in indexing volume ID in PHG4Shower
-  int get_volume_id(const std::string & nodename);
+enum PIDDetector
+{
+  PIDAll = 0,
+  mRICH = 1,
+  DIRC = 2,
+  dRICH = 3,
+  GasRICH = 4,
+  ETTL = 11,
+  CTTL = 12,
+  FTTL = 13,
+  InvalidDetector = -1
+};
 
-}
+const std::map<std::string, PIDDetector> PIDDetectorNameMap = {
+    {"PIDAll", PIDAll},
+    {"mRICH", mRICH},
+    {"DIRC", DIRC},
+    {"dRICH", dRICH},
+    {"GasRICH", GasRICH},
+    {"ETTL", ETTL},
+    {"CTTL", CTTL},
+    {"FTTL", FTTL}};
+
+// consistent with PDG encoding
+enum PIDCandidate
+{
+  ElectronCandiate = 11,
+  MuonCandiate = 13,
+  PionCandiate = 211,
+  KaonCandiate = 321,
+  ProtonCandiate = 2212,
+  InvalidCandiate = 0
+};
+
+//! convert EICPIDParticleContainer node names in to ID number for the container.
+//! used in indexing volume ID in PHG4Shower
+PIDDetector getPIDDetector(const std::string& name);
+
+}  // namespace EICPIDDefs
 
 #endif
-
-

--- a/reconstruction/eicpidbase/EICPIDDefs.h
+++ b/reconstruction/eicpidbase/EICPIDDefs.h
@@ -1,0 +1,22 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4MAIN_EICPIDDefs_H
+#define G4MAIN_EICPIDDefs_H
+
+#include <string>
+
+namespace EICPIDDefs
+{
+  typedef unsigned long long keytype;
+  static const unsigned int keybits = 32;
+  static const unsigned int hit_idbits = sizeof(keytype)*8-keybits;
+
+  //! convert EICPIDParticleContainer node names in to ID number for the container.
+  //! used in indexing volume ID in PHG4Shower
+  int get_volume_id(const std::string & nodename);
+
+}
+
+#endif
+
+

--- a/reconstruction/eicpidbase/EICPIDDefs.h
+++ b/reconstruction/eicpidbase/EICPIDDefs.h
@@ -3,9 +3,9 @@
 #ifndef EICPID_EICPIDDefs_H
 #define EICPID_EICPIDDefs_H
 
+#include <climits>
 #include <map>
 #include <string>
-#include <climits>
 
 namespace EICPIDDefs
 {
@@ -47,9 +47,10 @@ enum PIDCandidate
   InvalidCandiate = 0
 };
 
-//! convert EICPIDParticleContainer node names in to ID number for the container.
-//! used in indexing volume ID in PHG4Shower
+//! convert PID detector node names in to ID number for the container.
 PIDDetector getPIDDetector(const std::string& name);
+
+const std::string& getPIDDetectorName(const PIDDetector det);
 
 }  // namespace EICPIDDefs
 

--- a/reconstruction/eicpidbase/EICPIDParticle.cc
+++ b/reconstruction/eicpidbase/EICPIDParticle.cc
@@ -1,6 +1,6 @@
 #include "EICPIDParticle.h"
 
-#include <TSystem.h> // for gSystem
+#include <TSystem.h>  // for gSystem
 
 #include <cassert>
 #include <cstdlib>
@@ -8,186 +8,83 @@
 
 using namespace std;
 
-void
-EICPIDParticle::CopyFrom(const PHObject *phobj)
+const std::map<EICPIDParticle::PROPERTY,
+               std::pair<const std::string, EICPIDParticle::PROPERTY_TYPE> >
+    EICPIDParticle::m_propertyInfo = {
+        {CTTL_beta, {"Beta on CTTL", type_float}},
+        {ETTL_beta, {"Beta on ETTL", type_float}},
+        {FTTL_beta, {"Beta on FTTL", type_float}}  //
+};
+
+void EICPIDParticle::CopyFrom(const PHObject* phobj)
 {
-  const EICPIDParticle *g4hit = dynamic_cast<const EICPIDParticle *> (phobj);
-  assert(g4hit);
-  for (int i =0; i<2; i++)
-    {
-      set_x(i,g4hit->get_x(i));
-      set_y(i,g4hit->get_y(i));
-      set_z(i,g4hit->get_z(i));
-      set_t(i,g4hit->get_t(i));
-    }
-  set_edep(g4hit->get_edep());
-  set_hit_id(g4hit->get_hit_id());
-  set_shower_id(g4hit->get_shower_id());
-  set_trkid(g4hit->get_trkid());
-// This is a generic copy of ALL properties a hit has
-// do not add explicit copies, they will be added to
-// the new hits with their default value increasing memory use
+  const EICPIDParticle* src = dynamic_cast<const EICPIDParticle*>(phobj);
+  assert(src);
+  set_id(src->get_id());
+  // This is a generic copy of ALL properties a hit has
+  // do not add explicit copies, they will be added to
+  // the new hits with their default value increasing memory use
   for (unsigned char ic = 0; ic < UCHAR_MAX; ic++)
+  {
+    PROPERTY prop_id = static_cast<EICPIDParticle::PROPERTY>(ic);
+    if (src->has_property(prop_id))
     {
-      PROPERTY prop_id = static_cast<EICPIDParticle::PROPERTY> (ic);
-      if (g4hit->has_property(prop_id))
-        {
-	  set_property_nocheck(prop_id,g4hit->get_property_nocheck(prop_id));
-	}
+      set_property_nocheck(prop_id, src->get_property_nocheck(prop_id));
     }
+  }
 }
 
-
-void
-EICPIDParticle::identify(ostream& os) const
+void EICPIDParticle::identify(ostream& os) const
 {
   os << "Class " << this->ClassName() << endl;
-  os << "x0: " << get_x(0)
-       << ", y0: " << get_y(0)
-       << ", z0: " << get_z(0)
-       << ", t0: " << get_t(0) << endl;
-  os << "x1: " << get_x(1)
-       << ", y1: " << get_y(1)
-       << ", z1: " << get_z(1)
-       << ", t1: " << get_t(1) << endl;
-  os     << "trackid: " << get_trkid() << ", edep: " << get_edep() << endl;
-  os     << "strip_z_index: " << get_strip_z_index() << ", strip_y_index: " << get_strip_y_index() << endl;
-  os     << "ladder_z_index: " << get_ladder_z_index() << ", ladder_phi_index: " << get_ladder_phi_index() << endl;
-  os     << "stave_index: " << get_property_int(prop_stave_index) << " half_stave_index " << get_property_int(prop_half_stave_index) << endl;
-  os     << "module_index: " << get_property_int(prop_module_index) << " chip_index " << get_property_int(prop_chip_index) << endl;
-  os << "layer id: " << get_layer() << ", scint_id: " << get_scint_id() << endl;
-  os << "hit type: " << get_hit_type() << endl; 
   return;
 }
 
-ostream& operator<<(ostream& stream, const EICPIDParticle * hit){
-  stream <<endl<< "(x,y,z) = "<< "("<<hit->get_avg_x()<<", "<<hit->get_avg_y()<<", "<<hit->get_avg_z()<<")"<<endl;
-	stream << "trackid: " << hit->get_trkid()<<" hitid: "<<hit->get_hit_id()<<" layer: "<<hit->get_layer()<<endl;
-  return stream;
-}
-
-void
-EICPIDParticle::Reset()
+void EICPIDParticle::Reset()
 {
   cout << "Reset not implemented by daughter class" << endl;
   return;
 }
 
-std::pair<const std::string,EICPIDParticle::PROPERTY_TYPE>
+std::pair<const std::string, EICPIDParticle::PROPERTY_TYPE>
 EICPIDParticle::get_property_info(const PROPERTY prop_id)
 {
-  switch (prop_id)
-  {
-  case  prop_eion:
-    return make_pair("ionizing energy loss",EICPIDParticle::type_float);
-  case   prop_light_yield:
-    return make_pair("light yield",EICPIDParticle::type_float);
-  case   scint_gammas:
-    return make_pair("scintillation photons",EICPIDParticle::type_float);
-  case   cerenkov_gammas:
-    return make_pair("cerenkov photons",EICPIDParticle::type_float);
-  case   prop_px_0:
-    return make_pair("px in",EICPIDParticle::type_float);
-  case   prop_px_1:
-    return make_pair("px out",EICPIDParticle::type_float);
-  case   prop_py_0:
-    return make_pair("py in",EICPIDParticle::type_float);
-  case   prop_py_1:
-    return make_pair("py out",EICPIDParticle::type_float);
-  case   prop_pz_0:
-    return make_pair("pz in",EICPIDParticle::type_float);
-  case   prop_pz_1:
-    return make_pair("pz out",EICPIDParticle::type_float);
-  case   prop_local_x_0:
-    return make_pair("local x in",EICPIDParticle::type_float);
-  case   prop_local_x_1:
-    return make_pair("local x out",EICPIDParticle::type_float);
-  case   prop_local_y_0:
-    return make_pair("local y in",EICPIDParticle::type_float);
-  case   prop_local_y_1:
-    return make_pair("local y out",EICPIDParticle::type_float);
-  case   prop_local_z_0:
-    return make_pair("local z in",EICPIDParticle::type_float);
-  case   prop_local_z_1:
-    return make_pair("local z out",EICPIDParticle::type_float);
-  case   prop_path_length:
-    return make_pair("pathlength",EICPIDParticle::type_float);
-  case   prop_layer:
-    return make_pair("layer ID",EICPIDParticle::type_uint);
-  case   prop_scint_id:
-    return make_pair("scintillator ID",EICPIDParticle::type_int);
-  case   prop_row:
-    return make_pair("row",EICPIDParticle::type_int);
-  case   prop_strip_z_index:
-    return make_pair("strip z index",EICPIDParticle::type_int);
-  case   prop_strip_y_index:
-    return make_pair("strip y index",EICPIDParticle::type_int);
-  case   prop_ladder_z_index:
-    return make_pair("ladder z index",EICPIDParticle::type_int);
-  case   prop_ladder_phi_index:
-    return make_pair("ladder phi index",EICPIDParticle::type_int);
-  case   prop_index_i:
-    return make_pair("generic index i",EICPIDParticle::type_int);
-  case   prop_index_j:
-    return make_pair("generic index j",EICPIDParticle::type_int);
-  case   prop_index_k:
-    return make_pair("generic index k",EICPIDParticle::type_int);
-  case   prop_index_l:
-    return make_pair("generic index l",EICPIDParticle::type_int);
-  case  prop_stave_index:
-    return make_pair("stave index",EICPIDParticle::type_int);
-  case  prop_half_stave_index:
-    return make_pair("half stave index",EICPIDParticle::type_int);
-  case  prop_module_index:
-    return make_pair("module index",EICPIDParticle::type_int);
-  case  prop_chip_index:
-    return make_pair("chip index",EICPIDParticle::type_int);
-  case  prop_local_pos_x_0:
-    return make_pair("local x pos in",EICPIDParticle::type_float);
-  case  prop_local_pos_y_0:
-    return make_pair("local y pos in",EICPIDParticle::type_float);
-  case  prop_local_pos_z_0:
-    return make_pair("local z pos in",EICPIDParticle::type_float);
-  case   prop_hit_type:
-    return make_pair("hit type",EICPIDParticle::type_int);
-  case  prop_local_pos_x_1:
-    return make_pair("local x pos out",EICPIDParticle::type_float);
-  case  prop_local_pos_y_1:
-    return make_pair("local y pos out",EICPIDParticle::type_float);
-  case  prop_local_pos_z_1:
-    return make_pair("local z pos out",EICPIDParticle::type_float);
+  const auto iter = m_propertyInfo.find(prop_id);
 
-  default:
+  if (iter == m_propertyInfo.end())
+  {
     cout << "EICPIDParticle::get_property_info - Fatal Error - unknown index " << prop_id << endl;
     gSystem->Exit(1);
     exit(1);
   }
+  else
+  {
+    return iter->second;
+  }
 }
 
-
-bool
-EICPIDParticle::check_property(const PROPERTY prop_id, const PROPERTY_TYPE prop_type)
+bool EICPIDParticle::check_property(const PROPERTY prop_id, const PROPERTY_TYPE prop_type)
 {
-  pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id);
+  pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
   if (property_info.second != prop_type)
-    {
-      return false;
-    }
+  {
+    return false;
+  }
   return true;
 }
 
 string
 EICPIDParticle::get_property_type(const PROPERTY_TYPE prop_type)
 {
-  switch(prop_type)
-    {
-    case type_int:
-      return "int";
-    case type_uint:
-      return "unsigned int";
-    case type_float:
-      return "float";
-    default:
-      return "unkown";
-    }
+  switch (prop_type)
+  {
+  case type_int:
+    return "int";
+  case type_uint:
+    return "unsigned int";
+  case type_float:
+    return "float";
+  default:
+    return "unkown";
+  }
 }

--- a/reconstruction/eicpidbase/EICPIDParticle.cc
+++ b/reconstruction/eicpidbase/EICPIDParticle.cc
@@ -11,6 +11,7 @@ using namespace std;
 const std::map<EICPIDParticle::PROPERTY,
                std::pair<const std::string, EICPIDParticle::PROPERTY_TYPE> >
     EICPIDParticle::m_propertyInfo = {
+        {Truth_PID, {"Truth PID", type_int}},
         {CTTL_beta, {"Beta on CTTL", type_float}},
         {ETTL_beta, {"Beta on ETTL", type_float}},
         {FTTL_beta, {"Beta on FTTL", type_float}}  //

--- a/reconstruction/eicpidbase/EICPIDParticle.cc
+++ b/reconstruction/eicpidbase/EICPIDParticle.cc
@@ -12,6 +12,8 @@ const std::map<EICPIDParticle::PROPERTY,
                std::pair<const std::string, EICPIDParticle::PROPERTY_TYPE> >
     EICPIDParticle::m_propertyInfo = {
         {Truth_PID, {"Truth PID", type_int}},
+        {Truth_momentum, {"Truth Momentum", type_float}},
+        {Truth_eta, {"Truth eta", type_float}},
         {CTTL_beta, {"Beta on CTTL", type_float}},
         {ETTL_beta, {"Beta on ETTL", type_float}},
         {FTTL_beta, {"Beta on FTTL", type_float}}  //

--- a/reconstruction/eicpidbase/EICPIDParticle.cc
+++ b/reconstruction/eicpidbase/EICPIDParticle.cc
@@ -1,0 +1,193 @@
+#include "EICPIDParticle.h"
+
+#include <TSystem.h> // for gSystem
+
+#include <cassert>
+#include <cstdlib>
+#include <type_traits>
+
+using namespace std;
+
+void
+EICPIDParticle::CopyFrom(const PHObject *phobj)
+{
+  const EICPIDParticle *g4hit = dynamic_cast<const EICPIDParticle *> (phobj);
+  assert(g4hit);
+  for (int i =0; i<2; i++)
+    {
+      set_x(i,g4hit->get_x(i));
+      set_y(i,g4hit->get_y(i));
+      set_z(i,g4hit->get_z(i));
+      set_t(i,g4hit->get_t(i));
+    }
+  set_edep(g4hit->get_edep());
+  set_hit_id(g4hit->get_hit_id());
+  set_shower_id(g4hit->get_shower_id());
+  set_trkid(g4hit->get_trkid());
+// This is a generic copy of ALL properties a hit has
+// do not add explicit copies, they will be added to
+// the new hits with their default value increasing memory use
+  for (unsigned char ic = 0; ic < UCHAR_MAX; ic++)
+    {
+      PROPERTY prop_id = static_cast<EICPIDParticle::PROPERTY> (ic);
+      if (g4hit->has_property(prop_id))
+        {
+	  set_property_nocheck(prop_id,g4hit->get_property_nocheck(prop_id));
+	}
+    }
+}
+
+
+void
+EICPIDParticle::identify(ostream& os) const
+{
+  os << "Class " << this->ClassName() << endl;
+  os << "x0: " << get_x(0)
+       << ", y0: " << get_y(0)
+       << ", z0: " << get_z(0)
+       << ", t0: " << get_t(0) << endl;
+  os << "x1: " << get_x(1)
+       << ", y1: " << get_y(1)
+       << ", z1: " << get_z(1)
+       << ", t1: " << get_t(1) << endl;
+  os     << "trackid: " << get_trkid() << ", edep: " << get_edep() << endl;
+  os     << "strip_z_index: " << get_strip_z_index() << ", strip_y_index: " << get_strip_y_index() << endl;
+  os     << "ladder_z_index: " << get_ladder_z_index() << ", ladder_phi_index: " << get_ladder_phi_index() << endl;
+  os     << "stave_index: " << get_property_int(prop_stave_index) << " half_stave_index " << get_property_int(prop_half_stave_index) << endl;
+  os     << "module_index: " << get_property_int(prop_module_index) << " chip_index " << get_property_int(prop_chip_index) << endl;
+  os << "layer id: " << get_layer() << ", scint_id: " << get_scint_id() << endl;
+  os << "hit type: " << get_hit_type() << endl; 
+  return;
+}
+
+ostream& operator<<(ostream& stream, const EICPIDParticle * hit){
+  stream <<endl<< "(x,y,z) = "<< "("<<hit->get_avg_x()<<", "<<hit->get_avg_y()<<", "<<hit->get_avg_z()<<")"<<endl;
+	stream << "trackid: " << hit->get_trkid()<<" hitid: "<<hit->get_hit_id()<<" layer: "<<hit->get_layer()<<endl;
+  return stream;
+}
+
+void
+EICPIDParticle::Reset()
+{
+  cout << "Reset not implemented by daughter class" << endl;
+  return;
+}
+
+std::pair<const std::string,EICPIDParticle::PROPERTY_TYPE>
+EICPIDParticle::get_property_info(const PROPERTY prop_id)
+{
+  switch (prop_id)
+  {
+  case  prop_eion:
+    return make_pair("ionizing energy loss",EICPIDParticle::type_float);
+  case   prop_light_yield:
+    return make_pair("light yield",EICPIDParticle::type_float);
+  case   scint_gammas:
+    return make_pair("scintillation photons",EICPIDParticle::type_float);
+  case   cerenkov_gammas:
+    return make_pair("cerenkov photons",EICPIDParticle::type_float);
+  case   prop_px_0:
+    return make_pair("px in",EICPIDParticle::type_float);
+  case   prop_px_1:
+    return make_pair("px out",EICPIDParticle::type_float);
+  case   prop_py_0:
+    return make_pair("py in",EICPIDParticle::type_float);
+  case   prop_py_1:
+    return make_pair("py out",EICPIDParticle::type_float);
+  case   prop_pz_0:
+    return make_pair("pz in",EICPIDParticle::type_float);
+  case   prop_pz_1:
+    return make_pair("pz out",EICPIDParticle::type_float);
+  case   prop_local_x_0:
+    return make_pair("local x in",EICPIDParticle::type_float);
+  case   prop_local_x_1:
+    return make_pair("local x out",EICPIDParticle::type_float);
+  case   prop_local_y_0:
+    return make_pair("local y in",EICPIDParticle::type_float);
+  case   prop_local_y_1:
+    return make_pair("local y out",EICPIDParticle::type_float);
+  case   prop_local_z_0:
+    return make_pair("local z in",EICPIDParticle::type_float);
+  case   prop_local_z_1:
+    return make_pair("local z out",EICPIDParticle::type_float);
+  case   prop_path_length:
+    return make_pair("pathlength",EICPIDParticle::type_float);
+  case   prop_layer:
+    return make_pair("layer ID",EICPIDParticle::type_uint);
+  case   prop_scint_id:
+    return make_pair("scintillator ID",EICPIDParticle::type_int);
+  case   prop_row:
+    return make_pair("row",EICPIDParticle::type_int);
+  case   prop_strip_z_index:
+    return make_pair("strip z index",EICPIDParticle::type_int);
+  case   prop_strip_y_index:
+    return make_pair("strip y index",EICPIDParticle::type_int);
+  case   prop_ladder_z_index:
+    return make_pair("ladder z index",EICPIDParticle::type_int);
+  case   prop_ladder_phi_index:
+    return make_pair("ladder phi index",EICPIDParticle::type_int);
+  case   prop_index_i:
+    return make_pair("generic index i",EICPIDParticle::type_int);
+  case   prop_index_j:
+    return make_pair("generic index j",EICPIDParticle::type_int);
+  case   prop_index_k:
+    return make_pair("generic index k",EICPIDParticle::type_int);
+  case   prop_index_l:
+    return make_pair("generic index l",EICPIDParticle::type_int);
+  case  prop_stave_index:
+    return make_pair("stave index",EICPIDParticle::type_int);
+  case  prop_half_stave_index:
+    return make_pair("half stave index",EICPIDParticle::type_int);
+  case  prop_module_index:
+    return make_pair("module index",EICPIDParticle::type_int);
+  case  prop_chip_index:
+    return make_pair("chip index",EICPIDParticle::type_int);
+  case  prop_local_pos_x_0:
+    return make_pair("local x pos in",EICPIDParticle::type_float);
+  case  prop_local_pos_y_0:
+    return make_pair("local y pos in",EICPIDParticle::type_float);
+  case  prop_local_pos_z_0:
+    return make_pair("local z pos in",EICPIDParticle::type_float);
+  case   prop_hit_type:
+    return make_pair("hit type",EICPIDParticle::type_int);
+  case  prop_local_pos_x_1:
+    return make_pair("local x pos out",EICPIDParticle::type_float);
+  case  prop_local_pos_y_1:
+    return make_pair("local y pos out",EICPIDParticle::type_float);
+  case  prop_local_pos_z_1:
+    return make_pair("local z pos out",EICPIDParticle::type_float);
+
+  default:
+    cout << "EICPIDParticle::get_property_info - Fatal Error - unknown index " << prop_id << endl;
+    gSystem->Exit(1);
+    exit(1);
+  }
+}
+
+
+bool
+EICPIDParticle::check_property(const PROPERTY prop_id, const PROPERTY_TYPE prop_type)
+{
+  pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id);
+  if (property_info.second != prop_type)
+    {
+      return false;
+    }
+  return true;
+}
+
+string
+EICPIDParticle::get_property_type(const PROPERTY_TYPE prop_type)
+{
+  switch(prop_type)
+    {
+    case type_int:
+      return "int";
+    case type_uint:
+      return "unsigned int";
+    case type_float:
+      return "float";
+    default:
+      return "unkown";
+    }
+}

--- a/reconstruction/eicpidbase/EICPIDParticle.h
+++ b/reconstruction/eicpidbase/EICPIDParticle.h
@@ -42,8 +42,11 @@ class EICPIDParticle : public PHObject
   //! 1.add new tag below with unique value,
   //! 2.add a short name to EICPIDParticle::m_propertyInfo
   enum PROPERTY
-  {  //
-    CTTL_beta = 1,
+  {
+    Truth_PID = 0,
+
+    //
+    CTTL_beta = 10,
     ETTL_beta,
     FTTL_beta,
 

--- a/reconstruction/eicpidbase/EICPIDParticle.h
+++ b/reconstruction/eicpidbase/EICPIDParticle.h
@@ -1,4 +1,4 @@
-// Tell emacs that this is a C++ source
+// TeLogLikelyhood emacs that this is a C++ source
 //  -*- C++ -*-.
 #ifndef EICPID_EICPIDParticle_H
 #define EICPID_EICPIDParticle_H
@@ -25,6 +25,10 @@ class EICPIDParticle : public PHObject
 
   virtual EICPIDDefs::keytype get_id() const { return EICPIDDefs::INVALID_KEY; }
   virtual void set_id(const EICPIDDefs::keytype) { return; }
+
+  virtual float get_SumLogLikelyhood(EICPIDDefs::PIDCandidate) const { return 0; }
+  virtual float get_LogLikelyhood(EICPIDDefs::PIDCandidate, EICPIDDefs::PIDDetector) const { return 0; }
+  virtual void set_LogLikelyhood(EICPIDDefs::PIDCandidate, EICPIDDefs::PIDDetector, float) {}
 
   enum PROPERTY_TYPE
   {  //

--- a/reconstruction/eicpidbase/EICPIDParticle.h
+++ b/reconstruction/eicpidbase/EICPIDParticle.h
@@ -44,7 +44,7 @@ class EICPIDParticle : public PHObject
   enum PROPERTY
   {
     Truth_PID = 0,
-    Truth_momentum ,
+    Truth_momentum,
     Truth_eta,
 
     //
@@ -73,7 +73,6 @@ class EICPIDParticle : public PHObject
   static std::string get_property_type(const PROPERTY_TYPE prop_type);
 
  protected:
-
   static constexpr float m_minLogLikelihood = -100;
 
   virtual unsigned int get_property_nocheck(const PROPERTY /*prop_id*/) const { return UINT_MAX; }

--- a/reconstruction/eicpidbase/EICPIDParticle.h
+++ b/reconstruction/eicpidbase/EICPIDParticle.h
@@ -44,6 +44,8 @@ class EICPIDParticle : public PHObject
   enum PROPERTY
   {
     Truth_PID = 0,
+    Truth_momentum ,
+    Truth_eta,
 
     //
     CTTL_beta = 10,

--- a/reconstruction/eicpidbase/EICPIDParticle.h
+++ b/reconstruction/eicpidbase/EICPIDParticle.h
@@ -27,7 +27,7 @@ class EICPIDParticle : public PHObject
   virtual void set_id(const EICPIDDefs::keytype) { return; }
 
   virtual float get_SumLogLikelyhood(EICPIDDefs::PIDCandidate) const { return 0; }
-  virtual float get_LogLikelyhood(EICPIDDefs::PIDCandidate, EICPIDDefs::PIDDetector) const { return 0; }
+  virtual float get_LogLikelyhood(EICPIDDefs::PIDCandidate, EICPIDDefs::PIDDetector) const { return m_minLogLikelihood; }
   virtual void set_LogLikelyhood(EICPIDDefs::PIDCandidate, EICPIDDefs::PIDDetector, float) {}
 
   enum PROPERTY_TYPE
@@ -71,6 +71,9 @@ class EICPIDParticle : public PHObject
   static std::string get_property_type(const PROPERTY_TYPE prop_type);
 
  protected:
+
+  static constexpr float m_minLogLikelihood = -100;
+
   virtual unsigned int get_property_nocheck(const PROPERTY /*prop_id*/) const { return UINT_MAX; }
   virtual void set_property_nocheck(const PROPERTY /*prop_id*/, const unsigned int) { return; }
   ClassDefOverride(EICPIDParticle, 1)

--- a/reconstruction/eicpidbase/EICPIDParticle.h
+++ b/reconstruction/eicpidbase/EICPIDParticle.h
@@ -1,0 +1,206 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef EICPID_EICPIDParticle_H
+#define EICPID_EICPIDParticle_H
+
+#include <phool/PHObject.h>
+
+#include <cmath>
+#include <climits>
+#include <iostream> 
+#include <string>
+#include <utility>
+#include "EICPIDDefs.h"
+
+class EICPIDParticle: public PHObject
+{
+ public:
+  EICPIDParticle() {}
+  ~EICPIDParticle() override {}
+
+  void identify(std::ostream& os = std::cout) const override;
+  void CopyFrom(const PHObject *phobj) override;
+  friend std::ostream &operator<<(std::ostream & stream, const EICPIDParticle * hit);
+  void Reset() override;
+
+  // The indices here represent the entry and exit points of the particle
+  virtual float get_x(const int) const {return NAN;}
+  virtual float get_y(const int) const {return NAN;}
+  virtual float get_z(const int) const {return NAN;}
+  virtual float get_px(const int) const {return NAN;}
+  virtual float get_py(const int) const {return NAN;}
+  virtual float get_pz(const int) const {return NAN;}
+  virtual float get_local_x(const int) const {return NAN;}
+  virtual float get_local_y(const int) const {return NAN;}
+  virtual float get_local_z(const int) const {return NAN;}
+  virtual float get_t(const int) const {return NAN;}
+  virtual float get_edep() const {return NAN;}
+  virtual float get_eion() const {return NAN;}
+  virtual float get_light_yield() const {return NAN;}
+  virtual float get_path_length() const {return NAN;}
+  virtual unsigned int get_layer() const {return UINT_MAX;}
+  virtual EICPIDDefs::keytype get_hit_id() const {return ULONG_LONG_MAX;}
+  virtual int get_detid() const {return INT_MIN;}
+  virtual int get_shower_id() const {return INT_MIN;}
+  virtual int get_scint_id() const {return INT_MIN;}
+  virtual int get_row() const {return INT_MIN;}
+  virtual int get_trkid() const {return INT_MIN;}
+  virtual int get_strip_z_index() const {return INT_MIN;}
+  virtual int get_strip_y_index() const {return INT_MIN;}
+  virtual int get_ladder_z_index() const {return INT_MIN;}
+  virtual int get_ladder_phi_index() const {return INT_MIN;}
+  virtual int get_index_i() const {return INT_MIN;}
+  virtual int get_index_j() const {return INT_MIN;}
+  virtual int get_index_k() const {return INT_MIN;}
+  virtual int get_index_l() const {return INT_MIN;}
+  virtual int get_hit_type() const {return INT_MIN;}
+
+  virtual void set_x(const int, const float) {return;}
+  virtual void set_y(const int, const float) {return;}
+  virtual void set_z(const int, const float) {return;}
+  virtual void set_px(const int, const float) {return;}
+  virtual void set_py(const int, const float) {return;}
+  virtual void set_pz(const int, const float) {return;}
+  virtual void set_local_x(const int, const float) {return;}
+  virtual void set_local_y(const int, const float) {return;}
+  virtual void set_local_z(const int, const float) {return;}
+  virtual void set_t(const int, const float) {return;}
+  virtual void set_edep(const float) {return;}
+  virtual void set_eion(const float) {return;}
+  virtual void set_light_yield(const float){return;}
+  virtual void set_path_length(const float){return;}
+  virtual void set_layer(const unsigned int) {return;}
+  virtual void set_hit_id(const EICPIDDefs::keytype) {return;}
+  virtual void set_shower_id(const int) {return;}
+  virtual void set_scint_id(const int) {return;}
+  virtual void set_row(const int) {return;}
+  virtual void set_trkid(const int) {return;}
+  virtual void set_strip_z_index(const int) {return;}
+  virtual void set_strip_y_index(const int) {return;}
+  virtual void set_ladder_z_index(const int) {return;}
+  virtual void set_ladder_phi_index(const int) {return;}
+  virtual void set_index_i(const int) {return;}
+  virtual void set_index_j(const int) {return;}
+  virtual void set_index_k(const int) {return;}
+  virtual void set_index_l(const int) {return;}
+  virtual void set_hit_type(const int) {return;}
+
+  virtual float get_avg_x() const;
+  virtual float get_avg_y() const;
+  virtual float get_avg_z() const;
+  virtual float get_avg_t() const;
+
+  virtual void print() const {std::cout<<"EICPIDParticle base class - print() not implemented"<<std::endl;}
+
+
+  //! Procedure to add a new PROPERTY tag:
+  //! 1.add new tag below with unique value,
+  //! 2.add a short name to EICPIDParticle::get_property_info
+  enum PROPERTY 
+  {//
+
+    //-- hit properties: 1 - 10  --
+    //! ionizing energy loss
+    prop_eion = 1,
+
+    //! for scintillation detectors, the amount of light produced
+    prop_light_yield = 2,
+    scint_gammas = 3,
+    cerenkov_gammas = 4,
+
+    //-- track properties: 10 - 20  --
+
+    //! momentum
+    prop_px_0 = 10,
+    prop_px_1 = 11,
+    prop_py_0 = 12,
+    prop_py_1 = 13,
+    prop_pz_0 = 14,
+    prop_pz_1 = 15,
+
+    //! pathlength
+    prop_path_length = 16,
+
+    //! local coordinate
+    prop_local_x_0 = 20,
+    prop_local_x_1 = 21,
+    prop_local_y_0 = 22,
+    prop_local_y_1 = 23,
+    prop_local_z_0 = 24,
+    prop_local_z_1 = 25,
+
+    //-- detector specific IDs: 100+ --
+
+    //! layer ID
+    prop_layer = 101,
+    //! scintillator ID
+    prop_scint_id = 102,
+    //! row (mother volume or steel plate id)
+    prop_row = 103,
+
+    //! SVX stuff
+    prop_strip_z_index = 110,
+    prop_strip_y_index = 111,
+    prop_ladder_z_index = 112,
+    prop_ladder_phi_index = 113,
+
+    // MAPS stuff 
+    prop_stave_index = 114,
+    prop_half_stave_index = 115,
+    prop_module_index = 116,
+    prop_chip_index = 117,
+
+    prop_local_pos_x_0 = 118,
+    prop_local_pos_y_0 = 119,
+    prop_local_pos_z_0 = 120,
+
+    //! generic indexes
+    prop_index_i = 121,
+    prop_index_j = 122,
+    prop_index_k = 123,
+    prop_index_l = 124,
+
+    //! hit type
+    prop_hit_type = 125,
+
+    prop_local_pos_x_1 = 128,
+    prop_local_pos_y_1 = 126,
+    prop_local_pos_z_1 = 127,
+
+    //! max limit in order to fit into 8 bit unsigned number
+    prop_MAX_NUMBER = UCHAR_MAX
+  };
+
+  enum PROPERTY_TYPE 
+  {//
+    type_int = 1,
+    type_uint = 2,
+    type_float = 3,
+    type_unknown = -1
+  };
+
+  virtual bool  has_property(const PROPERTY /*prop_id*/) const {return false;}
+  virtual float get_property_float(const PROPERTY /*prop_id*/) const {return NAN;}
+  virtual int   get_property_int(const PROPERTY /*prop_id*/) const {return INT_MIN;}
+  virtual unsigned int   get_property_uint(const PROPERTY /*prop_id*/) const {return UINT_MAX;}
+  virtual void  set_property(const PROPERTY /*prop_id*/, const float /*value*/) {return;}
+  virtual void  set_property(const PROPERTY /*prop_id*/, const int /*value*/) {return;}
+  virtual void  set_property(const PROPERTY /*prop_id*/, const unsigned int /*value*/) {return;}
+  static std::pair<const std::string,PROPERTY_TYPE> get_property_info(PROPERTY prop_id);
+  static bool check_property(const PROPERTY prop_id, const PROPERTY_TYPE prop_type);
+  static std::string get_property_type(const PROPERTY_TYPE prop_type);
+
+ protected:
+  virtual unsigned int get_property_nocheck(const PROPERTY /*prop_id*/) const {return UINT_MAX;}
+  virtual void set_property_nocheck(const PROPERTY /*prop_id*/,const unsigned int) {return;}
+  ClassDefOverride(EICPIDParticle,1)
+};
+
+
+inline float EICPIDParticle::get_avg_x() const { return 0.5*(get_x(0)+get_x(1)); }
+inline float EICPIDParticle::get_avg_y() const { return 0.5*(get_y(0)+get_y(1)); }
+inline float EICPIDParticle::get_avg_z() const { return 0.5*(get_z(0)+get_z(1)); }
+inline float EICPIDParticle::get_avg_t() const { return 0.5*(get_t(0)+get_t(1)); }
+
+
+#endif

--- a/reconstruction/eicpidbase/EICPIDParticle.h
+++ b/reconstruction/eicpidbase/EICPIDParticle.h
@@ -5,202 +5,68 @@
 
 #include <phool/PHObject.h>
 
-#include <cmath>
 #include <climits>
-#include <iostream> 
+#include <cmath>
+#include <iostream>
+#include <map>
 #include <string>
 #include <utility>
 #include "EICPIDDefs.h"
 
-class EICPIDParticle: public PHObject
+class EICPIDParticle : public PHObject
 {
  public:
   EICPIDParticle() {}
   ~EICPIDParticle() override {}
 
-  void identify(std::ostream& os = std::cout) const override;
+  void identify(std::ostream &os = std::cout) const override;
   void CopyFrom(const PHObject *phobj) override;
-  friend std::ostream &operator<<(std::ostream & stream, const EICPIDParticle * hit);
   void Reset() override;
 
-  // The indices here represent the entry and exit points of the particle
-  virtual float get_x(const int) const {return NAN;}
-  virtual float get_y(const int) const {return NAN;}
-  virtual float get_z(const int) const {return NAN;}
-  virtual float get_px(const int) const {return NAN;}
-  virtual float get_py(const int) const {return NAN;}
-  virtual float get_pz(const int) const {return NAN;}
-  virtual float get_local_x(const int) const {return NAN;}
-  virtual float get_local_y(const int) const {return NAN;}
-  virtual float get_local_z(const int) const {return NAN;}
-  virtual float get_t(const int) const {return NAN;}
-  virtual float get_edep() const {return NAN;}
-  virtual float get_eion() const {return NAN;}
-  virtual float get_light_yield() const {return NAN;}
-  virtual float get_path_length() const {return NAN;}
-  virtual unsigned int get_layer() const {return UINT_MAX;}
-  virtual EICPIDDefs::keytype get_hit_id() const {return ULONG_LONG_MAX;}
-  virtual int get_detid() const {return INT_MIN;}
-  virtual int get_shower_id() const {return INT_MIN;}
-  virtual int get_scint_id() const {return INT_MIN;}
-  virtual int get_row() const {return INT_MIN;}
-  virtual int get_trkid() const {return INT_MIN;}
-  virtual int get_strip_z_index() const {return INT_MIN;}
-  virtual int get_strip_y_index() const {return INT_MIN;}
-  virtual int get_ladder_z_index() const {return INT_MIN;}
-  virtual int get_ladder_phi_index() const {return INT_MIN;}
-  virtual int get_index_i() const {return INT_MIN;}
-  virtual int get_index_j() const {return INT_MIN;}
-  virtual int get_index_k() const {return INT_MIN;}
-  virtual int get_index_l() const {return INT_MIN;}
-  virtual int get_hit_type() const {return INT_MIN;}
+  virtual EICPIDDefs::keytype get_id() const { return EICPIDDefs::INVALID_KEY; }
+  virtual void set_id(const EICPIDDefs::keytype) { return; }
 
-  virtual void set_x(const int, const float) {return;}
-  virtual void set_y(const int, const float) {return;}
-  virtual void set_z(const int, const float) {return;}
-  virtual void set_px(const int, const float) {return;}
-  virtual void set_py(const int, const float) {return;}
-  virtual void set_pz(const int, const float) {return;}
-  virtual void set_local_x(const int, const float) {return;}
-  virtual void set_local_y(const int, const float) {return;}
-  virtual void set_local_z(const int, const float) {return;}
-  virtual void set_t(const int, const float) {return;}
-  virtual void set_edep(const float) {return;}
-  virtual void set_eion(const float) {return;}
-  virtual void set_light_yield(const float){return;}
-  virtual void set_path_length(const float){return;}
-  virtual void set_layer(const unsigned int) {return;}
-  virtual void set_hit_id(const EICPIDDefs::keytype) {return;}
-  virtual void set_shower_id(const int) {return;}
-  virtual void set_scint_id(const int) {return;}
-  virtual void set_row(const int) {return;}
-  virtual void set_trkid(const int) {return;}
-  virtual void set_strip_z_index(const int) {return;}
-  virtual void set_strip_y_index(const int) {return;}
-  virtual void set_ladder_z_index(const int) {return;}
-  virtual void set_ladder_phi_index(const int) {return;}
-  virtual void set_index_i(const int) {return;}
-  virtual void set_index_j(const int) {return;}
-  virtual void set_index_k(const int) {return;}
-  virtual void set_index_l(const int) {return;}
-  virtual void set_hit_type(const int) {return;}
-
-  virtual float get_avg_x() const;
-  virtual float get_avg_y() const;
-  virtual float get_avg_z() const;
-  virtual float get_avg_t() const;
-
-  virtual void print() const {std::cout<<"EICPIDParticle base class - print() not implemented"<<std::endl;}
-
-
-  //! Procedure to add a new PROPERTY tag:
-  //! 1.add new tag below with unique value,
-  //! 2.add a short name to EICPIDParticle::get_property_info
-  enum PROPERTY 
-  {//
-
-    //-- hit properties: 1 - 10  --
-    //! ionizing energy loss
-    prop_eion = 1,
-
-    //! for scintillation detectors, the amount of light produced
-    prop_light_yield = 2,
-    scint_gammas = 3,
-    cerenkov_gammas = 4,
-
-    //-- track properties: 10 - 20  --
-
-    //! momentum
-    prop_px_0 = 10,
-    prop_px_1 = 11,
-    prop_py_0 = 12,
-    prop_py_1 = 13,
-    prop_pz_0 = 14,
-    prop_pz_1 = 15,
-
-    //! pathlength
-    prop_path_length = 16,
-
-    //! local coordinate
-    prop_local_x_0 = 20,
-    prop_local_x_1 = 21,
-    prop_local_y_0 = 22,
-    prop_local_y_1 = 23,
-    prop_local_z_0 = 24,
-    prop_local_z_1 = 25,
-
-    //-- detector specific IDs: 100+ --
-
-    //! layer ID
-    prop_layer = 101,
-    //! scintillator ID
-    prop_scint_id = 102,
-    //! row (mother volume or steel plate id)
-    prop_row = 103,
-
-    //! SVX stuff
-    prop_strip_z_index = 110,
-    prop_strip_y_index = 111,
-    prop_ladder_z_index = 112,
-    prop_ladder_phi_index = 113,
-
-    // MAPS stuff 
-    prop_stave_index = 114,
-    prop_half_stave_index = 115,
-    prop_module_index = 116,
-    prop_chip_index = 117,
-
-    prop_local_pos_x_0 = 118,
-    prop_local_pos_y_0 = 119,
-    prop_local_pos_z_0 = 120,
-
-    //! generic indexes
-    prop_index_i = 121,
-    prop_index_j = 122,
-    prop_index_k = 123,
-    prop_index_l = 124,
-
-    //! hit type
-    prop_hit_type = 125,
-
-    prop_local_pos_x_1 = 128,
-    prop_local_pos_y_1 = 126,
-    prop_local_pos_z_1 = 127,
-
-    //! max limit in order to fit into 8 bit unsigned number
-    prop_MAX_NUMBER = UCHAR_MAX
-  };
-
-  enum PROPERTY_TYPE 
-  {//
+  enum PROPERTY_TYPE
+  {  //
     type_int = 1,
     type_uint = 2,
     type_float = 3,
     type_unknown = -1
   };
 
-  virtual bool  has_property(const PROPERTY /*prop_id*/) const {return false;}
-  virtual float get_property_float(const PROPERTY /*prop_id*/) const {return NAN;}
-  virtual int   get_property_int(const PROPERTY /*prop_id*/) const {return INT_MIN;}
-  virtual unsigned int   get_property_uint(const PROPERTY /*prop_id*/) const {return UINT_MAX;}
-  virtual void  set_property(const PROPERTY /*prop_id*/, const float /*value*/) {return;}
-  virtual void  set_property(const PROPERTY /*prop_id*/, const int /*value*/) {return;}
-  virtual void  set_property(const PROPERTY /*prop_id*/, const unsigned int /*value*/) {return;}
-  static std::pair<const std::string,PROPERTY_TYPE> get_property_info(PROPERTY prop_id);
+  //! Procedure to add a new PROPERTY tag:
+  //! 1.add new tag below with unique value,
+  //! 2.add a short name to EICPIDParticle::m_propertyInfo
+  enum PROPERTY
+  {  //
+    CTTL_beta = 1,
+    ETTL_beta,
+    FTTL_beta,
+
+    //! max limit in order to fit into 8 bit unsigned number
+    prop_MAX_NUMBER = UCHAR_MAX
+  };
+
+  // property info definition in the EICPIDParticle.cc file
+  const static std::map<PROPERTY,
+                        std::pair<const std::string, EICPIDParticle::PROPERTY_TYPE> >
+      m_propertyInfo;
+
+  virtual bool has_property(const PROPERTY /*prop_id*/) const { return false; }
+  virtual float get_property_float(const PROPERTY /*prop_id*/) const { return NAN; }
+  virtual int get_property_int(const PROPERTY /*prop_id*/) const { return INT_MIN; }
+  virtual unsigned int get_property_uint(const PROPERTY /*prop_id*/) const { return UINT_MAX; }
+  virtual void set_property(const PROPERTY /*prop_id*/, const float /*value*/) { return; }
+  virtual void set_property(const PROPERTY /*prop_id*/, const int /*value*/) { return; }
+  virtual void set_property(const PROPERTY /*prop_id*/, const unsigned int /*value*/) { return; }
+  static std::pair<const std::string, PROPERTY_TYPE> get_property_info(PROPERTY prop_id);
   static bool check_property(const PROPERTY prop_id, const PROPERTY_TYPE prop_type);
   static std::string get_property_type(const PROPERTY_TYPE prop_type);
 
  protected:
-  virtual unsigned int get_property_nocheck(const PROPERTY /*prop_id*/) const {return UINT_MAX;}
-  virtual void set_property_nocheck(const PROPERTY /*prop_id*/,const unsigned int) {return;}
-  ClassDefOverride(EICPIDParticle,1)
+  virtual unsigned int get_property_nocheck(const PROPERTY /*prop_id*/) const { return UINT_MAX; }
+  virtual void set_property_nocheck(const PROPERTY /*prop_id*/, const unsigned int) { return; }
+  ClassDefOverride(EICPIDParticle, 1)
 };
-
-
-inline float EICPIDParticle::get_avg_x() const { return 0.5*(get_x(0)+get_x(1)); }
-inline float EICPIDParticle::get_avg_y() const { return 0.5*(get_y(0)+get_y(1)); }
-inline float EICPIDParticle::get_avg_z() const { return 0.5*(get_z(0)+get_z(1)); }
-inline float EICPIDParticle::get_avg_t() const { return 0.5*(get_t(0)+get_t(1)); }
-
 
 #endif

--- a/reconstruction/eicpidbase/EICPIDParticleContainer.cc
+++ b/reconstruction/eicpidbase/EICPIDParticleContainer.cc
@@ -11,190 +11,68 @@
 using namespace std;
 
 EICPIDParticleContainer::EICPIDParticleContainer()
-  : id(-1), hitmap(), layers()
 {
 }
 
-EICPIDParticleContainer::EICPIDParticleContainer(const std::string &nodename)
-  : id(EICPIDDefs::get_volume_id(nodename)), hitmap(), layers()
+void EICPIDParticleContainer::Reset()
 {
-}
-
-void
-EICPIDParticleContainer::Reset()
-{
-   while(hitmap.begin() != hitmap.end())
-     {
-       delete hitmap.begin()->second;
-       hitmap.erase(hitmap.begin());
-     }
-  return;
-}
-
-void
-EICPIDParticleContainer::identify(ostream& os) const
-{
-   ConstIterator iter;
-   os << "Number of hits: " << size() << endl;
-   for (iter = hitmap.begin(); iter != hitmap.end(); ++iter)
-     {
-       os << "hit key 0x" << hex << iter->first << dec << endl;
-       (iter->second)->identify();
-     }
-   set<unsigned int>::const_iterator siter;
-   os << "Number of layers: " << num_layers() << endl;
-   for (siter = layers.begin(); siter != layers.end(); ++siter)
-     {
-       os << "layer : " << *siter << endl;
-     }
-  return;
-}
-
-EICPIDDefs::keytype
-EICPIDParticleContainer::getmaxkey(const unsigned int detid)
-{
-  ConstRange miter = getHits(detid);
-  // first handle 2 special cases where there is no hit in the current layer
-  // no hits in this layer and higher layers (lower layers can contain hits)
-    if (miter.first == hitmap.end())
-    {
-      return 0;
-    }
-  // no hits in this layer - but hits in higher layers
-  if (miter.first == miter.second)
-    {
-      return  0;
-    }
-  EICPIDDefs::keytype detidlong = detid;
-  EICPIDDefs::keytype shiftval = detidlong << EICPIDDefs::hit_idbits;
-  ConstIterator lastlayerentry = miter.second;
-  --lastlayerentry;
-  EICPIDDefs::keytype iret = lastlayerentry->first - shiftval; // subtract layer mask
-  return iret;
-}
-
-
-EICPIDDefs::keytype
-EICPIDParticleContainer::genkey(const unsigned int detid)
-{
-  EICPIDDefs::keytype detidlong = detid;
-  if ((detidlong >> EICPIDDefs::keybits) > 0)
-    {
-      cout << PHWHERE << " detector id too large: " << detid << endl;
-      gSystem->Exit(1);
-    }
-  EICPIDDefs::keytype shiftval = detidlong << EICPIDDefs::hit_idbits;
-  //  cout << "max index: " << (detminmax->second)->first << endl;
-  // after removing hits with no energy deposition, we have holes
-  // in our hit ranges. This construct will get us the last hit in
-  // a layer and return it's hit id. Adding 1 will put us at the end of this layer
-  EICPIDDefs::keytype hitid = getmaxkey(detid);
-  hitid++;
-  EICPIDDefs::keytype newkey = hitid | shiftval;
-  if (hitmap.find(newkey) != hitmap.end())
-    {
-      cout << PHWHERE << " duplicate key: 0x" 
-           << hex << newkey << dec 
-	   << " for detector " << detid 
-	   << " hitmap.size: " << hitmap.size()
-	   << " hitid: " << hitid << " exiting now" << endl;
-            exit(1);
-    }
-  return newkey;
-}
-
-EICPIDParticleContainer::ConstIterator
-EICPIDParticleContainer::AddHit(EICPIDParticle *newhit)
-{
-  EICPIDDefs::keytype key = newhit->get_hit_id();
-  if (hitmap.find(key) != hitmap.end())
-    {
-      cout << "hit with id  0x" << hex << key << dec << " exists already" << endl;
-      return hitmap.find(key);
-    }
-  EICPIDDefs::keytype detidlong = key >>  EICPIDDefs::hit_idbits;
-  unsigned int detid = detidlong;
-  layers.insert(detid);
-  return hitmap.insert( std::make_pair( key, newhit ) ).first;
-}
-
-EICPIDParticleContainer::ConstIterator
-EICPIDParticleContainer::AddHit(const unsigned int detid, EICPIDParticle *newhit)
-{
-  EICPIDDefs::keytype key = genkey(detid);
-  layers.insert(detid);
-  newhit->set_hit_id(key);
-  return hitmap.insert( std::make_pair( key, newhit ) ).first;
-}
-
-EICPIDParticleContainer::ConstRange EICPIDParticleContainer::getHits(const unsigned int detid) const
-{
-  EICPIDDefs::keytype detidlong = detid;
-  if ((detidlong >> EICPIDDefs::keybits) > 0)
-    {
-      cout << " detector id too large: " << detid << endl;
-      exit(1);
-    }
-  EICPIDDefs::keytype keylow = detidlong << EICPIDDefs::hit_idbits;
-  EICPIDDefs::keytype keyup = ((detidlong + 1) << EICPIDDefs::hit_idbits) -1 ;
-  ConstRange retpair;
-  retpair.first = hitmap.lower_bound(keylow);
-  retpair.second = hitmap.upper_bound(keyup);
-  return retpair;
-}
-
-EICPIDParticleContainer::ConstRange EICPIDParticleContainer::getHits( void ) const
-{ return std::make_pair( hitmap.begin(), hitmap.end() ); }
-
-
-EICPIDParticleContainer::Iterator EICPIDParticleContainer::findOrAddHit(EICPIDDefs::keytype key)
-{
-  EICPIDParticleContainer::Iterator it = hitmap.find(key);
-  if(it == hitmap.end())
+  while (m_particleMap.begin() != m_particleMap.end())
   {
-    hitmap[key] = new EICPIDParticlev1();
-    it = hitmap.find(key);
+    delete m_particleMap.begin()->second;
+    m_particleMap.erase(m_particleMap.begin());
+  }
+  return;
+}
+
+void EICPIDParticleContainer::identify(ostream& os) const
+{
+  ConstIterator iter;
+  os << "Number of PIDParticles: " << size() << endl;
+  for (iter = m_particleMap.begin(); iter != m_particleMap.end(); ++iter)
+  {
+    os << "PIDParticles ID " << iter->first << ": ";
+    (iter->second)->identify();
+  }
+  return;
+}
+
+EICPIDParticleContainer::ConstIterator
+EICPIDParticleContainer::AddPIDParticle(EICPIDParticle* newhit)
+{
+  EICPIDDefs::keytype key = newhit->get_id();
+  if (m_particleMap.find(key) != m_particleMap.end())
+  {
+    cout << "hit with id " << key << " exists already" << endl;
+    return m_particleMap.find(key);
+  }
+  return m_particleMap.insert(std::make_pair(key, newhit)).first;
+}
+
+EICPIDParticleContainer::ConstRange EICPIDParticleContainer::getPIDParticles(void) const
+{
+  return std::make_pair(m_particleMap.begin(), m_particleMap.end());
+}
+
+EICPIDParticleContainer::Iterator EICPIDParticleContainer::findOrAddPIDParticle(EICPIDDefs::keytype key)
+{
+  EICPIDParticleContainer::Iterator it = m_particleMap.find(key);
+  if (it == m_particleMap.end())
+  {
+    m_particleMap[key] = new EICPIDParticlev1();
+    it = m_particleMap.find(key);
     EICPIDParticle* mhit = it->second;
-    mhit->set_hit_id(key);
-    mhit->set_edep(0.);
-    layers.insert(mhit->get_layer()); // add layer to our set of layers
+    mhit->set_id(key);
   }
   return it;
 }
 
-EICPIDParticle* EICPIDParticleContainer::findHit(EICPIDDefs::keytype key)
+EICPIDParticle* EICPIDParticleContainer::findEICPIDParticle(EICPIDDefs::keytype key)
 {
-  EICPIDParticleContainer::ConstIterator it = hitmap.find(key);
-  if(it != hitmap.end())
-    {
-      return it->second;
-    }
-    
+  EICPIDParticleContainer::ConstIterator it = m_particleMap.find(key);
+  if (it != m_particleMap.end())
+  {
+    return it->second;
+  }
+
   return nullptr;
 }
-
-void
-EICPIDParticleContainer::RemoveZeroEDep()
-{
-  //  unsigned int hitsbef = hitmap.size();
-  Iterator itr = hitmap.begin();
-  Iterator last = hitmap.end();
-  for (; itr != last; )
-    {
-      EICPIDParticle *hit = itr->second;
-      if (hit->get_edep() == 0)
-        {
-          delete hit;
-          hitmap.erase(itr++);
-        }
-      else
-        {
-          ++itr;
-        }
-    }
-//   unsigned int hitsafter = hitmap.size();
-//   cout << "hist before: " << hitsbef
-//        << ", hits after: " << hitsafter << endl;
-  return;
-}
-

--- a/reconstruction/eicpidbase/EICPIDParticleContainer.cc
+++ b/reconstruction/eicpidbase/EICPIDParticleContainer.cc
@@ -1,0 +1,200 @@
+#include "EICPIDParticleContainer.h"
+
+#include <phool/phool.h>
+
+#include <TSystem.h>
+
+#include <cstdlib>
+#include "EICPIDParticle.h"
+#include "EICPIDParticlev1.h"
+
+using namespace std;
+
+EICPIDParticleContainer::EICPIDParticleContainer()
+  : id(-1), hitmap(), layers()
+{
+}
+
+EICPIDParticleContainer::EICPIDParticleContainer(const std::string &nodename)
+  : id(EICPIDDefs::get_volume_id(nodename)), hitmap(), layers()
+{
+}
+
+void
+EICPIDParticleContainer::Reset()
+{
+   while(hitmap.begin() != hitmap.end())
+     {
+       delete hitmap.begin()->second;
+       hitmap.erase(hitmap.begin());
+     }
+  return;
+}
+
+void
+EICPIDParticleContainer::identify(ostream& os) const
+{
+   ConstIterator iter;
+   os << "Number of hits: " << size() << endl;
+   for (iter = hitmap.begin(); iter != hitmap.end(); ++iter)
+     {
+       os << "hit key 0x" << hex << iter->first << dec << endl;
+       (iter->second)->identify();
+     }
+   set<unsigned int>::const_iterator siter;
+   os << "Number of layers: " << num_layers() << endl;
+   for (siter = layers.begin(); siter != layers.end(); ++siter)
+     {
+       os << "layer : " << *siter << endl;
+     }
+  return;
+}
+
+EICPIDDefs::keytype
+EICPIDParticleContainer::getmaxkey(const unsigned int detid)
+{
+  ConstRange miter = getHits(detid);
+  // first handle 2 special cases where there is no hit in the current layer
+  // no hits in this layer and higher layers (lower layers can contain hits)
+    if (miter.first == hitmap.end())
+    {
+      return 0;
+    }
+  // no hits in this layer - but hits in higher layers
+  if (miter.first == miter.second)
+    {
+      return  0;
+    }
+  EICPIDDefs::keytype detidlong = detid;
+  EICPIDDefs::keytype shiftval = detidlong << EICPIDDefs::hit_idbits;
+  ConstIterator lastlayerentry = miter.second;
+  --lastlayerentry;
+  EICPIDDefs::keytype iret = lastlayerentry->first - shiftval; // subtract layer mask
+  return iret;
+}
+
+
+EICPIDDefs::keytype
+EICPIDParticleContainer::genkey(const unsigned int detid)
+{
+  EICPIDDefs::keytype detidlong = detid;
+  if ((detidlong >> EICPIDDefs::keybits) > 0)
+    {
+      cout << PHWHERE << " detector id too large: " << detid << endl;
+      gSystem->Exit(1);
+    }
+  EICPIDDefs::keytype shiftval = detidlong << EICPIDDefs::hit_idbits;
+  //  cout << "max index: " << (detminmax->second)->first << endl;
+  // after removing hits with no energy deposition, we have holes
+  // in our hit ranges. This construct will get us the last hit in
+  // a layer and return it's hit id. Adding 1 will put us at the end of this layer
+  EICPIDDefs::keytype hitid = getmaxkey(detid);
+  hitid++;
+  EICPIDDefs::keytype newkey = hitid | shiftval;
+  if (hitmap.find(newkey) != hitmap.end())
+    {
+      cout << PHWHERE << " duplicate key: 0x" 
+           << hex << newkey << dec 
+	   << " for detector " << detid 
+	   << " hitmap.size: " << hitmap.size()
+	   << " hitid: " << hitid << " exiting now" << endl;
+            exit(1);
+    }
+  return newkey;
+}
+
+EICPIDParticleContainer::ConstIterator
+EICPIDParticleContainer::AddHit(EICPIDParticle *newhit)
+{
+  EICPIDDefs::keytype key = newhit->get_hit_id();
+  if (hitmap.find(key) != hitmap.end())
+    {
+      cout << "hit with id  0x" << hex << key << dec << " exists already" << endl;
+      return hitmap.find(key);
+    }
+  EICPIDDefs::keytype detidlong = key >>  EICPIDDefs::hit_idbits;
+  unsigned int detid = detidlong;
+  layers.insert(detid);
+  return hitmap.insert( std::make_pair( key, newhit ) ).first;
+}
+
+EICPIDParticleContainer::ConstIterator
+EICPIDParticleContainer::AddHit(const unsigned int detid, EICPIDParticle *newhit)
+{
+  EICPIDDefs::keytype key = genkey(detid);
+  layers.insert(detid);
+  newhit->set_hit_id(key);
+  return hitmap.insert( std::make_pair( key, newhit ) ).first;
+}
+
+EICPIDParticleContainer::ConstRange EICPIDParticleContainer::getHits(const unsigned int detid) const
+{
+  EICPIDDefs::keytype detidlong = detid;
+  if ((detidlong >> EICPIDDefs::keybits) > 0)
+    {
+      cout << " detector id too large: " << detid << endl;
+      exit(1);
+    }
+  EICPIDDefs::keytype keylow = detidlong << EICPIDDefs::hit_idbits;
+  EICPIDDefs::keytype keyup = ((detidlong + 1) << EICPIDDefs::hit_idbits) -1 ;
+  ConstRange retpair;
+  retpair.first = hitmap.lower_bound(keylow);
+  retpair.second = hitmap.upper_bound(keyup);
+  return retpair;
+}
+
+EICPIDParticleContainer::ConstRange EICPIDParticleContainer::getHits( void ) const
+{ return std::make_pair( hitmap.begin(), hitmap.end() ); }
+
+
+EICPIDParticleContainer::Iterator EICPIDParticleContainer::findOrAddHit(EICPIDDefs::keytype key)
+{
+  EICPIDParticleContainer::Iterator it = hitmap.find(key);
+  if(it == hitmap.end())
+  {
+    hitmap[key] = new EICPIDParticlev1();
+    it = hitmap.find(key);
+    EICPIDParticle* mhit = it->second;
+    mhit->set_hit_id(key);
+    mhit->set_edep(0.);
+    layers.insert(mhit->get_layer()); // add layer to our set of layers
+  }
+  return it;
+}
+
+EICPIDParticle* EICPIDParticleContainer::findHit(EICPIDDefs::keytype key)
+{
+  EICPIDParticleContainer::ConstIterator it = hitmap.find(key);
+  if(it != hitmap.end())
+    {
+      return it->second;
+    }
+    
+  return nullptr;
+}
+
+void
+EICPIDParticleContainer::RemoveZeroEDep()
+{
+  //  unsigned int hitsbef = hitmap.size();
+  Iterator itr = hitmap.begin();
+  Iterator last = hitmap.end();
+  for (; itr != last; )
+    {
+      EICPIDParticle *hit = itr->second;
+      if (hit->get_edep() == 0)
+        {
+          delete hit;
+          hitmap.erase(itr++);
+        }
+      else
+        {
+          ++itr;
+        }
+    }
+//   unsigned int hitsafter = hitmap.size();
+//   cout << "hist before: " << hitsbef
+//        << ", hits after: " << hitsafter << endl;
+  return;
+}
+

--- a/reconstruction/eicpidbase/EICPIDParticleContainer.h
+++ b/reconstruction/eicpidbase/EICPIDParticleContainer.h
@@ -1,0 +1,76 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef EICPID_EICPIDParticleCONTAINER_H
+#define EICPID_EICPIDParticleCONTAINER_H
+
+#include <phool/PHObject.h>
+
+#include <iostream>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include "EICPIDDefs.h"
+
+class EICPIDParticle;
+
+class EICPIDParticleContainer: public PHObject
+{
+
+  public:
+  typedef std::map<EICPIDDefs::keytype, EICPIDParticle *> Map;
+  typedef Map::iterator Iterator;
+  typedef Map::const_iterator ConstIterator;
+  typedef std::pair<Iterator, Iterator> Range;
+  typedef std::pair<ConstIterator, ConstIterator> ConstRange;
+  typedef std::set<unsigned int>::const_iterator LayerIter;
+
+  EICPIDParticleContainer(); //< used only by ROOT for DST readback
+  EICPIDParticleContainer(const std::string &nodename);
+
+  ~EICPIDParticleContainer() override {}
+
+  void Reset() override;
+
+  void identify(std::ostream& os = std::cout) const override;
+
+  //! container ID should follow definition of EICPIDDefs::get_volume_id(DST nodename)
+  void SetID(int i) {id = i;}
+  int GetID() const {return id;}
+  
+  ConstIterator AddHit(EICPIDParticle *newhit);
+
+  ConstIterator AddHit(const unsigned int detid, EICPIDParticle *newhit);
+  
+  Iterator findOrAddHit(EICPIDDefs::keytype key);
+
+  EICPIDParticle* findHit(EICPIDDefs::keytype key );
+
+  EICPIDDefs::keytype genkey(const unsigned int detid);
+
+  //! return all hits matching a given detid
+  ConstRange getHits(const unsigned int detid) const;
+
+  //! return all hist
+  ConstRange getHits( void ) const;
+
+  unsigned int size( void ) const
+  { return hitmap.size(); }
+  unsigned int num_layers(void) const
+  { return layers.size(); }
+  std::pair<LayerIter, LayerIter> getLayers() const
+     { return make_pair(layers.begin(), layers.end());} 
+  void AddLayer(const unsigned int ilayer) {layers.insert(ilayer);}
+  void RemoveZeroEDep();
+  EICPIDDefs::keytype getmaxkey(const unsigned int detid);
+
+ protected:
+
+  int id; //< unique identifier from hash of node name. Defined following EICPIDDefs::get_volume_id
+  Map hitmap;
+  std::set<unsigned int> layers; // layers is not reset since layers must not change event by event
+
+  ClassDefOverride(EICPIDParticleContainer,1)
+};
+
+#endif

--- a/reconstruction/eicpidbase/EICPIDParticleContainer.h
+++ b/reconstruction/eicpidbase/EICPIDParticleContainer.h
@@ -10,23 +10,22 @@
 #include <set>
 #include <string>
 #include <utility>
+
 #include "EICPIDDefs.h"
 
 class EICPIDParticle;
 
-class EICPIDParticleContainer: public PHObject
+class EICPIDParticleContainer : public PHObject
 {
-
-  public:
-  typedef std::map<EICPIDDefs::keytype, EICPIDParticle *> Map;
+ public:
+  typedef std::map<EICPIDDefs::keytype, EICPIDParticle*> Map;
   typedef Map::iterator Iterator;
   typedef Map::const_iterator ConstIterator;
   typedef std::pair<Iterator, Iterator> Range;
   typedef std::pair<ConstIterator, ConstIterator> ConstRange;
   typedef std::set<unsigned int>::const_iterator LayerIter;
 
-  EICPIDParticleContainer(); //< used only by ROOT for DST readback
-  EICPIDParticleContainer(const std::string &nodename);
+  EICPIDParticleContainer();
 
   ~EICPIDParticleContainer() override {}
 
@@ -34,43 +33,24 @@ class EICPIDParticleContainer: public PHObject
 
   void identify(std::ostream& os = std::cout) const override;
 
-  //! container ID should follow definition of EICPIDDefs::get_volume_id(DST nodename)
-  void SetID(int i) {id = i;}
-  int GetID() const {return id;}
-  
-  ConstIterator AddHit(EICPIDParticle *newhit);
+  ConstIterator AddPIDParticle(EICPIDParticle* newhit);
 
-  ConstIterator AddHit(const unsigned int detid, EICPIDParticle *newhit);
-  
-  Iterator findOrAddHit(EICPIDDefs::keytype key);
+  Iterator findOrAddPIDParticle(EICPIDDefs::keytype key);
 
-  EICPIDParticle* findHit(EICPIDDefs::keytype key );
-
-  EICPIDDefs::keytype genkey(const unsigned int detid);
-
-  //! return all hits matching a given detid
-  ConstRange getHits(const unsigned int detid) const;
+  EICPIDParticle* findEICPIDParticle(EICPIDDefs::keytype key);
 
   //! return all hist
-  ConstRange getHits( void ) const;
+  ConstRange getPIDParticles(void) const;
 
-  unsigned int size( void ) const
-  { return hitmap.size(); }
-  unsigned int num_layers(void) const
-  { return layers.size(); }
-  std::pair<LayerIter, LayerIter> getLayers() const
-     { return make_pair(layers.begin(), layers.end());} 
-  void AddLayer(const unsigned int ilayer) {layers.insert(ilayer);}
-  void RemoveZeroEDep();
-  EICPIDDefs::keytype getmaxkey(const unsigned int detid);
+  unsigned int size(void) const
+  {
+    return m_particleMap.size();
+  }
 
  protected:
+  Map m_particleMap;
 
-  int id; //< unique identifier from hash of node name. Defined following EICPIDDefs::get_volume_id
-  Map hitmap;
-  std::set<unsigned int> layers; // layers is not reset since layers must not change event by event
-
-  ClassDefOverride(EICPIDParticleContainer,1)
+  ClassDefOverride(EICPIDParticleContainer, 1)
 };
 
 #endif

--- a/reconstruction/eicpidbase/EICPIDParticleContainerLinkDef.h
+++ b/reconstruction/eicpidbase/EICPIDParticleContainerLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class EICPIDParticleContainer+;
+
+#endif /* __CINT__ */

--- a/reconstruction/eicpidbase/EICPIDParticleContainerLinkDef.h
+++ b/reconstruction/eicpidbase/EICPIDParticleContainerLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class EICPIDParticleContainer+;
+#pragma link C++ class EICPIDParticleContainer + ;
 
 #endif /* __CINT__ */

--- a/reconstruction/eicpidbase/EICPIDParticleLinkDef.h
+++ b/reconstruction/eicpidbase/EICPIDParticleLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class EICPIDParticle+;
+#pragma link C++ class EICPIDParticle + ;
 
 #endif /* __CINT__ */

--- a/reconstruction/eicpidbase/EICPIDParticleLinkDef.h
+++ b/reconstruction/eicpidbase/EICPIDParticleLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class EICPIDParticle+;
+
+#endif /* __CINT__ */

--- a/reconstruction/eicpidbase/EICPIDParticlev1.cc
+++ b/reconstruction/eicpidbase/EICPIDParticlev1.cc
@@ -11,106 +11,53 @@
 
 using namespace std;
 
-EICPIDParticlev1::EICPIDParticlev1(const EICPIDParticle *g4hit)
+EICPIDParticlev1::EICPIDParticlev1(const EICPIDParticle* g4hit)
 {
   CopyFrom(g4hit);
 }
 
-void
-EICPIDParticlev1::Reset()
+void EICPIDParticlev1::Reset()
 {
-  hitid = ULONG_LONG_MAX;
-  trackid = INT_MIN;
-  showerid = INT_MIN;
-  edep = NAN;
-  for (int i = 0; i<2;i++)
-    {
-      set_x(i,NAN);
-      set_y(i,NAN);
-      set_z(i,NAN);
-      set_t(i,NAN);
-    }
+  m_id = -1;
   prop_map.clear();
 }
 
-int
-EICPIDParticlev1::get_detid() const
-{
-  // a compile time check if the hit_idbits are within range (1-32)
-  static_assert (EICPIDDefs::hit_idbits <= sizeof(unsigned int)*8,"hit_idbits < 32, fix in EICPIDDefs.h");
-  int detid = (hitid>>EICPIDDefs::hit_idbits);
-  return detid;
-}
-
-void
-EICPIDParticlev1::print() const {
-  std::cout<<"New Hitv1  0x"<< hex << hitid 
-	   << dec << "  on track "<<trackid<<" EDep "<<edep<<std::endl;
-  std::cout<<"Location: X "<<x[0]<<"/"<<x[1]<<"  Y "<<y[0]<<"/"<<y[1]<<"  Z "<<z[0]<<"/"<<z[1]<<std::endl;
-  std::cout<<"Time        "<<t[0]<<"/"<<t[1]<<std::endl;
-
-  for (prop_map_t::const_iterator i = prop_map.begin(); i!= prop_map.end(); ++i)
-    {
-      PROPERTY prop_id = static_cast<PROPERTY>(i->first);
-      pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
-      cout << "\t" << prop_id << ":\t" << property_info.first << " = \t";
-      switch(property_info.second)
-	{
-	case type_int:
-	  cout << get_property_int(prop_id);
-	  break;
-	case type_uint:
-	  cout << get_property_uint(prop_id);
-	  break;
-	case type_float:
-	  cout << get_property_float(prop_id);
-	  break;
-	default:
-	  cout << " unknown type ";
-	}
-      cout <<endl;
-    }
-}
-
-bool
-EICPIDParticlev1::has_property(const PROPERTY prop_id) const
+bool EICPIDParticlev1::has_property(const PROPERTY prop_id) const
 {
   prop_map_t::const_iterator i = prop_map.find(prop_id);
-  return i!=prop_map.end();
+  return i != prop_map.end();
 }
 
-float
-EICPIDParticlev1::get_property_float(const PROPERTY prop_id) const
+float EICPIDParticlev1::get_property_float(const PROPERTY prop_id) const
 {
-  if (!check_property(prop_id,type_float))
-    {
-      pair<const string,PROPERTY_TYPE> property_info =get_property_info(prop_id); 
-      cout << PHWHERE << " Property " << property_info.first << " with id "
-           << prop_id << " is of type " << get_property_type(property_info.second) 
-	   << " not " << get_property_type(type_float) << endl; 
-      exit(1);
-    }
+  if (!check_property(prop_id, type_float))
+  {
+    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    cout << PHWHERE << " Property " << property_info.first << " with id "
+         << prop_id << " is of type " << get_property_type(property_info.second)
+         << " not " << get_property_type(type_float) << endl;
+    exit(1);
+  }
   prop_map_t::const_iterator i = prop_map.find(prop_id);
 
-  if (i!=prop_map.end()) return u_property(i->second).fdata;
+  if (i != prop_map.end()) return u_property(i->second).fdata;
 
-  return   NAN ;
+  return NAN;
 }
 
-int
-EICPIDParticlev1::get_property_int(const PROPERTY prop_id) const
+int EICPIDParticlev1::get_property_int(const PROPERTY prop_id) const
 {
-  if (!check_property(prop_id,type_int))
-    {
-      pair<const string,PROPERTY_TYPE> property_info =get_property_info(prop_id); 
-      cout << PHWHERE << " Property " << property_info.first << " with id "
-           << prop_id << " is of type " << get_property_type(property_info.second) 
-	   << " not " << get_property_type(type_int) << endl; 
-      exit(1);
-    }
+  if (!check_property(prop_id, type_int))
+  {
+    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    cout << PHWHERE << " Property " << property_info.first << " with id "
+         << prop_id << " is of type " << get_property_type(property_info.second)
+         << " not " << get_property_type(type_int) << endl;
+    exit(1);
+  }
   prop_map_t::const_iterator i = prop_map.find(prop_id);
 
-  if (i!=prop_map.end()) return u_property(i->second).idata;
+  if (i != prop_map.end()) return u_property(i->second).idata;
 
   return INT_MIN;
 }
@@ -118,60 +65,57 @@ EICPIDParticlev1::get_property_int(const PROPERTY prop_id) const
 unsigned int
 EICPIDParticlev1::get_property_uint(const PROPERTY prop_id) const
 {
-  if (!check_property(prop_id,type_uint))
-    {
-      pair<const string,PROPERTY_TYPE> property_info =get_property_info(prop_id); 
-      cout << PHWHERE << " Property " << property_info.first << " with id "
-           << prop_id << " is of type " << get_property_type(property_info.second) 
-	   << " not " << get_property_type(type_uint) << endl; 
-      exit(1);
-    }
+  if (!check_property(prop_id, type_uint))
+  {
+    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    cout << PHWHERE << " Property " << property_info.first << " with id "
+         << prop_id << " is of type " << get_property_type(property_info.second)
+         << " not " << get_property_type(type_uint) << endl;
+    exit(1);
+  }
   prop_map_t::const_iterator i = prop_map.find(prop_id);
 
-  if (i!=prop_map.end()) return u_property(i->second).uidata;
+  if (i != prop_map.end()) return u_property(i->second).uidata;
 
-  return UINT_MAX ;
+  return UINT_MAX;
 }
 
-void
-EICPIDParticlev1::set_property(const PROPERTY prop_id, const float value)
+void EICPIDParticlev1::set_property(const PROPERTY prop_id, const float value)
 {
-  if (!check_property(prop_id,type_float))
-    {
-      pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id); 
-      cout << PHWHERE << " Property " << property_info.first << " with id "
-           << prop_id << " is of type " << get_property_type(property_info.second) 
-	   << " not " << get_property_type(type_float) << endl; 
-      exit(1);
-    }
+  if (!check_property(prop_id, type_float))
+  {
+    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    cout << PHWHERE << " Property " << property_info.first << " with id "
+         << prop_id << " is of type " << get_property_type(property_info.second)
+         << " not " << get_property_type(type_float) << endl;
+    exit(1);
+  }
   prop_map[prop_id] = u_property(value).get_storage();
 }
 
-void
-EICPIDParticlev1::set_property(const PROPERTY prop_id, const int value)
+void EICPIDParticlev1::set_property(const PROPERTY prop_id, const int value)
 {
-  if (!check_property(prop_id,type_int))
-    {
-      pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id); 
-      cout << PHWHERE << " Property " << property_info.first << " with id "
-           << prop_id << " is of type " << get_property_type(property_info.second) 
-	   << " not " << get_property_type(type_int) << endl; 
-      exit(1);
-    }
+  if (!check_property(prop_id, type_int))
+  {
+    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    cout << PHWHERE << " Property " << property_info.first << " with id "
+         << prop_id << " is of type " << get_property_type(property_info.second)
+         << " not " << get_property_type(type_int) << endl;
+    exit(1);
+  }
   prop_map[prop_id] = u_property(value).get_storage();
 }
 
-void
-EICPIDParticlev1::set_property(const PROPERTY prop_id, const unsigned int value)
+void EICPIDParticlev1::set_property(const PROPERTY prop_id, const unsigned int value)
 {
-  if (!check_property(prop_id,type_uint))
-    {
-      pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id); 
-      cout << PHWHERE << " Property " << property_info.first << " with id "
-           << prop_id << " is of type " << get_property_type(property_info.second) 
-	   << " not " << get_property_type(type_uint) << endl; 
-      exit(1);
-    }
+  if (!check_property(prop_id, type_uint))
+  {
+    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    cout << PHWHERE << " Property " << property_info.first << " with id "
+         << prop_id << " is of type " << get_property_type(property_info.second)
+         << " not " << get_property_type(type_uint) << endl;
+    exit(1);
+  }
   prop_map[prop_id] = u_property(value).get_storage();
 }
 
@@ -180,239 +124,35 @@ EICPIDParticlev1::get_property_nocheck(const PROPERTY prop_id) const
 {
   prop_map_t::const_iterator iter = prop_map.find(prop_id);
   if (iter != prop_map.end())
-    {
-      return iter->second;
-    }
+  {
+    return iter->second;
+  }
   return UINT_MAX;
 }
 
-float
-EICPIDParticlev1::get_px(const int i) const
+void EICPIDParticlev1::identify(ostream& os) const
 {
-  switch(i)
+  os << "Class " << this->ClassName();
+  os << " id: " << m_id << endl;
+  for (prop_map_t::const_iterator i = prop_map.begin(); i != prop_map.end(); ++i)
+  {
+    PROPERTY prop_id = static_cast<PROPERTY>(i->first);
+    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    os << "\t" << prop_id << ":\t" << property_info.first << " = \t";
+    switch (property_info.second)
     {
-    case 0:
-      return  get_property_float(prop_px_0);
-    case 1:
-      return  get_property_float(prop_px_1);
+    case type_int:
+      os << get_property_int(prop_id);
+      break;
+    case type_uint:
+      os << get_property_uint(prop_id);
+      break;
+    case type_float:
+      os << get_property_float(prop_id);
+      break;
     default:
-      cout << "Invalid index in get_px: " << i << endl;
-      exit(1);
+      os << " unknown type ";
     }
-}
-
-float
-EICPIDParticlev1::get_py(const int i) const
-{
-  switch(i)
-    {
-    case 0:
-      return  get_property_float(prop_py_0);
-    case 1:
-      return  get_property_float(prop_py_1);
-    default:
-      cout << "Invalid index in get_py: " << i << endl;
-      exit(1);
-    }
-}
-
-float
-EICPIDParticlev1::get_pz(const int i) const
-{
-  switch(i)
-    {
-    case 0:
-      return  get_property_float(prop_pz_0);
-    case 1:
-      return  get_property_float(prop_pz_1);
-    default:
-      cout << "Invalid index in get_pz: " << i << endl;
-      exit(1);
-    }
-}
-
-void
-EICPIDParticlev1::set_px(const int i, const float f)
-{
-  switch(i)
-    {
-    case 0:
-      set_property(prop_px_0,f);
-      return;
-    case 1:
-      set_property(prop_px_1,f);
-      return;
-    default:
-      cout << "Invalid index in set_px: " << i << endl;
-      exit(1);
-    }
-}
-
-void
-EICPIDParticlev1::set_py(const int i, const float f)
-{
-  switch(i)
-    {
-    case 0:
-      set_property(prop_py_0,f);
-      return;
-    case 1:
-      set_property(prop_py_1,f);
-      return;
-    default:
-      cout << "Invalid index in set_py: " << i << endl;
-      exit(1);
-    }
-}
-
-void
-EICPIDParticlev1::set_pz(const int i, const float f)
-{
-  switch(i)
-    {
-    case 0:
-      set_property(prop_pz_0,f);
-      return;
-    case 1:
-      set_property(prop_pz_1,f);
-      return;
-    default:
-      cout << "Invalid index in set_pz: " << i << endl;
-      exit(1);
-    }
-}
-
-
-float
-EICPIDParticlev1::get_local_x(const int i) const
-{
-  switch(i)
-    {
-    case 0:
-      return  get_property_float(prop_local_x_0);
-    case 1:
-      return  get_property_float(prop_local_x_1);
-    default:
-      cout << "Invalid index in get_local_x: " << i << endl;
-      exit(1);
-    }
-}
-
-float
-EICPIDParticlev1::get_local_y(const int i) const
-{
-  switch(i)
-    {
-    case 0:
-      return  get_property_float(prop_local_y_0);
-    case 1:
-      return  get_property_float(prop_local_y_1);
-    default:
-      cout << "Invalid index in get_local_y: " << i << endl;
-      exit(1);
-    }
-}
-
-float
-EICPIDParticlev1::get_local_z(const int i) const
-{
-  switch(i)
-    {
-    case 0:
-      return  get_property_float(prop_local_z_0);
-    case 1:
-      return  get_property_float(prop_local_z_1);
-    default:
-      cout << "Invalid index in get_local_z: " << i << endl;
-      exit(1);
-    }
-}
-
-void
-EICPIDParticlev1::set_local_x(const int i, const float f)
-{
-  switch(i)
-    {
-    case 0:
-      set_property(prop_local_x_0,f);
-      return;
-    case 1:
-      set_property(prop_local_x_1,f);
-      return;
-    default:
-      cout << "Invalid index in set_local_x: " << i << endl;
-      exit(1);
-    }
-}
-
-void
-EICPIDParticlev1::set_local_y(const int i, const float f)
-{
-  switch(i)
-    {
-    case 0:
-      set_property(prop_local_y_0,f);
-      return;
-    case 1:
-      set_property(prop_local_y_1,f);
-      return;
-    default:
-      cout << "Invalid index in set_local_y: " << i << endl;
-      exit(1);
-    }
-}
-
-void
-EICPIDParticlev1::set_local_z(const int i, const float f)
-{
-  switch(i)
-    {
-    case 0:
-      set_property(prop_local_z_0,f);
-      return;
-    case 1:
-      set_property(prop_local_z_1,f);
-      return;
-    default:
-      cout << "Invalid index in set_local_z: " << i << endl;
-      exit(1);
-    }
-}
-
-void
-EICPIDParticlev1::identify(ostream& os) const
-{
-  os << "Class " << this->ClassName() << endl;
-  os << "hitid: 0x" << hex << hitid << dec << endl; 
-  os << "x0: " << get_x(0)
-       << ", y0: " << get_y(0)
-       << ", z0: " << get_z(0)
-       << ", t0: " << get_t(0) << endl;
-  os << "x1: " << get_x(1)
-       << ", y1: " << get_y(1)
-       << ", z1: " << get_z(1)
-       << ", t1: " << get_t(1) << endl;
-  os << "trackid: " << trackid << ", showerid: " << showerid
-       << ", edep: " << edep << endl;
-  for (prop_map_t::const_iterator i = prop_map.begin(); i!= prop_map.end(); ++i)
-    {
-      PROPERTY prop_id = static_cast<PROPERTY>(i->first);
-      pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
-      os << "\t" << prop_id << ":\t" << property_info.first << " = \t";
-      switch(property_info.second)
-	{
-	case type_int:
-	  os << get_property_int(prop_id);
-	  break;
-	case type_uint:
-	  os << get_property_uint(prop_id);
-	  break;
-	case type_float:
-	  os << get_property_float(prop_id);
-	  break;
-	default:
-	  os << " unknown type ";
-	}
-      os <<endl;
-    }
+    os << endl;
+  }
 }

--- a/reconstruction/eicpidbase/EICPIDParticlev1.cc
+++ b/reconstruction/eicpidbase/EICPIDParticlev1.cc
@@ -81,7 +81,7 @@ float EICPIDParticlev1::get_LogLikelyhood(EICPIDDefs::PIDCandidate pid, EICPIDDe
   const auto iter = m_LogLikelyhoodMap.find(key);
 
   if (iter == m_LogLikelyhoodMap.end())
-    return 0;
+    return m_minLogLikelihood;
   else
     return iter->second;
 }

--- a/reconstruction/eicpidbase/EICPIDParticlev1.cc
+++ b/reconstruction/eicpidbase/EICPIDParticlev1.cc
@@ -1,0 +1,418 @@
+#include "EICPIDParticlev1.h"
+
+#include <phool/phool.h>
+
+#include <climits>
+#include <cmath>
+#include <cstdlib>
+#include <string>
+#include <utility>
+#include "EICPIDDefs.h"
+
+using namespace std;
+
+EICPIDParticlev1::EICPIDParticlev1(const EICPIDParticle *g4hit)
+{
+  CopyFrom(g4hit);
+}
+
+void
+EICPIDParticlev1::Reset()
+{
+  hitid = ULONG_LONG_MAX;
+  trackid = INT_MIN;
+  showerid = INT_MIN;
+  edep = NAN;
+  for (int i = 0; i<2;i++)
+    {
+      set_x(i,NAN);
+      set_y(i,NAN);
+      set_z(i,NAN);
+      set_t(i,NAN);
+    }
+  prop_map.clear();
+}
+
+int
+EICPIDParticlev1::get_detid() const
+{
+  // a compile time check if the hit_idbits are within range (1-32)
+  static_assert (EICPIDDefs::hit_idbits <= sizeof(unsigned int)*8,"hit_idbits < 32, fix in EICPIDDefs.h");
+  int detid = (hitid>>EICPIDDefs::hit_idbits);
+  return detid;
+}
+
+void
+EICPIDParticlev1::print() const {
+  std::cout<<"New Hitv1  0x"<< hex << hitid 
+	   << dec << "  on track "<<trackid<<" EDep "<<edep<<std::endl;
+  std::cout<<"Location: X "<<x[0]<<"/"<<x[1]<<"  Y "<<y[0]<<"/"<<y[1]<<"  Z "<<z[0]<<"/"<<z[1]<<std::endl;
+  std::cout<<"Time        "<<t[0]<<"/"<<t[1]<<std::endl;
+
+  for (prop_map_t::const_iterator i = prop_map.begin(); i!= prop_map.end(); ++i)
+    {
+      PROPERTY prop_id = static_cast<PROPERTY>(i->first);
+      pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+      cout << "\t" << prop_id << ":\t" << property_info.first << " = \t";
+      switch(property_info.second)
+	{
+	case type_int:
+	  cout << get_property_int(prop_id);
+	  break;
+	case type_uint:
+	  cout << get_property_uint(prop_id);
+	  break;
+	case type_float:
+	  cout << get_property_float(prop_id);
+	  break;
+	default:
+	  cout << " unknown type ";
+	}
+      cout <<endl;
+    }
+}
+
+bool
+EICPIDParticlev1::has_property(const PROPERTY prop_id) const
+{
+  prop_map_t::const_iterator i = prop_map.find(prop_id);
+  return i!=prop_map.end();
+}
+
+float
+EICPIDParticlev1::get_property_float(const PROPERTY prop_id) const
+{
+  if (!check_property(prop_id,type_float))
+    {
+      pair<const string,PROPERTY_TYPE> property_info =get_property_info(prop_id); 
+      cout << PHWHERE << " Property " << property_info.first << " with id "
+           << prop_id << " is of type " << get_property_type(property_info.second) 
+	   << " not " << get_property_type(type_float) << endl; 
+      exit(1);
+    }
+  prop_map_t::const_iterator i = prop_map.find(prop_id);
+
+  if (i!=prop_map.end()) return u_property(i->second).fdata;
+
+  return   NAN ;
+}
+
+int
+EICPIDParticlev1::get_property_int(const PROPERTY prop_id) const
+{
+  if (!check_property(prop_id,type_int))
+    {
+      pair<const string,PROPERTY_TYPE> property_info =get_property_info(prop_id); 
+      cout << PHWHERE << " Property " << property_info.first << " with id "
+           << prop_id << " is of type " << get_property_type(property_info.second) 
+	   << " not " << get_property_type(type_int) << endl; 
+      exit(1);
+    }
+  prop_map_t::const_iterator i = prop_map.find(prop_id);
+
+  if (i!=prop_map.end()) return u_property(i->second).idata;
+
+  return INT_MIN;
+}
+
+unsigned int
+EICPIDParticlev1::get_property_uint(const PROPERTY prop_id) const
+{
+  if (!check_property(prop_id,type_uint))
+    {
+      pair<const string,PROPERTY_TYPE> property_info =get_property_info(prop_id); 
+      cout << PHWHERE << " Property " << property_info.first << " with id "
+           << prop_id << " is of type " << get_property_type(property_info.second) 
+	   << " not " << get_property_type(type_uint) << endl; 
+      exit(1);
+    }
+  prop_map_t::const_iterator i = prop_map.find(prop_id);
+
+  if (i!=prop_map.end()) return u_property(i->second).uidata;
+
+  return UINT_MAX ;
+}
+
+void
+EICPIDParticlev1::set_property(const PROPERTY prop_id, const float value)
+{
+  if (!check_property(prop_id,type_float))
+    {
+      pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id); 
+      cout << PHWHERE << " Property " << property_info.first << " with id "
+           << prop_id << " is of type " << get_property_type(property_info.second) 
+	   << " not " << get_property_type(type_float) << endl; 
+      exit(1);
+    }
+  prop_map[prop_id] = u_property(value).get_storage();
+}
+
+void
+EICPIDParticlev1::set_property(const PROPERTY prop_id, const int value)
+{
+  if (!check_property(prop_id,type_int))
+    {
+      pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id); 
+      cout << PHWHERE << " Property " << property_info.first << " with id "
+           << prop_id << " is of type " << get_property_type(property_info.second) 
+	   << " not " << get_property_type(type_int) << endl; 
+      exit(1);
+    }
+  prop_map[prop_id] = u_property(value).get_storage();
+}
+
+void
+EICPIDParticlev1::set_property(const PROPERTY prop_id, const unsigned int value)
+{
+  if (!check_property(prop_id,type_uint))
+    {
+      pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id); 
+      cout << PHWHERE << " Property " << property_info.first << " with id "
+           << prop_id << " is of type " << get_property_type(property_info.second) 
+	   << " not " << get_property_type(type_uint) << endl; 
+      exit(1);
+    }
+  prop_map[prop_id] = u_property(value).get_storage();
+}
+
+unsigned int
+EICPIDParticlev1::get_property_nocheck(const PROPERTY prop_id) const
+{
+  prop_map_t::const_iterator iter = prop_map.find(prop_id);
+  if (iter != prop_map.end())
+    {
+      return iter->second;
+    }
+  return UINT_MAX;
+}
+
+float
+EICPIDParticlev1::get_px(const int i) const
+{
+  switch(i)
+    {
+    case 0:
+      return  get_property_float(prop_px_0);
+    case 1:
+      return  get_property_float(prop_px_1);
+    default:
+      cout << "Invalid index in get_px: " << i << endl;
+      exit(1);
+    }
+}
+
+float
+EICPIDParticlev1::get_py(const int i) const
+{
+  switch(i)
+    {
+    case 0:
+      return  get_property_float(prop_py_0);
+    case 1:
+      return  get_property_float(prop_py_1);
+    default:
+      cout << "Invalid index in get_py: " << i << endl;
+      exit(1);
+    }
+}
+
+float
+EICPIDParticlev1::get_pz(const int i) const
+{
+  switch(i)
+    {
+    case 0:
+      return  get_property_float(prop_pz_0);
+    case 1:
+      return  get_property_float(prop_pz_1);
+    default:
+      cout << "Invalid index in get_pz: " << i << endl;
+      exit(1);
+    }
+}
+
+void
+EICPIDParticlev1::set_px(const int i, const float f)
+{
+  switch(i)
+    {
+    case 0:
+      set_property(prop_px_0,f);
+      return;
+    case 1:
+      set_property(prop_px_1,f);
+      return;
+    default:
+      cout << "Invalid index in set_px: " << i << endl;
+      exit(1);
+    }
+}
+
+void
+EICPIDParticlev1::set_py(const int i, const float f)
+{
+  switch(i)
+    {
+    case 0:
+      set_property(prop_py_0,f);
+      return;
+    case 1:
+      set_property(prop_py_1,f);
+      return;
+    default:
+      cout << "Invalid index in set_py: " << i << endl;
+      exit(1);
+    }
+}
+
+void
+EICPIDParticlev1::set_pz(const int i, const float f)
+{
+  switch(i)
+    {
+    case 0:
+      set_property(prop_pz_0,f);
+      return;
+    case 1:
+      set_property(prop_pz_1,f);
+      return;
+    default:
+      cout << "Invalid index in set_pz: " << i << endl;
+      exit(1);
+    }
+}
+
+
+float
+EICPIDParticlev1::get_local_x(const int i) const
+{
+  switch(i)
+    {
+    case 0:
+      return  get_property_float(prop_local_x_0);
+    case 1:
+      return  get_property_float(prop_local_x_1);
+    default:
+      cout << "Invalid index in get_local_x: " << i << endl;
+      exit(1);
+    }
+}
+
+float
+EICPIDParticlev1::get_local_y(const int i) const
+{
+  switch(i)
+    {
+    case 0:
+      return  get_property_float(prop_local_y_0);
+    case 1:
+      return  get_property_float(prop_local_y_1);
+    default:
+      cout << "Invalid index in get_local_y: " << i << endl;
+      exit(1);
+    }
+}
+
+float
+EICPIDParticlev1::get_local_z(const int i) const
+{
+  switch(i)
+    {
+    case 0:
+      return  get_property_float(prop_local_z_0);
+    case 1:
+      return  get_property_float(prop_local_z_1);
+    default:
+      cout << "Invalid index in get_local_z: " << i << endl;
+      exit(1);
+    }
+}
+
+void
+EICPIDParticlev1::set_local_x(const int i, const float f)
+{
+  switch(i)
+    {
+    case 0:
+      set_property(prop_local_x_0,f);
+      return;
+    case 1:
+      set_property(prop_local_x_1,f);
+      return;
+    default:
+      cout << "Invalid index in set_local_x: " << i << endl;
+      exit(1);
+    }
+}
+
+void
+EICPIDParticlev1::set_local_y(const int i, const float f)
+{
+  switch(i)
+    {
+    case 0:
+      set_property(prop_local_y_0,f);
+      return;
+    case 1:
+      set_property(prop_local_y_1,f);
+      return;
+    default:
+      cout << "Invalid index in set_local_y: " << i << endl;
+      exit(1);
+    }
+}
+
+void
+EICPIDParticlev1::set_local_z(const int i, const float f)
+{
+  switch(i)
+    {
+    case 0:
+      set_property(prop_local_z_0,f);
+      return;
+    case 1:
+      set_property(prop_local_z_1,f);
+      return;
+    default:
+      cout << "Invalid index in set_local_z: " << i << endl;
+      exit(1);
+    }
+}
+
+void
+EICPIDParticlev1::identify(ostream& os) const
+{
+  os << "Class " << this->ClassName() << endl;
+  os << "hitid: 0x" << hex << hitid << dec << endl; 
+  os << "x0: " << get_x(0)
+       << ", y0: " << get_y(0)
+       << ", z0: " << get_z(0)
+       << ", t0: " << get_t(0) << endl;
+  os << "x1: " << get_x(1)
+       << ", y1: " << get_y(1)
+       << ", z1: " << get_z(1)
+       << ", t1: " << get_t(1) << endl;
+  os << "trackid: " << trackid << ", showerid: " << showerid
+       << ", edep: " << edep << endl;
+  for (prop_map_t::const_iterator i = prop_map.begin(); i!= prop_map.end(); ++i)
+    {
+      PROPERTY prop_id = static_cast<PROPERTY>(i->first);
+      pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+      os << "\t" << prop_id << ":\t" << property_info.first << " = \t";
+      switch(property_info.second)
+	{
+	case type_int:
+	  os << get_property_int(prop_id);
+	  break;
+	case type_uint:
+	  os << get_property_uint(prop_id);
+	  break;
+	case type_float:
+	  os << get_property_float(prop_id);
+	  break;
+	default:
+	  os << " unknown type ";
+	}
+      os <<endl;
+    }
+}

--- a/reconstruction/eicpidbase/EICPIDParticlev1.cc
+++ b/reconstruction/eicpidbase/EICPIDParticlev1.cc
@@ -26,7 +26,10 @@ void EICPIDParticlev1::Reset()
 void EICPIDParticlev1::identify(ostream& os) const
 {
   os << "Class " << this->ClassName();
-  os << " id: " << m_id << endl;
+  os << " id: " << m_id
+      <<", m_LogLikelyhoodMap.size() = "<<m_LogLikelyhoodMap.size()
+      <<", prop_map.size() = "<<prop_map.size()
+      << endl;
   for (const auto& pair : m_LogLikelyhoodMap)
   {
     const auto& key = pair.first;

--- a/reconstruction/eicpidbase/EICPIDParticlev1.cc
+++ b/reconstruction/eicpidbase/EICPIDParticlev1.cc
@@ -20,6 +20,44 @@ void EICPIDParticlev1::Reset()
 {
   m_id = -1;
   prop_map.clear();
+  m_LogLikelyhoodMap.clear();
+}
+
+void EICPIDParticlev1::identify(ostream& os) const
+{
+  os << "Class " << this->ClassName();
+  os << " id: " << m_id << endl;
+  for (const auto& pair : m_LogLikelyhoodMap)
+  {
+    const auto& key = pair.first;
+    const auto& LL = pair.second;
+
+    os << "\t"
+       << "PID Candidate " << key.first << " from detector ID " << key.second
+       << " " << EICPIDDefs::getPIDDetectorName(key.second);
+    os << " :\t LogLikelyhood = " << LL << endl;
+  }
+  for (prop_map_t::const_iterator i = prop_map.begin(); i != prop_map.end(); ++i)
+  {
+    PROPERTY prop_id = static_cast<PROPERTY>(i->first);
+    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    os << "\t" << prop_id << ":\t" << property_info.first << " = \t";
+    switch (property_info.second)
+    {
+    case type_int:
+      os << get_property_int(prop_id);
+      break;
+    case type_uint:
+      os << get_property_uint(prop_id);
+      break;
+    case type_float:
+      os << get_property_float(prop_id);
+      break;
+    default:
+      os << " unknown type ";
+    }
+    os << endl;
+  }
 }
 
 float EICPIDParticlev1::get_SumLogLikelyhood(EICPIDDefs::PIDCandidate pid) const
@@ -158,31 +196,4 @@ EICPIDParticlev1::get_property_nocheck(const PROPERTY prop_id) const
     return iter->second;
   }
   return UINT_MAX;
-}
-
-void EICPIDParticlev1::identify(ostream& os) const
-{
-  os << "Class " << this->ClassName();
-  os << " id: " << m_id << endl;
-  for (prop_map_t::const_iterator i = prop_map.begin(); i != prop_map.end(); ++i)
-  {
-    PROPERTY prop_id = static_cast<PROPERTY>(i->first);
-    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
-    os << "\t" << prop_id << ":\t" << property_info.first << " = \t";
-    switch (property_info.second)
-    {
-    case type_int:
-      os << get_property_int(prop_id);
-      break;
-    case type_uint:
-      os << get_property_uint(prop_id);
-      break;
-    case type_float:
-      os << get_property_float(prop_id);
-      break;
-    default:
-      os << " unknown type ";
-    }
-    os << endl;
-  }
 }

--- a/reconstruction/eicpidbase/EICPIDParticlev1.cc
+++ b/reconstruction/eicpidbase/EICPIDParticlev1.cc
@@ -27,9 +27,9 @@ void EICPIDParticlev1::identify(ostream& os) const
 {
   os << "Class " << this->ClassName();
   os << " id: " << m_id
-      <<", m_LogLikelyhoodMap.size() = "<<m_LogLikelyhoodMap.size()
-      <<", prop_map.size() = "<<prop_map.size()
-      << endl;
+     << ", m_LogLikelyhoodMap.size() = " << m_LogLikelyhoodMap.size()
+     << ", prop_map.size() = " << prop_map.size()
+     << endl;
   for (const auto& pair : m_LogLikelyhoodMap)
   {
     const auto& key = pair.first;

--- a/reconstruction/eicpidbase/EICPIDParticlev1.cc
+++ b/reconstruction/eicpidbase/EICPIDParticlev1.cc
@@ -22,6 +22,36 @@ void EICPIDParticlev1::Reset()
   prop_map.clear();
 }
 
+float EICPIDParticlev1::get_SumLogLikelyhood(EICPIDDefs::PIDCandidate pid) const
+{
+  float LL = 0;
+  for (const auto& pair : m_LogLikelyhoodMap)
+  {
+    if (pair.first.first == pid) LL += pair.second;
+  }
+  return LL;
+}
+
+float EICPIDParticlev1::get_LogLikelyhood(EICPIDDefs::PIDCandidate pid, EICPIDDefs::PIDDetector det) const
+{
+  if (det == EICPIDDefs::PIDAll) return get_SumLogLikelyhood(pid);
+
+  const LogLikelyhoodMapKey_t key(pid, det);
+  const auto iter = m_LogLikelyhoodMap.find(key);
+
+  if (iter == m_LogLikelyhoodMap.end())
+    return 0;
+  else
+    return iter->second;
+}
+
+void EICPIDParticlev1::set_LogLikelyhood(EICPIDDefs::PIDCandidate pid, EICPIDDefs::PIDDetector det, float LogLikelyhood)
+{
+  const LogLikelyhoodMapKey_t key(pid, det);
+
+  m_LogLikelyhoodMap[key] = LogLikelyhood;
+}
+
 bool EICPIDParticlev1::has_property(const PROPERTY prop_id) const
 {
   prop_map_t::const_iterator i = prop_map.find(prop_id);

--- a/reconstruction/eicpidbase/EICPIDParticlev1.h
+++ b/reconstruction/eicpidbase/EICPIDParticlev1.h
@@ -21,27 +21,9 @@ class EICPIDParticlev1 : public EICPIDParticle
   void identify(std::ostream& os = std::cout) const override;
   void Reset() override;
 
-  // The indices here represent the entry and exit points of the particle
-  float get_x(const int i) const override { return x[i]; }
-  float get_y(const int i) const override { return y[i]; }
-  float get_z(const int i) const override { return z[i]; }
-  float get_t(const int i) const override { return t[i]; }
-  float get_edep() const override { return edep; }
-  EICPIDDefs::keytype get_hit_id() const override { return hitid; }
-  int get_detid() const override;
-  int get_shower_id() const override { return showerid; }
-  int get_trkid() const override { return trackid; }
+  EICPIDDefs::keytype get_id() const override { return m_id; }
+  void set_id(const EICPIDDefs::keytype i) override { m_id = i; }
 
-  void set_x(const int i, const float f) override { x[i] = f; }
-  void set_y(const int i, const float f) override { y[i] = f; }
-  void set_z(const int i, const float f) override { z[i] = f; }
-  void set_t(const int i, const float f) override { t[i] = f; }
-  void set_edep(const float f) override { edep = f; }
-  void set_hit_id(const EICPIDDefs::keytype i) override { hitid = i; }
-  void set_shower_id(const int i) override { showerid = i; }
-  void set_trkid(const int i) override { trackid = i; }
-
-  void print() const override;
 
   bool has_property(const PROPERTY prop_id) const override;
   float get_property_float(const PROPERTY prop_id) const override;
@@ -51,63 +33,11 @@ class EICPIDParticlev1 : public EICPIDParticle
   void set_property(const PROPERTY prop_id, const int value) override;
   void set_property(const PROPERTY prop_id, const unsigned int value) override;
 
-  float get_px(const int i) const override;
-  float get_py(const int i) const override;
-  float get_pz(const int i) const override;
-  float get_local_x(const int i) const override;
-  float get_local_y(const int i) const override;
-  float get_local_z(const int i) const override;
-  float get_eion() const override { return get_property_float(prop_eion); }
-  float get_light_yield() const override { return get_property_float(prop_light_yield); }
-  float get_path_length() const override { return get_property_float(prop_path_length); }
-  unsigned int get_layer() const override { return get_property_uint(prop_layer); }
-  int get_scint_id() const override { return get_property_int(prop_scint_id); }
-  int get_row() const override { return get_property_int(prop_row); }
-  int get_strip_z_index() const override { return get_property_int(prop_strip_z_index); }
-  int get_strip_y_index() const override { return get_property_int(prop_strip_y_index); }
-  int get_ladder_z_index() const override { return get_property_int(prop_ladder_z_index); }
-  int get_ladder_phi_index() const override { return get_property_int(prop_ladder_phi_index); }
-  int get_index_i() const override { return get_property_int(prop_index_i); }
-  int get_index_j() const override { return get_property_int(prop_index_j); }
-  int get_index_k() const override { return get_property_int(prop_index_k); }
-  int get_index_l() const override { return get_property_int(prop_index_l); }
-  int get_hit_type() const override { return get_property_int(prop_hit_type); }
-
-  void set_px(const int i, const float f) override;
-  void set_py(const int i, const float f) override;
-  void set_pz(const int i, const float f) override;
-  void set_local_x(const int i, const float f) override;
-  void set_local_y(const int i, const float f) override;
-  void set_local_z(const int i, const float f) override;
-  void set_eion(const float f) override { set_property(prop_eion, f); }
-  void set_light_yield(const float f) override { set_property(prop_light_yield, f); }
-  void set_path_length(const float f) override { set_property(prop_path_length, f); }
-  void set_layer(const unsigned int i) override { set_property(prop_layer, i); }
-  void set_scint_id(const int i) override { set_property(prop_scint_id, i); }
-  void set_row(const int i) override { set_property(prop_row, i); }
-  void set_strip_z_index(const int i) override { set_property(prop_strip_z_index, i); }
-  void set_strip_y_index(const int i) override { set_property(prop_strip_y_index, i); }
-  void set_ladder_z_index(const int i) override { set_property(prop_ladder_z_index, i); }
-  void set_ladder_phi_index(const int i) override { set_property(prop_ladder_phi_index, i); }
-  void set_index_i(const int i) override { set_property(prop_index_i, i); }
-  void set_index_j(const int i) override { set_property(prop_index_j, i); }
-  void set_index_k(const int i) override { set_property(prop_index_k, i); }
-  void set_index_l(const int i) override { set_property(prop_index_l, i); }
-  void set_hit_type(const int i) override { set_property(prop_hit_type, i); }
-
  protected:
   unsigned int get_property_nocheck(const PROPERTY prop_id) const override;
   void set_property_nocheck(const PROPERTY prop_id, const unsigned int ui) override { prop_map[prop_id] = ui; }
-  // Store both the entry and exit points of the particle
-  // Remember, particles do not always enter on the inner edge!
-  float x[2] = {NAN, NAN};
-  float y[2] = {NAN, NAN};
-  float z[2] = {NAN, NAN};
-  float t[2] = {NAN, NAN};
-  EICPIDDefs::keytype hitid = ULONG_LONG_MAX;
-  int trackid = INT_MIN;
-  int showerid = INT_MIN;
-  float edep = NAN;
+
+  EICPIDDefs::keytype m_id = -1;
 
   //! storage types for additional property
   typedef uint8_t prop_id_t;

--- a/reconstruction/eicpidbase/EICPIDParticlev1.h
+++ b/reconstruction/eicpidbase/EICPIDParticlev1.h
@@ -1,4 +1,4 @@
-// Tell emacs that this is a C++ source
+// TeLogLikelyhood emacs that this is a C++ source
 //  -*- C++ -*-.
 #ifndef EICPID_EICPIDParticleV1_H
 #define EICPID_EICPIDParticleV1_H
@@ -24,6 +24,9 @@ class EICPIDParticlev1 : public EICPIDParticle
   EICPIDDefs::keytype get_id() const override { return m_id; }
   void set_id(const EICPIDDefs::keytype i) override { m_id = i; }
 
+  float get_SumLogLikelyhood(EICPIDDefs::PIDCandidate pid) const override;
+  float get_LogLikelyhood(EICPIDDefs::PIDCandidate pid, EICPIDDefs::PIDDetector det) const override;
+  void set_LogLikelyhood(EICPIDDefs::PIDCandidate pid, EICPIDDefs::PIDDetector det, float LogLikelyhood) override;
 
   bool has_property(const PROPERTY prop_id) const override;
   float get_property_float(const PROPERTY prop_id) const override;
@@ -72,6 +75,9 @@ class EICPIDParticlev1 : public EICPIDParticle
 
   //! container for additional property
   prop_map_t prop_map;
+
+  typedef std::pair<EICPIDDefs::PIDCandidate, EICPIDDefs::PIDDetector> LogLikelyhoodMapKey_t;
+  std::map<LogLikelyhoodMapKey_t, float> m_LogLikelyhoodMap;
 
   ClassDefOverride(EICPIDParticlev1, 2)
 };

--- a/reconstruction/eicpidbase/EICPIDParticlev1.h
+++ b/reconstruction/eicpidbase/EICPIDParticlev1.h
@@ -79,7 +79,7 @@ class EICPIDParticlev1 : public EICPIDParticle
   typedef std::pair<EICPIDDefs::PIDCandidate, EICPIDDefs::PIDDetector> LogLikelyhoodMapKey_t;
   std::map<LogLikelyhoodMapKey_t, float> m_LogLikelyhoodMap;
 
-  ClassDefOverride(EICPIDParticlev1, 2)
+  ClassDefOverride(EICPIDParticlev1, 1)
 };
 
 #endif

--- a/reconstruction/eicpidbase/EICPIDParticlev1.h
+++ b/reconstruction/eicpidbase/EICPIDParticlev1.h
@@ -48,7 +48,8 @@ class EICPIDParticlev1 : public EICPIDParticle
   typedef std::map<prop_id_t, prop_storage_t> prop_map_t;
 
   //! convert between 32bit inputs and storage type prop_storage_t
-  union u_property {
+  union u_property
+  {
     float fdata;
     int32_t idata;
     uint32_t uidata;

--- a/reconstruction/eicpidbase/EICPIDParticlev1.h
+++ b/reconstruction/eicpidbase/EICPIDParticlev1.h
@@ -1,0 +1,149 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef EICPID_EICPIDParticleV1_H
+#define EICPID_EICPIDParticleV1_H
+
+#include <climits>  // for INT_MIN, ULONG_LONG_MAX
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <map>
+
+#include "EICPIDDefs.h"
+#include "EICPIDParticle.h"
+
+class EICPIDParticlev1 : public EICPIDParticle
+{
+ public:
+  EICPIDParticlev1() = default;
+  explicit EICPIDParticlev1(const EICPIDParticle* g4hit);
+  ~EICPIDParticlev1() override = default;
+  void identify(std::ostream& os = std::cout) const override;
+  void Reset() override;
+
+  // The indices here represent the entry and exit points of the particle
+  float get_x(const int i) const override { return x[i]; }
+  float get_y(const int i) const override { return y[i]; }
+  float get_z(const int i) const override { return z[i]; }
+  float get_t(const int i) const override { return t[i]; }
+  float get_edep() const override { return edep; }
+  EICPIDDefs::keytype get_hit_id() const override { return hitid; }
+  int get_detid() const override;
+  int get_shower_id() const override { return showerid; }
+  int get_trkid() const override { return trackid; }
+
+  void set_x(const int i, const float f) override { x[i] = f; }
+  void set_y(const int i, const float f) override { y[i] = f; }
+  void set_z(const int i, const float f) override { z[i] = f; }
+  void set_t(const int i, const float f) override { t[i] = f; }
+  void set_edep(const float f) override { edep = f; }
+  void set_hit_id(const EICPIDDefs::keytype i) override { hitid = i; }
+  void set_shower_id(const int i) override { showerid = i; }
+  void set_trkid(const int i) override { trackid = i; }
+
+  void print() const override;
+
+  bool has_property(const PROPERTY prop_id) const override;
+  float get_property_float(const PROPERTY prop_id) const override;
+  int get_property_int(const PROPERTY prop_id) const override;
+  unsigned int get_property_uint(const PROPERTY prop_id) const override;
+  void set_property(const PROPERTY prop_id, const float value) override;
+  void set_property(const PROPERTY prop_id, const int value) override;
+  void set_property(const PROPERTY prop_id, const unsigned int value) override;
+
+  float get_px(const int i) const override;
+  float get_py(const int i) const override;
+  float get_pz(const int i) const override;
+  float get_local_x(const int i) const override;
+  float get_local_y(const int i) const override;
+  float get_local_z(const int i) const override;
+  float get_eion() const override { return get_property_float(prop_eion); }
+  float get_light_yield() const override { return get_property_float(prop_light_yield); }
+  float get_path_length() const override { return get_property_float(prop_path_length); }
+  unsigned int get_layer() const override { return get_property_uint(prop_layer); }
+  int get_scint_id() const override { return get_property_int(prop_scint_id); }
+  int get_row() const override { return get_property_int(prop_row); }
+  int get_strip_z_index() const override { return get_property_int(prop_strip_z_index); }
+  int get_strip_y_index() const override { return get_property_int(prop_strip_y_index); }
+  int get_ladder_z_index() const override { return get_property_int(prop_ladder_z_index); }
+  int get_ladder_phi_index() const override { return get_property_int(prop_ladder_phi_index); }
+  int get_index_i() const override { return get_property_int(prop_index_i); }
+  int get_index_j() const override { return get_property_int(prop_index_j); }
+  int get_index_k() const override { return get_property_int(prop_index_k); }
+  int get_index_l() const override { return get_property_int(prop_index_l); }
+  int get_hit_type() const override { return get_property_int(prop_hit_type); }
+
+  void set_px(const int i, const float f) override;
+  void set_py(const int i, const float f) override;
+  void set_pz(const int i, const float f) override;
+  void set_local_x(const int i, const float f) override;
+  void set_local_y(const int i, const float f) override;
+  void set_local_z(const int i, const float f) override;
+  void set_eion(const float f) override { set_property(prop_eion, f); }
+  void set_light_yield(const float f) override { set_property(prop_light_yield, f); }
+  void set_path_length(const float f) override { set_property(prop_path_length, f); }
+  void set_layer(const unsigned int i) override { set_property(prop_layer, i); }
+  void set_scint_id(const int i) override { set_property(prop_scint_id, i); }
+  void set_row(const int i) override { set_property(prop_row, i); }
+  void set_strip_z_index(const int i) override { set_property(prop_strip_z_index, i); }
+  void set_strip_y_index(const int i) override { set_property(prop_strip_y_index, i); }
+  void set_ladder_z_index(const int i) override { set_property(prop_ladder_z_index, i); }
+  void set_ladder_phi_index(const int i) override { set_property(prop_ladder_phi_index, i); }
+  void set_index_i(const int i) override { set_property(prop_index_i, i); }
+  void set_index_j(const int i) override { set_property(prop_index_j, i); }
+  void set_index_k(const int i) override { set_property(prop_index_k, i); }
+  void set_index_l(const int i) override { set_property(prop_index_l, i); }
+  void set_hit_type(const int i) override { set_property(prop_hit_type, i); }
+
+ protected:
+  unsigned int get_property_nocheck(const PROPERTY prop_id) const override;
+  void set_property_nocheck(const PROPERTY prop_id, const unsigned int ui) override { prop_map[prop_id] = ui; }
+  // Store both the entry and exit points of the particle
+  // Remember, particles do not always enter on the inner edge!
+  float x[2] = {NAN, NAN};
+  float y[2] = {NAN, NAN};
+  float z[2] = {NAN, NAN};
+  float t[2] = {NAN, NAN};
+  EICPIDDefs::keytype hitid = ULONG_LONG_MAX;
+  int trackid = INT_MIN;
+  int showerid = INT_MIN;
+  float edep = NAN;
+
+  //! storage types for additional property
+  typedef uint8_t prop_id_t;
+  typedef uint32_t prop_storage_t;
+  typedef std::map<prop_id_t, prop_storage_t> prop_map_t;
+
+  //! convert between 32bit inputs and storage type prop_storage_t
+  union u_property {
+    float fdata;
+    int32_t idata;
+    uint32_t uidata;
+
+    u_property(int32_t in)
+      : idata(in)
+    {
+    }
+    u_property(uint32_t in)
+      : uidata(in)
+    {
+    }
+    u_property(float in)
+      : fdata(in)
+    {
+    }
+    u_property()
+      : uidata(0)
+    {
+    }
+
+    prop_storage_t get_storage() const { return uidata; }
+  };
+
+  //! container for additional property
+  prop_map_t prop_map;
+
+  ClassDefOverride(EICPIDParticlev1, 2)
+};
+
+#endif

--- a/reconstruction/eicpidbase/EICPIDParticlev1LinkDef.h
+++ b/reconstruction/eicpidbase/EICPIDParticlev1LinkDef.h
@@ -1,8 +1,8 @@
 #ifdef __CINT__
 
-#pragma link C++ class std::pair<EICPIDDefs::PIDCandidate, EICPIDDefs::PIDDetector> +;
-#pragma link C++ class std::pair<std::pair<EICPIDDefs::PIDCandidate, EICPIDDefs::PIDDetector>, float> +;
-#pragma link C++ class std::map<std::pair<EICPIDDefs::PIDCandidate, EICPIDDefs::PIDDetector>, float> +;
-#pragma link C++ class EICPIDParticlev1 +;
+#pragma link C++ class std::pair < EICPIDDefs::PIDCandidate, EICPIDDefs::PIDDetector> + ;
+#pragma link C++ class std::pair < std::pair < EICPIDDefs::PIDCandidate, EICPIDDefs::PIDDetector>, float> + ;
+#pragma link C++ class std::map < std::pair < EICPIDDefs::PIDCandidate, EICPIDDefs::PIDDetector>, float> + ;
+#pragma link C++ class EICPIDParticlev1 + ;
 
 #endif /* __CINT__ */

--- a/reconstruction/eicpidbase/EICPIDParticlev1LinkDef.h
+++ b/reconstruction/eicpidbase/EICPIDParticlev1LinkDef.h
@@ -1,5 +1,8 @@
 #ifdef __CINT__
 
-#pragma link C++ class EICPIDParticlev1+;
+#pragma link C++ class std::pair<EICPIDDefs::PIDCandidate, EICPIDDefs::PIDDetector> +;
+#pragma link C++ class std::pair<std::pair<EICPIDDefs::PIDCandidate, EICPIDDefs::PIDDetector>, float> +;
+#pragma link C++ class std::map<std::pair<EICPIDDefs::PIDCandidate, EICPIDDefs::PIDDetector>, float> +;
+#pragma link C++ class EICPIDParticlev1 +;
 
 #endif /* __CINT__ */

--- a/reconstruction/eicpidbase/EICPIDParticlev1LinkDef.h
+++ b/reconstruction/eicpidbase/EICPIDParticlev1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class EICPIDParticlev1+;
+
+#endif /* __CINT__ */

--- a/reconstruction/eicpidbase/Makefile.am
+++ b/reconstruction/eicpidbase/Makefile.am
@@ -29,7 +29,6 @@ libeicpidbase_la_SOURCES = \ \
 libeicpidbase_la_LIBADD = \
   -lphool  
 
-
 ROOTDICTS = \
   EICPIDParticle_Dict.cc \
   EICPIDParticleContainer_Dict.cc \

--- a/reconstruction/eicpidbase/Makefile.am
+++ b/reconstruction/eicpidbase/Makefile.am
@@ -1,0 +1,68 @@
+AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include \
+  -I$(ROOTSYS)/include
+
+AM_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
+  -L$(OFFLINE_MAIN)/lib64
+
+pkginclude_HEADERS = \
+	EICPIDDefs.h \
+	EICPIDParticle.h \
+	EICPIDParticleContainer.h \
+	EICPIDParticlev1.h 
+
+lib_LTLIBRARIES = \
+  libeicpidbase.la
+
+libeicpidbase_la_SOURCES = \ \
+  $(ROOTDICTS) \
+	EICPIDDefs.cc \
+	EICPIDParticle.cc \
+	EICPIDParticleContainer.cc \
+	EICPIDParticlev1.cc
+
+libeicpidbase_la_LIBADD = \
+  -lphool  
+
+
+ROOTDICTS = \
+  EICPIDParticle_Dict.cc \
+  EICPIDParticleContainer_Dict.cc \
+  EICPIDParticlev1_Dict.cc
+
+pcmdir = $(libdir)
+nobase_dist_pcm_DATA = \
+  EICPIDParticle_Dict_rdict.pcm \
+  EICPIDParticleContainer_Dict_rdict.pcm \
+  EICPIDParticlev1_Dict_rdict.pcm
+
+
+# Rule for generating table CINT dictionaries.
+%_Dict.cc: %.h %LinkDef.h
+	rootcint -f $@ @CINTDEFS@ $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
+
+#just to get the dependency
+%_Dict_rdict.pcm: %_Dict.cc ;
+
+BUILT_SOURCES = testexternals.cc
+
+noinst_PROGRAMS = \
+  testexternals
+
+testexternals_SOURCES = testexternals.cc
+testexternals_LDADD   = libeicpidbase.la
+
+testexternals.cc:
+	echo "//*** this is a generated file. Do not commit, do not edit" > $@
+	echo "int main()" >> $@
+	echo "{" >> $@
+	echo "  return 0;" >> $@
+	echo "}" >> $@
+
+clean-local:
+	rm -f *Dict* $(BUILT_SOURCES) *.pcm

--- a/reconstruction/eicpidbase/autogen.sh
+++ b/reconstruction/eicpidbase/autogen.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(cd $srcdir; aclocal -I ${OFFLINE_MAIN}/share;\
+libtoolize --force; automake -a --add-missing; autoconf)
+
+$srcdir/configure  "$@"

--- a/reconstruction/eicpidbase/configure.ac
+++ b/reconstruction/eicpidbase/configure.ac
@@ -1,0 +1,21 @@
+AC_INIT(eicpidbase,[1.00])
+AC_CONFIG_SRCDIR([configure.ac])
+
+AM_INIT_AUTOMAKE
+AC_PROG_CXX(CC g++)
+LT_INIT([disable-static])
+
+case $CXX in
+ clang++)
+  CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wextra"
+ ;;
+ *g++)
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic -Wextra"
+ ;;
+esac
+
+CINTDEFS=" -noIncludePaths  -inlineInputHeader "
+AC_SUBST(CINTDEFS)
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/simulation/g4simulation/g4eicdirc/G4DIRCTree.cc
+++ b/simulation/g4simulation/g4eicdirc/G4DIRCTree.cc
@@ -3,22 +3,22 @@
 #include "PrtHit.h"
 
 #include <g4main/PHG4Hit.h>
-#include <g4main/PHG4HitContainer.h>        // for PHG4HitContainer, PHG4Hit...
+#include <g4main/PHG4HitContainer.h>  // for PHG4HitContainer, PHG4Hit...
 #include <g4main/PHG4Particle.h>
 #include <g4main/PHG4TruthInfoContainer.h>
 
-#include <fun4all/SubsysReco.h>             // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/getClass.h>
 
 #include <TFile.h>
 #include <TTree.h>
 
-#include <cmath>                           // for atan2, sqrt
-#include <cstring>                         // for strcmp
-#include <iostream>                         // for ostringstream, operator<<
+#include <cmath>     // for atan2, sqrt
+#include <cstring>   // for strcmp
+#include <iostream>  // for ostringstream, operator<<
 #include <sstream>
-#include <utility>                          // for pair
+#include <utility>  // for pair
 
 G4DIRCTree::G4DIRCTree(const std::string &name, const std::string &filename)
   : SubsysReco(name)
@@ -36,7 +36,7 @@ int G4DIRCTree::Init(PHCompositeNode *)
   g4tree->SetAutoSave(1000000);
 
   std::cout << "Initialize Geant 4 Tree ... << " << std::endl;
- 
+
   /// Event level
   g4tree->Branch("momentum", &mG4EvtTree.momentum, "p/D");
   g4tree->Branch("theta", &mG4EvtTree.theta, "theta/D");
@@ -64,8 +64,8 @@ int G4DIRCTree::Init(PHCompositeNode *)
 
   g4tree->Branch("mcp_id", mG4EvtTree.mcp_id, "mcp_id[nhits]/I");
   g4tree->Branch("pixel_id", mG4EvtTree.pixel_id, "pixel_id[nhits]/I");
-  g4tree->Branch("lead_time", mG4EvtTree.lead_time,"lead_time[nhits]/D");
-  g4tree->Branch("wavelength", mG4EvtTree.wavelength,"wavelength[nhits]/D");
+  g4tree->Branch("lead_time", mG4EvtTree.lead_time, "lead_time[nhits]/D");
+  g4tree->Branch("wavelength", mG4EvtTree.wavelength, "wavelength[nhits]/D");
   g4tree->Branch("hit_pathId", mG4EvtTree.hit_pathId, "hit_pathId[nhits]/L");
   g4tree->Branch("nrefl", mG4EvtTree.nrefl, "nrefl[nhits]/I");
 
@@ -76,7 +76,6 @@ int G4DIRCTree::Init(PHCompositeNode *)
   g4tree->Branch("hit_pos", mG4EvtTree.hit_pos, "hit_pos[nhits][3]/D");
   //g4tree->Branch("track_mom_bar", mG4EvtTree.track_mom_bar, "track_mom_bar[nhits][3]/D");
   //g4tree->Branch("track_hit_pos_bar", mG4EvtTree.track_hit_pos_bar, "track_hit_pos_bar[nhits][3]/D");
-
 
   return 0;
 }
@@ -109,8 +108,7 @@ int G4DIRCTree::process_event(PHCompositeNode *topNode)
       mG4EvtTree.track_mom_bar[i] = bar_vectors::get_p_bar()[evt_num](i);
       mG4EvtTree.track_hit_pos_bar[i] = bar_vectors::get_pos_bar()[evt_num](i);
       }*/
-  
-  	  
+
   int nhits = 0;
 
   std::ostringstream nodename;
@@ -123,11 +121,10 @@ int G4DIRCTree::process_event(PHCompositeNode *topNode)
     nodename << "G4HIT_" << *iter;
     PHG4HitContainer *hits = findNode::getClass<PHG4HitContainer>(topNode, nodename.str());
 
-    if (!strcmp("G4HIT_DIRC", nodename.str().c_str())) // DIRC
-      {
-	process_hit(hits, "G4HIT_DIRC", detid, nhits);
-      }
-	
+    if (!strcmp("G4HIT_DIRC", nodename.str().c_str()))  // DIRC
+    {
+      process_hit(hits, "G4HIT_DIRC", detid, nhits);
+    }
   }
 
   mG4EvtTree.nhits = nhits;
@@ -159,16 +156,16 @@ void G4DIRCTree::AddNode(const std::string &name, const int detid)
 int G4DIRCTree::process_hit(PHG4HitContainer *hits, const std::string &dName, int detid, int &nhits)
 {
   if (hits)
-  {   
+  {
     PHG4HitContainer::ConstRange hit_range_0 = hits->getHits();
     for (PHG4HitContainer::ConstIterator hit_iter_0 = hit_range_0.first; hit_iter_0 != hit_range_0.second; hit_iter_0++)
     {
-      PrtHit *dirc_hit = dynamic_cast<PrtHit*>(hit_iter_0->second);
+      PrtHit *dirc_hit = dynamic_cast<PrtHit *>(hit_iter_0->second);
 
       mG4EvtTree.detid[nhits] = detid;
       mG4EvtTree.hitid[nhits] = dirc_hit->get_hit_id();
       mG4EvtTree.trkid[nhits] = dirc_hit->get_trkid();
-      
+
       mG4EvtTree.x0[nhits] = dirc_hit->get_x(0);
       mG4EvtTree.y0[nhits] = dirc_hit->get_y(0);
       mG4EvtTree.z0[nhits] = dirc_hit->get_z(0);
@@ -184,19 +181,17 @@ int G4DIRCTree::process_hit(PHG4HitContainer *hits, const std::string &dName, in
       mG4EvtTree.hit_pathId[nhits] = dirc_hit->GetPathInPrizm();
       mG4EvtTree.nrefl[nhits] = dirc_hit->GetNreflectionsInPrizm();
 
-      for(int i=0; i < 3; i++)
-        {
-          mG4EvtTree.hit_globalPos[nhits][i] = dirc_hit->GetGlobalPos()(i);
-          mG4EvtTree.hit_localPos[nhits][i] = dirc_hit->GetLocalPos()(i);
-          mG4EvtTree.hit_digiPos[nhits][i] = dirc_hit->GetDigiPos()(i);
-          mG4EvtTree.hit_mom[nhits][i] = dirc_hit->GetMomentum()(i);
-          mG4EvtTree.hit_pos[nhits][i] = dirc_hit->GetPosition()(i);	    
-	  
-	}
-      
-      nhits++;
+      for (int i = 0; i < 3; i++)
+      {
+        mG4EvtTree.hit_globalPos[nhits][i] = dirc_hit->GetGlobalPos()(i);
+        mG4EvtTree.hit_localPos[nhits][i] = dirc_hit->GetLocalPos()(i);
+        mG4EvtTree.hit_digiPos[nhits][i] = dirc_hit->GetDigiPos()(i);
+        mG4EvtTree.hit_mom[nhits][i] = dirc_hit->GetMomentum()(i);
+        mG4EvtTree.hit_pos[nhits][i] = dirc_hit->GetPosition()(i);
       }
 
+      nhits++;
+    }
 
     /*PHG4HitContainer::ConstRange hit_range_1 = hits->getHits();
     for (PHG4HitContainer::ConstIterator hit_iter_1 = hit_range_1.first; hit_iter_1 != hit_range_1.second; hit_iter_1++)
@@ -213,7 +208,6 @@ int G4DIRCTree::process_hit(PHG4HitContainer *hits, const std::string &dName, in
 
 	nhits++;
 	}*/
-
   }
 
   return 0;

--- a/simulation/g4simulation/g4eicdirc/G4DIRCTree.h
+++ b/simulation/g4simulation/g4eicdirc/G4DIRCTree.h
@@ -5,10 +5,10 @@
 
 #include <fun4all/SubsysReco.h>
 
+#include <TVector3.h>
 #include <map>
 #include <set>
 #include <string>
-#include <TVector3.h>
 
 // Forward declarations
 class PHCompositeNode;

--- a/simulation/g4simulation/g4eicdirc/G4EicDircDetector.cc
+++ b/simulation/g4simulation/g4eicdirc/G4EicDircDetector.cc
@@ -10,32 +10,31 @@
 
 #include <Geant4/G4AssemblyVolume.hh>
 #include <Geant4/G4Box.hh>
+#include <Geant4/G4Colour.hh>
 #include <Geant4/G4Cons.hh>
-#include <Geant4/G4Trd.hh>
+#include <Geant4/G4Element.hh>
 #include <Geant4/G4IntersectionSolid.hh>
+#include <Geant4/G4LogicalBorderSurface.hh>
+#include <Geant4/G4LogicalSkinSurface.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
+#include <Geant4/G4OpticalSurface.hh>
 #include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4ProcessManager.hh>
 #include <Geant4/G4RotationMatrix.hh>
+#include <Geant4/G4RunManager.hh>
 #include <Geant4/G4Sphere.hh>
 #include <Geant4/G4SubtractionSolid.hh>
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4ThreeVector.hh>
-#include <Geant4/G4Trap.hh>
-#include <Geant4/G4Tubs.hh>
-#include <Geant4/G4Element.hh>
-#include <Geant4/G4LogicalBorderSurface.hh>
-#include <Geant4/G4LogicalSkinSurface.hh>
-#include <Geant4/G4OpticalSurface.hh>
-#include <Geant4/G4UnionSolid.hh>
 #include <Geant4/G4Transform3D.hh>
-#include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4RunManager.hh>
-#include <Geant4/G4Colour.hh>
-#include <Geant4/G4VisAttributes.hh>
+#include <Geant4/G4Trap.hh>
+#include <Geant4/G4Trd.hh>
+#include <Geant4/G4Tubs.hh>
 #include <Geant4/G4UImanager.hh>
+#include <Geant4/G4UnionSolid.hh>
 #include <Geant4/G4VUserDetectorConstruction.hh>
-#include <Geant4/G4ProcessManager.hh>
+#include <Geant4/G4VisAttributes.hh>
 
 #include <cmath>
 #include <iostream>  // for operator<<, endl, bas...
@@ -43,38 +42,37 @@
 class G4VSolid;
 class PHCompositeNode;
 
-G4EicDircDetector::G4EicDircDetector(PHG4Subsystem *subsys,
-                                     PHCompositeNode *Node,
-                                     PHParameters *parameters,
-                                     const std::string &dnam)
+G4EicDircDetector::G4EicDircDetector(PHG4Subsystem* subsys,
+                                     PHCompositeNode* Node,
+                                     PHParameters* parameters,
+                                     const std::string& dnam)
   : PHG4Detector(subsys, Node, dnam)
   , m_Params(parameters)
-  , m_DisplayAction(dynamic_cast<G4EicDircDisplayAction *>(subsys->GetDisplayAction()))
+  , m_DisplayAction(dynamic_cast<G4EicDircDisplayAction*>(subsys->GetDisplayAction()))
 {
 }
 
 //_______________________________________________________________
 
-int G4EicDircDetector::IsInDetector(G4VPhysicalVolume *volume) const
-{ 
+int G4EicDircDetector::IsInDetector(G4VPhysicalVolume* volume) const
+{
   /*std::map<G4VPhysicalVolume *, int>::const_iterator iter = m_PhysicalVolumes_active.find(volume);
   if(iter != m_PhysicalVolumes_active.end())
     {
       return iter->second;
       }*/
-  if(!volume) return 0;
-  std::map<G4LogicalVolume *, int>::const_iterator iter = m_LogicalVolumes_active.find(volume->GetLogicalVolume());
-  
-  if(iter != m_LogicalVolumes_active.end())
-    {
-      return iter->second;
-    }
-  
+  if (!volume) return 0;
+  std::map<G4LogicalVolume*, int>::const_iterator iter = m_LogicalVolumes_active.find(volume->GetLogicalVolume());
+
+  if (iter != m_LogicalVolumes_active.end())
+  {
+    return iter->second;
+  }
+
   return 0;
 }
 
-
-void G4EicDircDetector::ConstructMe(G4LogicalVolume *logicWorld)
+void G4EicDircDetector::ConstructMe(G4LogicalVolume* logicWorld)
 {
   // ---------- DIRC supoort stucture ---------------
 
@@ -292,28 +290,27 @@ void G4EicDircDetector::ConstructMe(G4LogicalVolume *logicWorld)
 	}
 	}*/
 
-
   // -------------- DIRC ----------------------
 
   fGeomType = m_Params->get_int_param("Geom_type");
-  fLensId = m_Params->get_int_param("Lens_id"); 
+  fLensId = m_Params->get_int_param("Lens_id");
   fNBar = m_Params->get_double_param("NBars");
 
-  if (Verbosity ()) std::cout << "Nbars = " << fNBar << std::endl;
+  if (Verbosity()) std::cout << "Nbars = " << fNBar << std::endl;
 
   fNRow = m_Params->get_int_param("MCP_rows");
   fNCol = m_Params->get_int_param("MCP_columns");
 
   fPrizm[0] = m_Params->get_double_param("Prizm_width");
-  fPrizm[1] = m_Params->get_double_param("Prizm_length"); 
+  fPrizm[1] = m_Params->get_double_param("Prizm_length");
   fPrizm[3] = m_Params->get_double_param("Prizm_height_at_lens");
-  fPrizm[2]= fPrizm[3] + (fPrizm[1]*tan(32*deg));
-  
-  fBar[0] = fBarL[0] = fBarS[0] = m_Params->get_double_param("Bar_thickness"); 
-  fBar[1] = fBarL[1] = fBarS[1] = m_Params->get_double_param("Bar_width"); 
+  fPrizm[2] = fPrizm[3] + (fPrizm[1] * tan(32 * deg));
+
+  fBar[0] = fBarL[0] = fBarS[0] = m_Params->get_double_param("Bar_thickness");
+  fBar[1] = fBarL[1] = fBarS[1] = m_Params->get_double_param("Bar_width");
   fBarL[2] = m_Params->get_double_param("BarL_length");
   fBarS[2] = m_Params->get_double_param("BarS_length");
-  
+
   fNBoxes = m_Params->get_int_param("NBoxes");
   fRadius = m_Params->get_double_param("Radius");
   zshift = m_Params->get_double_param("z_shift");
@@ -321,41 +318,56 @@ void G4EicDircDetector::ConstructMe(G4LogicalVolume *logicWorld)
   //-------------------
 
   fBarsGap = 0.15;
-  
-  if (Verbosity ()) std::cout << "Nbarboxes = "<< fNBoxes << std::endl;
-  if (Verbosity ()) std::cout << "barrel radius = " << fRadius << " mm" << std::endl;
-  
-  fMirror[0] = m_Params->get_double_param("Mirror_height"); 
-  fMirror[1] = fPrizm[0]; fMirror[2] =1;
-  
-  fMcpTotal[0] = fMcpTotal[1] = 53+4; fMcpTotal[2]=1;
-  fMcpActive[0] = fMcpActive[1] = 53; fMcpActive[2]=1;
-  fLens[0] = fLens[1] = 40; fLens[2]=10;
-  
+
+  if (Verbosity()) std::cout << "Nbarboxes = " << fNBoxes << std::endl;
+  if (Verbosity()) std::cout << "barrel radius = " << fRadius << " mm" << std::endl;
+
+  fMirror[0] = m_Params->get_double_param("Mirror_height");
+  fMirror[1] = fPrizm[0];
+  fMirror[2] = 1;
+
+  fMcpTotal[0] = fMcpTotal[1] = 53 + 4;
+  fMcpTotal[2] = 1;
+  fMcpActive[0] = fMcpActive[1] = 53;
+  fMcpActive[2] = 1;
+  fLens[0] = fLens[1] = 40;
+  fLens[2] = 10;
+
   fBoxWidth = fPrizm[0];
 
-  if(fGeomType == 1)  fNBoxes = 1;
+  if (fGeomType == 1) fNBoxes = 1;
 
-  fFd[0] = fBoxWidth; fFd[1]=fPrizm[2]; fFd[2] =1;
+  fFd[0] = fBoxWidth;
+  fFd[1] = fPrizm[2];
+  fFd[2] = 1;
 
-  
-  if(fLensId == 0 || fLensId==10){
-    fLens[2] =0;
+  if (fLensId == 0 || fLensId == 10)
+  {
+    fLens[2] = 0;
   }
-  if(fLensId == 2){
-    fLens[0] = fPrizm[3]; fLens[1] = 175; fLens[2]=14.4;
+  if (fLensId == 2)
+  {
+    fLens[0] = fPrizm[3];
+    fLens[1] = 175;
+    fLens[2] = 14.4;
   }
-  if(fLensId == 3){
-    fLens[0] = fPrizm[3]; fLens[1] = fPrizm[0]/fNBar; fLens[2]=15;
-    if(fNBar==1)  fLens[1] = fPrizm[0]/11.;
+  if (fLensId == 3)
+  {
+    fLens[0] = fPrizm[3];
+    fLens[1] = fPrizm[0] / fNBar;
+    fLens[2] = 15;
+    if (fNBar == 1) fLens[1] = fPrizm[0] / 11.;
   }
 
-  if(fLensId == 6){
-    fLens[0] = fPrizm[3]; fLens[1] = fPrizm[0]; fLens[2]=12;
-  }  
+  if (fLensId == 6)
+  {
+    fLens[0] = fPrizm[3];
+    fLens[1] = fPrizm[0];
+    fLens[2] = 12;
+  }
 
   fPrtRot = new G4RotationMatrix();
-  
+
   //-------------------------
   DefineMaterials();
 
@@ -364,21 +376,21 @@ void G4EicDircDetector::ConstructMe(G4LogicalVolume *logicWorld)
   double gluethickness = 0.05;
   int nparts = m_Params->get_int_param("Bar_pieces");
 
-  double dirclength = fBarL[2]*(nparts-1) + fBarS[2] + gluethickness*nparts;
+  double dirclength = fBarL[2] * (nparts - 1) + fBarS[2] + gluethickness * nparts;
 
   // The DIRC
   //G4Box* gDirc = new G4Box("gDirc",205.962, 193.251, 0.5*dirclength+314.565);
   //lDirc = new G4LogicalVolume(gDirc,defaultMaterial,"lDirc",0,0,0);
 
-  G4Box* gFd = new G4Box("gFd",0.5*fFd[1],0.5*fFd[0],0.5*fFd[2]);
-  lFd = new G4LogicalVolume(gFd,defaultMaterial,"lFd",0,0,0);
+  G4Box* gFd = new G4Box("gFd", 0.5 * fFd[1], 0.5 * fFd[0], 0.5 * fFd[2]);
+  lFd = new G4LogicalVolume(gFd, defaultMaterial, "lFd", 0, 0, 0);
   m_LogicalVolumes_active[lFd] = 1;
 
-  double dphi = 360*deg/(double)fNBoxes;  
+  double dphi = 360 * deg / (double) fNBoxes;
   //G4VPhysicalVolume* phy;
 
   G4AssemblyVolume* assemblySector = new G4AssemblyVolume();
- 
+
   /*for(int i=0; i<fNBoxes; i++){
       double tphi = dphi*i; 
       double dx = fRadius * cos(tphi);
@@ -391,137 +403,141 @@ void G4EicDircDetector::ConstructMe(G4LogicalVolume *logicWorld)
       assemblySector->MakeImprint(logicWorld, g4vec_sector_pos, tRot, i, OverlapCheck());
       //m_PhysicalVolumes_active[phy] = 1;
       }*/
-  
+
   // The Bar
-  G4Box *gBarL = new G4Box("gBarL", fBarL[0]/2., fBarL[1]/2., fBarL[2]/2.);
-  lBarL = new G4LogicalVolume(gBarL,BarMaterial,"lBarL",0,0,0);
+  G4Box* gBarL = new G4Box("gBarL", fBarL[0] / 2., fBarL[1] / 2., fBarL[2] / 2.);
+  lBarL = new G4LogicalVolume(gBarL, BarMaterial, "lBarL", 0, 0, 0);
   m_LogicalVolumes_active[lBarL] = 2;
 
-  G4Box *gBarS = new G4Box("gBarS", fBarS[0]/2., fBarS[1]/2., fBarS[2]/2.);
-  lBarS = new G4LogicalVolume(gBarS,BarMaterial,"lBarS",0,0,0);
+  G4Box* gBarS = new G4Box("gBarS", fBarS[0] / 2., fBarS[1] / 2., fBarS[2] / 2.);
+  lBarS = new G4LogicalVolume(gBarS, BarMaterial, "lBarS", 0, 0, 0);
   m_LogicalVolumes_active[lBarS] = 3;
-  
+
   // Glue
-  G4Box *gGlue = new G4Box("gGlue",fBar[0]/2.,fBar[1]/2.,0.5*gluethickness);
-  lGlue = new G4LogicalVolume(gGlue,epotekMaterial,"lGlue",0,0,0);
+  G4Box* gGlue = new G4Box("gGlue", fBar[0] / 2., fBar[1] / 2., 0.5 * gluethickness);
+  lGlue = new G4LogicalVolume(gGlue, epotekMaterial, "lGlue", 0, 0, 0);
   m_LogicalVolumes_active[lGlue] = 4;
 
-  int id=0; 
+  int id = 0;
 
-  for(int i=0; i<fNBar; i++){
-    double shifty = i*(fBar[1]+fBarsGap)- 0.5*fBoxWidth + fBar[1]/2.; 
-    for(int j=0; j<nparts; j++){
-      if(j < (nparts-1))
-	{
-	  double z = 0.5*dirclength - 0.5*fBarL[2] - (fBarL[2]+gluethickness)*j;
-	  //pDirc[i] = new G4PVPlacement(0,G4ThreeVector(0,shifty,z),lBarL,"wBar",lDirc,false,id,OverlapCheck());
-	  G4ThreeVector g4vec_lBarL_pos(0, shifty, z);
-	  assemblySector->AddPlacedVolume(lBarL, g4vec_lBarL_pos, 0);
-	  //m_PhysicalVolumes_active[pDirc[i]] = 3;
-	  //wGlue = new G4PVPlacement(0,G4ThreeVector(0,shifty,z-0.5*(fBarL[2]+gluethickness)),lGlue,"wGlue", lDirc,false,id,OverlapCheck());
-	  G4ThreeVector g4vec_lGlue_pos(0, shifty, z-0.5*(fBarL[2]+gluethickness));
-	  assemblySector->AddPlacedVolume(lGlue, g4vec_lGlue_pos, 0);
-	  //m_PhysicalVolumes_active[wGlue] = 4;
-	}
+  for (int i = 0; i < fNBar; i++)
+  {
+    double shifty = i * (fBar[1] + fBarsGap) - 0.5 * fBoxWidth + fBar[1] / 2.;
+    for (int j = 0; j < nparts; j++)
+    {
+      if (j < (nparts - 1))
+      {
+        double z = 0.5 * dirclength - 0.5 * fBarL[2] - (fBarL[2] + gluethickness) * j;
+        //pDirc[i] = new G4PVPlacement(0,G4ThreeVector(0,shifty,z),lBarL,"wBar",lDirc,false,id,OverlapCheck());
+        G4ThreeVector g4vec_lBarL_pos(0, shifty, z);
+        assemblySector->AddPlacedVolume(lBarL, g4vec_lBarL_pos, 0);
+        //m_PhysicalVolumes_active[pDirc[i]] = 3;
+        //wGlue = new G4PVPlacement(0,G4ThreeVector(0,shifty,z-0.5*(fBarL[2]+gluethickness)),lGlue,"wGlue", lDirc,false,id,OverlapCheck());
+        G4ThreeVector g4vec_lGlue_pos(0, shifty, z - 0.5 * (fBarL[2] + gluethickness));
+        assemblySector->AddPlacedVolume(lGlue, g4vec_lGlue_pos, 0);
+        //m_PhysicalVolumes_active[wGlue] = 4;
+      }
       else
-	{
-	  double z = 0.5*dirclength - (nparts-1)*fBarL[2] - 0.5*fBarS[2] - gluethickness*j;
-	  //pDirc[i] = new G4PVPlacement(0,G4ThreeVector(0,shifty,z),lBarS,"wBar",lDirc,false,id,OverlapCheck());
-	  G4ThreeVector g4vec_lBarS_pos(0, shifty, z);
-	  assemblySector->AddPlacedVolume(lBarS, g4vec_lBarS_pos, 0);
-	  //m_PhysicalVolumes_active[pDirc[i]] = 3;
-	  //wGlue = new G4PVPlacement(0,G4ThreeVector(0,shifty,z-0.5*(fBarS[2]+gluethickness)),lGlue,"wGlue", lDirc,false,id,OverlapCheck());
-	  G4ThreeVector g4vec_lGlue_pos(0, shifty, z-0.5*(fBarS[2]+gluethickness));
-	  assemblySector->AddPlacedVolume(lGlue, g4vec_lGlue_pos, 0);
-	  //m_PhysicalVolumes_active[wGlue] = 4;
-	}
+      {
+        double z = 0.5 * dirclength - (nparts - 1) * fBarL[2] - 0.5 * fBarS[2] - gluethickness * j;
+        //pDirc[i] = new G4PVPlacement(0,G4ThreeVector(0,shifty,z),lBarS,"wBar",lDirc,false,id,OverlapCheck());
+        G4ThreeVector g4vec_lBarS_pos(0, shifty, z);
+        assemblySector->AddPlacedVolume(lBarS, g4vec_lBarS_pos, 0);
+        //m_PhysicalVolumes_active[pDirc[i]] = 3;
+        //wGlue = new G4PVPlacement(0,G4ThreeVector(0,shifty,z-0.5*(fBarS[2]+gluethickness)),lGlue,"wGlue", lDirc,false,id,OverlapCheck());
+        G4ThreeVector g4vec_lGlue_pos(0, shifty, z - 0.5 * (fBarS[2] + gluethickness));
+        assemblySector->AddPlacedVolume(lGlue, g4vec_lGlue_pos, 0);
+        //m_PhysicalVolumes_active[wGlue] = 4;
+      }
       id++;
     }
   }
 
-  
   // The Mirror
-  G4Box* gMirror = new G4Box("gMirror",fMirror[0]/2.,fMirror[1]/2.,fMirror[2]/2.);
-  lMirror = new G4LogicalVolume(gMirror,MirrorMaterial,"lMirror",0,0,0);
+  G4Box* gMirror = new G4Box("gMirror", fMirror[0] / 2., fMirror[1] / 2., fMirror[2] / 2.);
+  lMirror = new G4LogicalVolume(gMirror, MirrorMaterial, "lMirror", 0, 0, 0);
   m_LogicalVolumes_active[lMirror] = 5;
   //wMirror =new G4PVPlacement(0,G4ThreeVector(0,0,0.5*dirclength+fMirror[2]/2.),lMirror,"wMirror", lDirc,false,0,OverlapCheck());
-  G4ThreeVector g4vec_lMirror_pos(0, 0, 0.5*dirclength+fMirror[2]/2.);
+  G4ThreeVector g4vec_lMirror_pos(0, 0, 0.5 * dirclength + fMirror[2] / 2.);
   assemblySector->AddPlacedVolume(lMirror, g4vec_lMirror_pos, 0);
-  //m_PhysicalVolumes_active[wMirror] = 5;  
+  //m_PhysicalVolumes_active[wMirror] = 5;
 
   // The Lenses
-  if(fLensId == 2){ // 2-layer lens
+  if (fLensId == 2)
+  {  // 2-layer lens
     double lensrad = 70;
     double lensMinThikness = 2;
-    G4Box* gfbox = new G4Box("Fbox",fLens[0]/2.,fLens[1]/2.,fLens[2]/2.);
-    G4ThreeVector zTrans(0, 0, -lensrad+fLens[2]/2.-lensMinThikness);
+    G4Box* gfbox = new G4Box("Fbox", fLens[0] / 2., fLens[1] / 2., fLens[2] / 2.);
+    G4ThreeVector zTrans(0, 0, -lensrad + fLens[2] / 2. - lensMinThikness);
 
-    G4Sphere* gsphere = new G4Sphere("Sphere",0,70,0.*deg,360.*deg,0.*deg,380.*deg);
-    G4IntersectionSolid* gLens1 = new G4IntersectionSolid("Fbox*Sphere", gfbox, gsphere,new G4RotationMatrix(),zTrans); 
-    G4SubtractionSolid* gLens2 = new G4SubtractionSolid("Fbox-Sphere", gfbox, gsphere,new G4RotationMatrix(),zTrans);
+    G4Sphere* gsphere = new G4Sphere("Sphere", 0, 70, 0. * deg, 360. * deg, 0. * deg, 380. * deg);
+    G4IntersectionSolid* gLens1 = new G4IntersectionSolid("Fbox*Sphere", gfbox, gsphere, new G4RotationMatrix(), zTrans);
+    G4SubtractionSolid* gLens2 = new G4SubtractionSolid("Fbox-Sphere", gfbox, gsphere, new G4RotationMatrix(), zTrans);
 
-    lLens1 = new G4LogicalVolume(gLens1,Nlak33aMaterial,"lLens1",0,0,0); //Nlak33aMaterial  
+    lLens1 = new G4LogicalVolume(gLens1, Nlak33aMaterial, "lLens1", 0, 0, 0);  //Nlak33aMaterial
     m_LogicalVolumes_active[lLens1] = 6;
-    lLens2 = new G4LogicalVolume(gLens2,BarMaterial,"lLens2",0,0,0);
+    lLens2 = new G4LogicalVolume(gLens2, BarMaterial, "lLens2", 0, 0, 0);
     m_LogicalVolumes_active[lLens2] = 7;
   }
 
-  if(fLensId == 3){ // 3-component spherical lens
-    double lensMinThikness = 2; 
-  
-    double r1 = 47.8;//0; 
-    double r2 = 29.1;//0; 
-  
+  if (fLensId == 3)
+  {  // 3-component spherical lens
+    double lensMinThikness = 2;
+
+    double r1 = 47.8;  //0;
+    double r2 = 29.1;  //0;
+
     //r1 = (r1==0)? 47.8: r1;
     //r2 = (r2==0)? 29.1: r2;
     // r1=80;
     // r2=35;
 
-    double cr2 = sqrt(fLens[1]*fLens[1]/4.+fBar[0]*fBar[0]/4.);
-    if(cr2 > r2) {
-      if (Verbosity ()) std::cout<<"bad lens"<<std::endl;
+    double cr2 = sqrt(fLens[1] * fLens[1] / 4. + fBar[0] * fBar[0] / 4.);
+    if (cr2 > r2)
+    {
+      if (Verbosity()) std::cout << "bad lens" << std::endl;
       cr2 = r2;
     }
-    fLens[2] = (2*lensMinThikness+r2-sqrt(r2*r2-cr2*cr2)+lensMinThikness);
-    if (Verbosity ()) std::cout << "lens thickness ="<< fLens[2] << " mm" << std::endl;
-    
-    G4ThreeVector zTrans1(0, 0, -r1-fLens[2]/2.+r1-sqrt(r1*r1-cr2*cr2) +lensMinThikness);
-    G4ThreeVector zTrans2(0, 0, -r2-fLens[2]/2.+r2-sqrt(r2*r2-cr2*cr2) +lensMinThikness*2);
+    fLens[2] = (2 * lensMinThikness + r2 - sqrt(r2 * r2 - cr2 * cr2) + lensMinThikness);
+    if (Verbosity()) std::cout << "lens thickness =" << fLens[2] << " mm" << std::endl;
 
-    G4Box* gfbox = new G4Box("Fbox",fLens[0]/2.,fLens[1]/2.,fLens[2]/2.);
-    G4Tubs* gfstube = new G4Tubs("ftube",0,cr2,fLens[2]/2.,0,360*deg);
+    G4ThreeVector zTrans1(0, 0, -r1 - fLens[2] / 2. + r1 - sqrt(r1 * r1 - cr2 * cr2) + lensMinThikness);
+    G4ThreeVector zTrans2(0, 0, -r2 - fLens[2] / 2. + r2 - sqrt(r2 * r2 - cr2 * cr2) + lensMinThikness * 2);
 
-    G4Sphere* gsphere1 = new G4Sphere("Sphere1",0,r1,0,360*deg,0,360*deg);
-    G4Sphere* gsphere2 = new G4Sphere("Sphere2",0,r2,0,360*deg,0,360*deg);
+    G4Box* gfbox = new G4Box("Fbox", fLens[0] / 2., fLens[1] / 2., fLens[2] / 2.);
+    G4Tubs* gfstube = new G4Tubs("ftube", 0, cr2, fLens[2] / 2., 0, 360 * deg);
 
-    G4IntersectionSolid* gbbox = new G4IntersectionSolid("bbox", gfbox, gfbox,new G4RotationMatrix(),G4ThreeVector(0,0,-lensMinThikness*2)); 
-    G4IntersectionSolid* gsbox = new G4IntersectionSolid("sbox", gfstube, gfbox,new G4RotationMatrix(),G4ThreeVector(0,0,lensMinThikness*2)); 
+    G4Sphere* gsphere1 = new G4Sphere("Sphere1", 0, r1, 0, 360 * deg, 0, 360 * deg);
+    G4Sphere* gsphere2 = new G4Sphere("Sphere2", 0, r2, 0, 360 * deg, 0, 360 * deg);
 
+    G4IntersectionSolid* gbbox = new G4IntersectionSolid("bbox", gfbox, gfbox, new G4RotationMatrix(), G4ThreeVector(0, 0, -lensMinThikness * 2));
+    G4IntersectionSolid* gsbox = new G4IntersectionSolid("sbox", gfstube, gfbox, new G4RotationMatrix(), G4ThreeVector(0, 0, lensMinThikness * 2));
 
-    G4UnionSolid* gubox = new G4UnionSolid("unionbox", gbbox, gsbox,new G4RotationMatrix(),G4ThreeVector(0,0,0)); 
+    G4UnionSolid* gubox = new G4UnionSolid("unionbox", gbbox, gsbox, new G4RotationMatrix(), G4ThreeVector(0, 0, 0));
 
-    G4IntersectionSolid* gLens1 = new G4IntersectionSolid("Lens1", gubox, gsphere1,new G4RotationMatrix(),-zTrans1); 
-    G4SubtractionSolid*  gLenst = new G4SubtractionSolid("temp", gubox, gsphere1, new G4RotationMatrix(),-zTrans1);
+    G4IntersectionSolid* gLens1 = new G4IntersectionSolid("Lens1", gubox, gsphere1, new G4RotationMatrix(), -zTrans1);
+    G4SubtractionSolid* gLenst = new G4SubtractionSolid("temp", gubox, gsphere1, new G4RotationMatrix(), -zTrans1);
 
-    G4IntersectionSolid* gLens2 = new G4IntersectionSolid("Lens2", gLenst, gsphere2, new G4RotationMatrix(),-zTrans2);
-    G4SubtractionSolid*  gLens3 = new G4SubtractionSolid("Lens3", gLenst, gsphere2,new G4RotationMatrix(),-zTrans2);
-    
-    lLens1 = new G4LogicalVolume(gLens1,BarMaterial,"lLens1",0,0,0);
+    G4IntersectionSolid* gLens2 = new G4IntersectionSolid("Lens2", gLenst, gsphere2, new G4RotationMatrix(), -zTrans2);
+    G4SubtractionSolid* gLens3 = new G4SubtractionSolid("Lens3", gLenst, gsphere2, new G4RotationMatrix(), -zTrans2);
+
+    lLens1 = new G4LogicalVolume(gLens1, BarMaterial, "lLens1", 0, 0, 0);
     m_LogicalVolumes_active[lLens1] = 6;
-    lLens2 = new G4LogicalVolume(gLens2,Nlak33aMaterial,"lLens2",0,0,0); //Nlak33aMaterial //PbF2Material //SapphireMaterial
+    lLens2 = new G4LogicalVolume(gLens2, Nlak33aMaterial, "lLens2", 0, 0, 0);  //Nlak33aMaterial //PbF2Material //SapphireMaterial
     m_LogicalVolumes_active[lLens2] = 7;
-    lLens3 = new G4LogicalVolume(gLens3,BarMaterial,"lLens3",0,0,0);
+    lLens3 = new G4LogicalVolume(gLens3, BarMaterial, "lLens3", 0, 0, 0);
     m_LogicalVolumes_active[lLens3] = 8;
   }
 
-  if(fLensId == 6){ // 3-component cylindrical lens
+  if (fLensId == 6)
+  {  // 3-component cylindrical lens
     double lensMinThikness = 2.0;
 
-    double r1 = 33;//0; 
-    double r2 = 24;//0; 
+    double r1 = 33;  //0;
+    double r2 = 24;  //0;
 
     lensMinThikness = 2;
-    double layer12 = lensMinThikness*2;
+    double layer12 = lensMinThikness * 2;
 
     // r1 = (r1==0)? 27.45: r1;
     // r2 = (r2==0)? 20.02: r2;
@@ -530,271 +546,279 @@ void G4EicDircDetector::ConstructMe(G4LogicalVolume *logicWorld)
     //r2 = (r2==0)? 24: r2;
     double shight = 25;
 
-    G4ThreeVector zTrans1(0, 0, -r1-fLens[2]/2.+r1-sqrt(r1*r1-shight/2.*shight/2.) +lensMinThikness);
-    G4ThreeVector zTrans2(0, 0, -r2-fLens[2]/2.+r2-sqrt(r2*r2-shight/2.*shight/2.) +layer12);
+    G4ThreeVector zTrans1(0, 0, -r1 - fLens[2] / 2. + r1 - sqrt(r1 * r1 - shight / 2. * shight / 2.) + lensMinThikness);
+    G4ThreeVector zTrans2(0, 0, -r2 - fLens[2] / 2. + r2 - sqrt(r2 * r2 - shight / 2. * shight / 2.) + layer12);
 
-    G4Box* gfbox = new G4Box("fbox",0.5*fLens[0],0.5*fLens[1],0.5*fLens[2]);
-    G4Box* gcbox = new G4Box("cbox",0.5*fLens[0],0.5*fLens[1]+1,0.5*fLens[2]);
-    G4ThreeVector tTrans1( 0.5*(fLens[0]+shight),0,-fLens[2]+layer12);
-    G4ThreeVector tTrans0(-0.5*(fLens[0]+shight),0,-fLens[2]+layer12);
-    G4SubtractionSolid*  tubox = new G4SubtractionSolid("tubox", gfbox, gcbox,new G4RotationMatrix(),tTrans1);
-    G4SubtractionSolid*  gubox = new G4SubtractionSolid("gubox", tubox, gcbox,new G4RotationMatrix(),tTrans0);
+    G4Box* gfbox = new G4Box("fbox", 0.5 * fLens[0], 0.5 * fLens[1], 0.5 * fLens[2]);
+    G4Box* gcbox = new G4Box("cbox", 0.5 * fLens[0], 0.5 * fLens[1] + 1, 0.5 * fLens[2]);
+    G4ThreeVector tTrans1(0.5 * (fLens[0] + shight), 0, -fLens[2] + layer12);
+    G4ThreeVector tTrans0(-0.5 * (fLens[0] + shight), 0, -fLens[2] + layer12);
+    G4SubtractionSolid* tubox = new G4SubtractionSolid("tubox", gfbox, gcbox, new G4RotationMatrix(), tTrans1);
+    G4SubtractionSolid* gubox = new G4SubtractionSolid("gubox", tubox, gcbox, new G4RotationMatrix(), tTrans0);
 
-    G4Tubs* gcylinder1  = new G4Tubs("Cylinder1",0,r1,0.5*fLens[1],0*deg,360*deg);
-    G4Tubs* gcylinder2  = new G4Tubs("Cylinder2",0,r2,0.5*fLens[1]-0.5,0*deg,360*deg);
-    G4Tubs* gcylinder1c = new G4Tubs("Cylinder1c",0,r1,0.5*fLens[1]+0.5,0*deg,360*deg);
-    G4Tubs* gcylinder2c = new G4Tubs("Cylinder2c",0,r2,0.5*fLens[1]+0.5,0*deg,360*deg);
+    G4Tubs* gcylinder1 = new G4Tubs("Cylinder1", 0, r1, 0.5 * fLens[1], 0 * deg, 360 * deg);
+    G4Tubs* gcylinder2 = new G4Tubs("Cylinder2", 0, r2, 0.5 * fLens[1] - 0.5, 0 * deg, 360 * deg);
+    G4Tubs* gcylinder1c = new G4Tubs("Cylinder1c", 0, r1, 0.5 * fLens[1] + 0.5, 0 * deg, 360 * deg);
+    G4Tubs* gcylinder2c = new G4Tubs("Cylinder2c", 0, r2, 0.5 * fLens[1] + 0.5, 0 * deg, 360 * deg);
     G4RotationMatrix* xRot = new G4RotationMatrix();
-    xRot->rotateX(M_PI/2.*rad);
+    xRot->rotateX(M_PI / 2. * rad);
 
-    G4IntersectionSolid* gLens1 = new G4IntersectionSolid("Lens1", gubox, gcylinder1,xRot,zTrans1);
-    G4SubtractionSolid*  gLenst = new G4SubtractionSolid("temp", gubox, gcylinder1c, xRot,zTrans1);
+    G4IntersectionSolid* gLens1 = new G4IntersectionSolid("Lens1", gubox, gcylinder1, xRot, zTrans1);
+    G4SubtractionSolid* gLenst = new G4SubtractionSolid("temp", gubox, gcylinder1c, xRot, zTrans1);
 
-    G4IntersectionSolid* gLens2 = new G4IntersectionSolid("Lens2", gLenst, gcylinder2, xRot,zTrans2);
-    G4SubtractionSolid*  gLens3 = new G4SubtractionSolid("Lens3", gLenst, gcylinder2c, xRot,zTrans2);
+    G4IntersectionSolid* gLens2 = new G4IntersectionSolid("Lens2", gLenst, gcylinder2, xRot, zTrans2);
+    G4SubtractionSolid* gLens3 = new G4SubtractionSolid("Lens3", gLenst, gcylinder2c, xRot, zTrans2);
 
-    lLens1 = new G4LogicalVolume(gLens1,BarMaterial,"lLens1",0,0,0);
+    lLens1 = new G4LogicalVolume(gLens1, BarMaterial, "lLens1", 0, 0, 0);
     m_LogicalVolumes_active[lLens1] = 6;
-    lLens2 = new G4LogicalVolume(gLens2,Nlak33aMaterial,"lLens2",0,0,0);
+    lLens2 = new G4LogicalVolume(gLens2, Nlak33aMaterial, "lLens2", 0, 0, 0);
     m_LogicalVolumes_active[lLens2] = 7;
-    lLens3 = new G4LogicalVolume(gLens3,BarMaterial,"lLens3",0,0,0);
-    m_LogicalVolumes_active[lLens3] = 8;
-  }  
-
-  if(fLensId ==100){
-    fLens[2]=200;
-    G4Box *gLens3 = new G4Box("gLens1",fBar[0]/2.,0.5*fBoxWidth,100);
-    lLens3 = new G4LogicalVolume(gLens3,BarMaterial,"lLens3",0,0,0);
+    lLens3 = new G4LogicalVolume(gLens3, BarMaterial, "lLens3", 0, 0, 0);
     m_LogicalVolumes_active[lLens3] = 8;
   }
-      
-  if(fLensId != 0 && fLensId != 10){
-    double shifth = -0.5*(dirclength+fLens[2]);
-    if(fLensId==100){
+
+  if (fLensId == 100)
+  {
+    fLens[2] = 200;
+    G4Box* gLens3 = new G4Box("gLens1", fBar[0] / 2., 0.5 * fBoxWidth, 100);
+    lLens3 = new G4LogicalVolume(gLens3, BarMaterial, "lLens3", 0, 0, 0);
+    m_LogicalVolumes_active[lLens3] = 8;
+  }
+
+  if (fLensId != 0 && fLensId != 10)
+  {
+    double shifth = -0.5 * (dirclength + fLens[2]);
+    if (fLensId == 100)
+    {
       //phy = new G4PVPlacement(0,G4ThreeVector(0,0,shifth),lLens3,"wLens3", lDirc,false,0,OverlapCheck());
       G4ThreeVector g4vec_lLens3_pos(0, 0, shifth);
       assemblySector->AddPlacedVolume(lLens3, g4vec_lLens3_pos, 0);
-
-    }else if(fNBar==1 && fLensId==3){
-      for(int i=0; i<11; i++){
-	double shifty = i*fLens[1] - 0.5*(fBoxWidth - fLens[1]);
-	//phy = new G4PVPlacement(0,G4ThreeVector(0,shifty,shifth),lLens1,"wLens1", lDirc,false,i,OverlapCheck());
-	G4ThreeVector g4vec_lLens_pos(0, shifty, shifth);
-	assemblySector->AddPlacedVolume(lLens1, g4vec_lLens_pos, 0);
-	//phy = new G4PVPlacement(0,G4ThreeVector(0,shifty,shifth),lLens2,"wLens2", lDirc,false,i,OverlapCheck());
-	assemblySector->AddPlacedVolume(lLens2, g4vec_lLens_pos, 0);
-	//phy = new G4PVPlacement(0,G4ThreeVector(0,shifty,shifth),lLens3,"wLens3", lDirc,false,i,OverlapCheck());
-	assemblySector->AddPlacedVolume(lLens3, g4vec_lLens_pos, 0);
-
+    }
+    else if (fNBar == 1 && fLensId == 3)
+    {
+      for (int i = 0; i < 11; i++)
+      {
+        double shifty = i * fLens[1] - 0.5 * (fBoxWidth - fLens[1]);
+        //phy = new G4PVPlacement(0,G4ThreeVector(0,shifty,shifth),lLens1,"wLens1", lDirc,false,i,OverlapCheck());
+        G4ThreeVector g4vec_lLens_pos(0, shifty, shifth);
+        assemblySector->AddPlacedVolume(lLens1, g4vec_lLens_pos, 0);
+        //phy = new G4PVPlacement(0,G4ThreeVector(0,shifty,shifth),lLens2,"wLens2", lDirc,false,i,OverlapCheck());
+        assemblySector->AddPlacedVolume(lLens2, g4vec_lLens_pos, 0);
+        //phy = new G4PVPlacement(0,G4ThreeVector(0,shifty,shifth),lLens3,"wLens3", lDirc,false,i,OverlapCheck());
+        assemblySector->AddPlacedVolume(lLens3, g4vec_lLens_pos, 0);
       }
-    }else{
-      for(int i=0; i<fNBar; i++){
-	double shifty = i*fLens[1] - 0.5*(fBoxWidth - fLens[1]);
-	if(fLensId!=6){
-	  //phy = new G4PVPlacement(0,G4ThreeVector(0,shifty,shifth),lLens1,"wLens1", lDirc,false,i,OverlapCheck());
-	  G4ThreeVector g4vec_lLens_pos(0, shifty, shifth);
-	  assemblySector->AddPlacedVolume(lLens1, g4vec_lLens_pos, 0);
-	  //m_PhysicalVolumes_active[phy] = 6;
+    }
+    else
+    {
+      for (int i = 0; i < fNBar; i++)
+      {
+        double shifty = i * fLens[1] - 0.5 * (fBoxWidth - fLens[1]);
+        if (fLensId != 6)
+        {
+          //phy = new G4PVPlacement(0,G4ThreeVector(0,shifty,shifth),lLens1,"wLens1", lDirc,false,i,OverlapCheck());
+          G4ThreeVector g4vec_lLens_pos(0, shifty, shifth);
+          assemblySector->AddPlacedVolume(lLens1, g4vec_lLens_pos, 0);
+          //m_PhysicalVolumes_active[phy] = 6;
 
-	  //phy = new G4PVPlacement(0,G4ThreeVector(0,shifty,shifth),lLens2,"wLens2", lDirc,false,i,OverlapCheck());
-	  assemblySector->AddPlacedVolume(lLens2, g4vec_lLens_pos, 0);
-	  //m_PhysicalVolumes_active[phy] = 7;
+          //phy = new G4PVPlacement(0,G4ThreeVector(0,shifty,shifth),lLens2,"wLens2", lDirc,false,i,OverlapCheck());
+          assemblySector->AddPlacedVolume(lLens2, g4vec_lLens_pos, 0);
+          //m_PhysicalVolumes_active[phy] = 7;
 
-	  if(fLensId == 3) 
-	    {
-	      //phy = new G4PVPlacement(0,G4ThreeVector(0,shifty,shifth),lLens3,"wLens3", lDirc,false,i,OverlapCheck());
-	      assemblySector->AddPlacedVolume(lLens3, g4vec_lLens_pos, 0);
-	    }
-	  //m_PhysicalVolumes_active[phy] = 8; 
-	}
+          if (fLensId == 3)
+          {
+            //phy = new G4PVPlacement(0,G4ThreeVector(0,shifty,shifth),lLens3,"wLens3", lDirc,false,i,OverlapCheck());
+            assemblySector->AddPlacedVolume(lLens3, g4vec_lLens_pos, 0);
+          }
+          //m_PhysicalVolumes_active[phy] = 8;
+        }
       }
-      if(fLensId==6){
-	double sh=0;
-	//phy = new G4PVPlacement(0,G4ThreeVector(0,0,shifth-sh),lLens1,"wLens1", lDirc,false,0,OverlapCheck());
-	G4ThreeVector g4vec_lLens_pos(0, 0, shifth-sh);
-	assemblySector->AddPlacedVolume(lLens1, g4vec_lLens_pos, 0);
-	//phy = new G4PVPlacement(0,G4ThreeVector(0,0,shifth-sh),lLens2,"wLens2", lDirc,false,0,OverlapCheck());
-	assemblySector->AddPlacedVolume(lLens2, g4vec_lLens_pos, 0);
-	//phy = new G4PVPlacement(0,G4ThreeVector(0,0,shifth-sh),lLens3,"wLens3", lDirc,false,0,OverlapCheck());
-	assemblySector->AddPlacedVolume(lLens3, g4vec_lLens_pos, 0);
-
+      if (fLensId == 6)
+      {
+        double sh = 0;
+        //phy = new G4PVPlacement(0,G4ThreeVector(0,0,shifth-sh),lLens1,"wLens1", lDirc,false,0,OverlapCheck());
+        G4ThreeVector g4vec_lLens_pos(0, 0, shifth - sh);
+        assemblySector->AddPlacedVolume(lLens1, g4vec_lLens_pos, 0);
+        //phy = new G4PVPlacement(0,G4ThreeVector(0,0,shifth-sh),lLens2,"wLens2", lDirc,false,0,OverlapCheck());
+        assemblySector->AddPlacedVolume(lLens2, g4vec_lLens_pos, 0);
+        //phy = new G4PVPlacement(0,G4ThreeVector(0,0,shifth-sh),lLens3,"wLens3", lDirc,false,0,OverlapCheck());
+        assemblySector->AddPlacedVolume(lLens3, g4vec_lLens_pos, 0);
       }
     }
   }
 
   // The Prizm
-  G4Trap* gPrizm = new G4Trap("gPrizm",fPrizm[0],fPrizm[1],fPrizm[2],fPrizm[3]);
-  lPrizm = new G4LogicalVolume(gPrizm, BarMaterial,"lPrizm",0,0,0);
+  G4Trap* gPrizm = new G4Trap("gPrizm", fPrizm[0], fPrizm[1], fPrizm[2], fPrizm[3]);
+  lPrizm = new G4LogicalVolume(gPrizm, BarMaterial, "lPrizm", 0, 0, 0);
   m_LogicalVolumes_active[lPrizm] = 9;
 
   G4RotationMatrix* xRot = new G4RotationMatrix();
   //xRot->rotateX(-M_PI/2.*rad); // for lDirc
-  xRot->rotateX(M_PI/2.*rad);
+  xRot->rotateX(M_PI / 2. * rad);
 
-  G4RotationMatrix *fdrot = new G4RotationMatrix();
-  double evshiftz = 0.5*dirclength+fPrizm[1]+fMcpActive[2]/2.+fLens[2];
+  G4RotationMatrix* fdrot = new G4RotationMatrix();
+  double evshiftz = 0.5 * dirclength + fPrizm[1] + fMcpActive[2] / 2. + fLens[2];
   double evshiftx = 0;
 
-  fPrismShift = G4ThreeVector((fPrizm[2]+fPrizm[3])/4.-0.5*fPrizm[3],0,-(0.5*(dirclength+fPrizm[1])+fLens[2]));
+  fPrismShift = G4ThreeVector((fPrizm[2] + fPrizm[3]) / 4. - 0.5 * fPrizm[3], 0, -(0.5 * (dirclength + fPrizm[1]) + fLens[2]));
   //phy = new G4PVPlacement(xRot,fPrismShift,lPrizm,"wPrizm", lDirc,false,0,OverlapCheck());
   assemblySector->AddPlacedVolume(lPrizm, fPrismShift, xRot);
   //m_PhysicalVolumes_active[phy] = 9;
 
   //phy = new G4PVPlacement(fdrot,G4ThreeVector(0.5*fFd[1]-0.5*fPrizm[3]-evshiftx,0,-evshiftz),lFd,"wFd", lDirc,false,0,OverlapCheck());
-  G4ThreeVector g4vec_lFd_pos(0.5*fFd[1]-0.5*fPrizm[3]-evshiftx,0,-evshiftz);
+  G4ThreeVector g4vec_lFd_pos(0.5 * fFd[1] - 0.5 * fPrizm[3] - evshiftx, 0, -evshiftz);
   assemblySector->AddPlacedVolume(lFd, g4vec_lFd_pos, fdrot);
   //m_PhysicalVolumes_active[phy] = 2;
-  
-  for(int i=0; i<fNBoxes; i++){
-    double tphi = dphi*i;
+
+  for (int i = 0; i < fNBoxes; i++)
+  {
+    double tphi = dphi * i;
     double dx = fRadius * cos(tphi);
     double dy = fRadius * sin(tphi);
 
-    G4RotationMatrix *tRot = new G4RotationMatrix();
+    G4RotationMatrix* tRot = new G4RotationMatrix();
     tRot->rotateZ(tphi);
     G4ThreeVector g4vec_sector_pos(dx, dy, zshift);
-    //phy = new G4PVPlacement(tRot,G4ThreeVector(dx,dy,zshift),lDirc,"wDirc",logicWorld,false,i,OverlapCheck());                                     
+    //phy = new G4PVPlacement(tRot,G4ThreeVector(dx,dy,zshift),lDirc,"wDirc",logicWorld,false,i,OverlapCheck());
     assemblySector->MakeImprint(logicWorld, g4vec_sector_pos, tRot, i, OverlapCheck());
-    //m_PhysicalVolumes_active[phy] = 1;                                                                                                             
+    //m_PhysicalVolumes_active[phy] = 1;
   }
-
 
   // MCP --
 
-  G4Box* gMcp = new G4Box("gMcp",fMcpTotal[0]/2.,fMcpTotal[1]/2.,fMcpTotal[2]/2.);
-  lMcp = new G4LogicalVolume(gMcp,BarMaterial,"lMcp",0,0,0);
+  G4Box* gMcp = new G4Box("gMcp", fMcpTotal[0] / 2., fMcpTotal[1] / 2., fMcpTotal[2] / 2.);
+  lMcp = new G4LogicalVolume(gMcp, BarMaterial, "lMcp", 0, 0, 0);
   m_LogicalVolumes_active[lMcp] = 10;
 
   fNpix1 = 16;
   fNpix2 = 16;
 
-  if (Verbosity ()) std::cout<<"fNpix1="<<fNpix1 << " fNpix2="<<fNpix2 <<std::endl;
-        
+  if (Verbosity()) std::cout << "fNpix1=" << fNpix1 << " fNpix2=" << fNpix2 << std::endl;
+
   // The MCP Pixel
-  G4Box* gPixel = new G4Box("gPixel",0.5*fMcpActive[0]/fNpix1,0.5*fMcpActive[1]/fNpix2,fMcpActive[2]/16.);
-  lPixel = new G4LogicalVolume(gPixel,BarMaterial,"lPixel",0,0,0);
+  G4Box* gPixel = new G4Box("gPixel", 0.5 * fMcpActive[0] / fNpix1, 0.5 * fMcpActive[1] / fNpix2, fMcpActive[2] / 16.);
+  lPixel = new G4LogicalVolume(gPixel, BarMaterial, "lPixel", 0, 0, 0);
   m_LogicalVolumes_active[lPixel] = 11;
-
-  for(int i=0; i<fNpix2; i++){
-    for(int j=0; j<fNpix1; j++){
-      double shiftx = i*(fMcpActive[0]/fNpix1)-fMcpActive[0]/2.+0.5*fMcpActive[0]/fNpix1;
-      double shifty = j*(fMcpActive[1]/fNpix2)-fMcpActive[1]/2.+0.5*fMcpActive[1]/fNpix2;
-      G4VPhysicalVolume* phy1 = new G4PVPlacement(0,G4ThreeVector(shiftx,shifty,0),lPixel,"wPixel", lMcp,false,fNpix2*i+j,OverlapCheck());      
-
+/*
+  for (int i = 0; i < fNpix2; i++)
+  {
+    for (int j = 0; j < fNpix1; j++)
+    {
+      double shiftx = i * (fMcpActive[0] / fNpix1) - fMcpActive[0] / 2. + 0.5 * fMcpActive[0] / fNpix1;
+      double shifty = j * (fMcpActive[1] / fNpix2) - fMcpActive[1] / 2. + 0.5 * fMcpActive[1] / fNpix2;
+      G4VPhysicalVolume* phy1 = new G4PVPlacement(0, G4ThreeVector(shiftx, shifty, 0), lPixel, "wPixel", lMcp, false, fNpix2 * i + j, OverlapCheck());
     }
   }
- 
-  int mcpId = 0;
-  double gapx = (fPrizm[2]-fNCol*fMcpTotal[0])/(double)(fNCol+1);
-  double gapy = (fBoxWidth-fNRow*fMcpTotal[1])/(double)(fNRow+1);
-  for(int i=0; i<fNCol; i++){
-    for(int j=0; j<fNRow; j++){
 
-      double shiftx = i*(fMcpTotal[0]+gapx)-0.5*(fFd[1]-fMcpTotal[0])+gapx;
-      double shifty = j*(fMcpTotal[1]+gapy)-0.5*(fBoxWidth-fMcpTotal[1])+gapy;
+  int mcpId = 0;
+  double gapx = (fPrizm[2] - fNCol * fMcpTotal[0]) / (double) (fNCol + 1);
+  double gapy = (fBoxWidth - fNRow * fMcpTotal[1]) / (double) (fNRow + 1);
+  for (int i = 0; i < fNCol; i++)
+  {
+    for (int j = 0; j < fNRow; j++)
+    {
+      double shiftx = i * (fMcpTotal[0] + gapx) - 0.5 * (fFd[1] - fMcpTotal[0]) + gapx;
+      double shifty = j * (fMcpTotal[1] + gapy) - 0.5 * (fBoxWidth - fMcpTotal[1]) + gapy;
       //phy = new G4PVPlacement(0,G4ThreeVector(shiftx,shifty,0),lMcp,"wMcp", lFd,false,mcpId++);
-      G4VPhysicalVolume* phy2 = new G4PVPlacement(0,G4ThreeVector(shiftx,shifty,0),lMcp,"wMcp", lFd,false,mcpId,OverlapCheck()); 
+      G4VPhysicalVolume* phy2 = new G4PVPlacement(0, G4ThreeVector(shiftx, shifty, 0), lMcp, "wMcp", lFd, false, mcpId, OverlapCheck());
       //m_PhysicalVolumes_active[phy] = 10;
       mcpId++;
     }
   }
-
-
+*/
   {
-    const int num = 36; 
+    const int num = 36;
     double WaveLength[num];
     double PhotonEnergy[num];
     double PMTReflectivity[num];
     double EfficiencyMirrors[num];
     const double LambdaE = 2.0 * 3.14159265358979323846 * 1.973269602e-16 * m * GeV;
-    for(int i=0;i<num;i++){
-      WaveLength[i]= (300 +i*10)*nanometer;
-      PhotonEnergy[num-(i+1)]= LambdaE/WaveLength[i];
-      PMTReflectivity[i]=0.;
-      EfficiencyMirrors[i]=0; 
+    for (int i = 0; i < num; i++)
+    {
+      WaveLength[i] = (300 + i * 10) * nanometer;
+      PhotonEnergy[num - (i + 1)] = LambdaE / WaveLength[i];
+      PMTReflectivity[i] = 0.;
+      EfficiencyMirrors[i] = 0;
     }
 
     /***************** QUANTUM EFFICIENCY OF BURLE AND HAMAMTSU PMT'S *****/
 
     //ideal pmt quantum efficiency
-    double QuantumEfficiencyIdial[num]=
-      {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,
-       1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,
-       1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,
-       1.0,1.0,1.0,1.0,1.0,1.0};
+    double QuantumEfficiencyIdial[num] =
+        {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+         1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+         1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+         1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
 
-    // Burle PMT's 
+    // Burle PMT's
     double QuantumEfficiencyB[num] =
-      {0.,0.001,0.002,0.005,0.01,0.015,0.02,0.03,0.04,0.05,0.06,
-       0.07,0.09,0.1,0.13,0.15,0.17,0.2,0.24,0.26,0.28,0.282,0.284,0.286,
-       0.288,0.29,0.28,0.26,0.24,0.22,0.20,0.18,0.15,0.13,0.12,0.10};
-  
+        {0., 0.001, 0.002, 0.005, 0.01, 0.015, 0.02, 0.03, 0.04, 0.05, 0.06,
+         0.07, 0.09, 0.1, 0.13, 0.15, 0.17, 0.2, 0.24, 0.26, 0.28, 0.282, 0.284, 0.286,
+         0.288, 0.29, 0.28, 0.26, 0.24, 0.22, 0.20, 0.18, 0.15, 0.13, 0.12, 0.10};
+
     //hamamatsu pmt quantum efficiency
-    double QuantumEfficiencyPMT[num]=
-      {0.001,0.002,0.004,0.007,0.011,0.015,0.020,0.026,0.033,0.040,0.045,
-       0.056,0.067,0.085,0.109,0.129,0.138,0.147,0.158,0.170,
-       0.181,0.188,0.196,0.203,0.206,0.212,0.218,0.219,0.225,0.230,
-       0.228,0.222,0.217,0.210,0.199,0.177};
+    double QuantumEfficiencyPMT[num] =
+        {0.001, 0.002, 0.004, 0.007, 0.011, 0.015, 0.020, 0.026, 0.033, 0.040, 0.045,
+         0.056, 0.067, 0.085, 0.109, 0.129, 0.138, 0.147, 0.158, 0.170,
+         0.181, 0.188, 0.196, 0.203, 0.206, 0.212, 0.218, 0.219, 0.225, 0.230,
+         0.228, 0.222, 0.217, 0.210, 0.199, 0.177};
 
     // these quantum efficiencies have to be multiplied by geometry
     //   efficiency of given PMT's
     //   for Hamamatsu by factor 0.7
-    //   for Burle by factor 0.45 
-    for(int k=0;k<36;k++){
-      QuantumEfficiencyB[k] =  QuantumEfficiencyB[k] * 0.45 ;
-      QuantumEfficiencyPMT[k] =  QuantumEfficiencyPMT[k] *.7;
+    //   for Burle by factor 0.45
+    for (int k = 0; k < 36; k++)
+    {
+      QuantumEfficiencyB[k] = QuantumEfficiencyB[k] * 0.45;
+      QuantumEfficiencyPMT[k] = QuantumEfficiencyPMT[k] * .7;
     }
- 
-    
+
     /* define quantum efficiency for burle PMT's - the same efficiency is 
        assigned to pads and also to slots !!!! */
-    
+
     //burle pmt - bigger slots => logicPad
     G4MaterialPropertiesTable* PhotocatodBurleMPT = new G4MaterialPropertiesTable();
-    PhotocatodBurleMPT->AddProperty("EFFICIENCY",  PhotonEnergy,QuantumEfficiencyB,num);
-    PhotocatodBurleMPT->AddProperty("REFLECTIVITY",PhotonEnergy,PMTReflectivity,num);
+    PhotocatodBurleMPT->AddProperty("EFFICIENCY", PhotonEnergy, QuantumEfficiencyB, num);
+    PhotocatodBurleMPT->AddProperty("REFLECTIVITY", PhotonEnergy, PMTReflectivity, num);
 
- 
-    G4OpticalSurface* BurlePMTOpSurface= 
-      new G4OpticalSurface("BurlePMTOpSurface",glisur,polished,
-			   dielectric_metal);
+    G4OpticalSurface* BurlePMTOpSurface =
+        new G4OpticalSurface("BurlePMTOpSurface", glisur, polished,
+                             dielectric_metal);
     BurlePMTOpSurface->SetMaterialPropertiesTable(PhotocatodBurleMPT);
 
-    
     /* hamamatsu pmt's - smaller slots => quantum efficiency again
        assign to slot and pad */
-  
+
     fQuantumEfficiency = QuantumEfficiencyIdial;
     G4MaterialPropertiesTable* PhotocatodHamamatsuMPT = new G4MaterialPropertiesTable();
-    PhotocatodHamamatsuMPT->AddProperty("EFFICIENCY",  PhotonEnergy,fQuantumEfficiency,num);
-    PhotocatodHamamatsuMPT->AddProperty("REFLECTIVITY",PhotonEnergy,PMTReflectivity,num);
+    PhotocatodHamamatsuMPT->AddProperty("EFFICIENCY", PhotonEnergy, fQuantumEfficiency, num);
+    PhotocatodHamamatsuMPT->AddProperty("REFLECTIVITY", PhotonEnergy, PMTReflectivity, num);
 
-    G4OpticalSurface* HamamatsuPMTOpSurface= 
-      new G4OpticalSurface("HamamatsuPMTOpSurface",glisur,polished,dielectric_metal);
+    G4OpticalSurface* HamamatsuPMTOpSurface =
+        new G4OpticalSurface("HamamatsuPMTOpSurface", glisur, polished, dielectric_metal);
     HamamatsuPMTOpSurface->SetMaterialPropertiesTable(PhotocatodHamamatsuMPT);
 
     // // assignment to pad
     // if(hamamatsu8500)
-    new G4LogicalSkinSurface("HamamatsuPMTSurface",lPixel,HamamatsuPMTOpSurface);
+    new G4LogicalSkinSurface("HamamatsuPMTSurface", lPixel, HamamatsuPMTOpSurface);
 
     // Mirror
-    G4OpticalSurface* MirrorOpSurface= 
-      new G4OpticalSurface("MirrorOpSurface",glisur,polished,dielectric_metal);
-  
-    double ReflectivityMirrorBar[num]={
-      0.8755,0.882,0.889,0.895,0.9,0.9025,0.91,0.913,0.9165,0.92,0.923,
-      0.9245,0.9285,0.932,0.934,0.935,0.936,0.9385,0.9395,0.94,
-      0.9405,0.9405,0.9405,0.9405,0.94,0.9385,0.936,0.934,
-      0.931,0.9295,0.928,0.928,0.921,0.92,0.927,0.9215};
+    G4OpticalSurface* MirrorOpSurface =
+        new G4OpticalSurface("MirrorOpSurface", glisur, polished, dielectric_metal);
 
-    G4MaterialPropertiesTable *MirrorMPT = new G4MaterialPropertiesTable();
+    double ReflectivityMirrorBar[num] = {
+        0.8755, 0.882, 0.889, 0.895, 0.9, 0.9025, 0.91, 0.913, 0.9165, 0.92, 0.923,
+        0.9245, 0.9285, 0.932, 0.934, 0.935, 0.936, 0.9385, 0.9395, 0.94,
+        0.9405, 0.9405, 0.9405, 0.9405, 0.94, 0.9385, 0.936, 0.934,
+        0.931, 0.9295, 0.928, 0.928, 0.921, 0.92, 0.927, 0.9215};
+
+    G4MaterialPropertiesTable* MirrorMPT = new G4MaterialPropertiesTable();
     MirrorMPT->AddProperty("REFLECTIVITY", PhotonEnergy, ReflectivityMirrorBar, num);
-    MirrorMPT->AddProperty("EFFICIENCY", PhotonEnergy, EfficiencyMirrors,   num);
-  
+    MirrorMPT->AddProperty("EFFICIENCY", PhotonEnergy, EfficiencyMirrors, num);
+
     MirrorOpSurface->SetMaterialPropertiesTable(MirrorMPT);
-    new G4LogicalSkinSurface("MirrorSurface", lMirror,MirrorOpSurface);
+    new G4LogicalSkinSurface("MirrorSurface", lMirror, MirrorOpSurface);
   }
-  
+
   SetVisualization();
 
   /*PrtOpBoundaryProcess *fBoundaryProcess = new PrtOpBoundaryProcess();
@@ -802,81 +826,78 @@ void G4EicDircDetector::ConstructMe(G4LogicalVolume *logicWorld)
   pmanager->AddDiscreteProcess(fBoundaryProcess);
   pmanager->SetProcessOrderingToFirst(fBoundaryProcess, idxPostStep);
   */
-
 }
 
 void G4EicDircDetector::DefineMaterials()
 {
-  G4String symbol;             //a=mass of a mole;
-  double a, z, density;      //z=mean number of protons;  
+  G4String symbol;       //a=mass of a mole;
+  double a, z, density;  //z=mean number of protons;
 
   int ncomponents, natoms;
   double fractionmass;
 
   // define Elements
-  G4Element* H  = new G4Element("Hydrogen",symbol="H" , z= 1., a= 1.01*g/mole);
-  G4Element* C  = new G4Element("Carbon"  ,symbol="C" , z= 6., a= 12.01*g/mole);
-  G4Element* N  = new G4Element("Nitrogen",symbol="N" , z= 7., a= 14.01*g/mole);
-  G4Element* O  = new G4Element("Oxygen"  ,symbol="O" , z= 8., a= 16.00*g/mole);
-  G4Element* Si = new G4Element("Silicon" ,symbol="Si", z= 14., a= 28.09*g/mole);
-  G4Element* Al = new G4Element("Aluminum",symbol="Al", z=13., a=26.98*g/mole);
-
+  G4Element* H = new G4Element("Hydrogen", symbol = "H", z = 1., a = 1.01 * g / mole);
+  G4Element* C = new G4Element("Carbon", symbol = "C", z = 6., a = 12.01 * g / mole);
+  G4Element* N = new G4Element("Nitrogen", symbol = "N", z = 7., a = 14.01 * g / mole);
+  G4Element* O = new G4Element("Oxygen", symbol = "O", z = 8., a = 16.00 * g / mole);
+  G4Element* Si = new G4Element("Silicon", symbol = "Si", z = 14., a = 28.09 * g / mole);
+  G4Element* Al = new G4Element("Aluminum", symbol = "Al", z = 13., a = 26.98 * g / mole);
 
   // quartz material = SiO2
-  G4Material* SiO2 = new G4Material("quartz",density= 2.200*g/cm3, ncomponents=2);
-  SiO2->AddElement(Si, natoms=1);
-  SiO2->AddElement(O , natoms=2);
+  G4Material* SiO2 = new G4Material("quartz", density = 2.200 * g / cm3, ncomponents = 2);
+  SiO2->AddElement(Si, natoms = 1);
+  SiO2->AddElement(O, natoms = 2);
 
-  Nlak33aMaterial  = new G4Material("Nlak33a",density= 4.220*g/cm3, ncomponents=2);
-  Nlak33aMaterial->AddElement(Si, natoms=1);
-  Nlak33aMaterial->AddElement(O , natoms=2);
+  Nlak33aMaterial = new G4Material("Nlak33a", density = 4.220 * g / cm3, ncomponents = 2);
+  Nlak33aMaterial->AddElement(Si, natoms = 1);
+  Nlak33aMaterial->AddElement(O, natoms = 2);
 
-  PbF2Material  = new G4Material("PbF2",density= 3.97*g/cm3, ncomponents=2);
-  PbF2Material->AddElement(Si, natoms=1);
-  PbF2Material->AddElement(O , natoms=2);
+  PbF2Material = new G4Material("PbF2", density = 3.97 * g / cm3, ncomponents = 2);
+  PbF2Material->AddElement(Si, natoms = 1);
+  PbF2Material->AddElement(O, natoms = 2);
 
-  SapphireMaterial  = new G4Material("Sapphire",density= 4.220*g/cm3, ncomponents=2);
-  SapphireMaterial->AddElement(Al, natoms=2);
-  SapphireMaterial->AddElement(O , natoms=3);
-  
-  G4Material* Vacuum = new G4Material("interGalactic", 1., 1.008*g/mole, 
-				      1.e-25*g/cm3, kStateGas, 
-				      2.73*kelvin, 3.e-18*pascal);
-  G4Material* Air = new G4Material("Air"  , density= 1.290*mg/cm3, ncomponents=2);
-  Air->AddElement(N, fractionmass=0.7);
-  Air->AddElement(O, fractionmass=0.3);
+  SapphireMaterial = new G4Material("Sapphire", density = 4.220 * g / cm3, ncomponents = 2);
+  SapphireMaterial->AddElement(Al, natoms = 2);
+  SapphireMaterial->AddElement(O, natoms = 3);
 
-  G4Material* Aluminum = new G4Material("Aluminum",density=2.7*g/cm3,ncomponents=1);
-  Aluminum->AddElement(Al,fractionmass=1.0);
+  G4Material* Vacuum = new G4Material("interGalactic", 1., 1.008 * g / mole,
+                                      1.e-25 * g / cm3, kStateGas,
+                                      2.73 * kelvin, 3.e-18 * pascal);
+  G4Material* Air = new G4Material("Air", density = 1.290 * mg / cm3, ncomponents = 2);
+  Air->AddElement(N, fractionmass = 0.7);
+  Air->AddElement(O, fractionmass = 0.3);
 
-  G4Material* KamLandOil = new G4Material("KamLandOil",density=0.914*g/cm3,ncomponents=2);
-  KamLandOil->AddElement(C,natoms=12);
-  KamLandOil->AddElement(H,natoms=26);
+  G4Material* Aluminum = new G4Material("Aluminum", density = 2.7 * g / cm3, ncomponents = 1);
+  Aluminum->AddElement(Al, fractionmass = 1.0);
 
-  G4Material* CarbonFiber = new G4Material("CarbonFiber", density=0.145*g/cm3, ncomponents=1);
-  CarbonFiber->AddElement(C,natoms=1);
-  
+  G4Material* KamLandOil = new G4Material("KamLandOil", density = 0.914 * g / cm3, ncomponents = 2);
+  KamLandOil->AddElement(C, natoms = 12);
+  KamLandOil->AddElement(H, natoms = 26);
+
+  G4Material* CarbonFiber = new G4Material("CarbonFiber", density = 0.145 * g / cm3, ncomponents = 1);
+  CarbonFiber->AddElement(C, natoms = 1);
 
   /* as I don't know the exact material composition,
      I will use Epoxyd material composition and add
      the optical property of Epotek to this material */
 
-  G4Material* Epotek = new G4Material("Epotek",density=1.2*g/cm3,ncomponents=3);
+  G4Material* Epotek = new G4Material("Epotek", density = 1.2 * g / cm3, ncomponents = 3);
 
-  Epotek->AddElement(C,natoms=3);
-  Epotek->AddElement(H,natoms=5);
-  Epotek->AddElement(O,natoms=2);
-
+  Epotek->AddElement(C, natoms = 3);
+  Epotek->AddElement(H, natoms = 5);
+  Epotek->AddElement(O, natoms = 2);
 
   // assign main materials
-  if(fGeomType < 10) defaultMaterial = Vacuum;
-  else defaultMaterial = Air; //Vacuum // material of world
-  frontMaterial =  CarbonFiber; 
-  BarMaterial = SiO2; // material of all Bars, Quartz and Window
-  OilMaterial = KamLandOil; // material of volume 1,2,3,4
-  MirrorMaterial = Aluminum; // mirror material
-  epotekMaterial = Epotek; // Epotek material - glue between bars
-
+  if (fGeomType < 10)
+    defaultMaterial = Vacuum;
+  else
+    defaultMaterial = Air;  //Vacuum // material of world
+  frontMaterial = CarbonFiber;
+  BarMaterial = SiO2;         // material of all Bars, Quartz and Window
+  OilMaterial = KamLandOil;   // material of volume 1,2,3,4
+  MirrorMaterial = Aluminum;  // mirror material
+  epotekMaterial = Epotek;    // Epotek material - glue between bars
 
   // ------------ Generate & Add Material Properties Table ------------
 
@@ -884,109 +905,107 @@ void G4EicDircDetector::DefineMaterials()
   const int num = 36;
   double WaveLength[num];
   //double Absorption[num]; // default value for absorption
-  double AirAbsorption[num]; // absorption value for air
-  double AirRefractiveIndex[num]; // air refractive index
-  double PhotonEnergy[num]; // energy of photons which correspond to the given 
+  double AirAbsorption[num];       // absorption value for air
+  double AirRefractiveIndex[num];  // air refractive index
+  double PhotonEnergy[num];        // energy of photons which correspond to the given
   // refractive or absoprtion values
 
-  double PhotonEnergyNlak33a[76] = {1,1.2511,1.26386,1.27687,1.29016,1.30372,1.31758,1.33173,1.34619,1.36097,1.37607,1.39152,1.40731,1.42347,1.44,1.45692,1.47425,1.49199,1.51016,1.52878,1.54787,1.56744,1.58751,1.6081,1.62923,1.65092,1.6732,1.69609,1.71961,1.7438,1.76868,1.79427,1.82062,1.84775,1.87571,1.90452,1.93423,1.96488,1.99652,2.0292,2.06296,2.09787,2.13398,2.17135,2.21006,2.25017,2.29176,2.33492,2.37973,2.42631,2.47473,2.52514,2.57763,2.63236,2.68946,2.7491,2.81143,2.87666,2.94499,3.01665,3.09187,3.17095,3.25418,3.34189,3.43446,3.53231,3.6359,3.74575,3.86244,3.98663,4.11908,4.26062,4.41225,4.57506,4.75035,4.93961};
-  
-  int n_PbF2=56;
-  double en_PbF2[] = {1.55 ,1.569,1.59 ,1.61 ,1.631,1.653,1.675,1.698,1.722,1.746,1.771,1.797,1.823,1.851,1.879,1.907,1.937,1.968,2    ,2.033,2.066,2.101,2.138,2.175,2.214,2.254,2.296,2.339,2.384,2.431,2.48 ,2.53 ,2.583,2.638,2.695,2.755,2.818,2.883,2.952,3.024,3.1  ,3.179,3.263,3.351,3.444,3.542,3.647,3.757,3.875,3.999,4.133,4.275,4.428,4.592,4.769,4.959};
-  double ab_PbF2[]= {407,403.3,379.1,406.3,409.7,408.9,406.7,404.7,391.7,397.7,409.6,403.7,403.8,409.7,404.9,404.2,407.1,411.1,403.1,406.1,415.4,399.1,405.8,408.2,385.7,405.6,405.2,401.6,402.6,407.1,417.7,401.1,389.9,411.9,400.9,398.3,402.1,408.7,384.8,415.8,413.1,385.7,353.7,319.1,293.6,261.9,233.6,204.4,178.3,147.6,118.2,78.7 ,51.6 ,41.5 ,24.3 ,8.8};
-  double ref_PbF2[]= {1.749,1.749,1.75 ,1.75 ,1.751,1.752,1.752,1.753,1.754,1.754,1.755,1.756,1.757,1.757,1.758,1.759,1.76 ,1.761,1.762,1.764,1.765,1.766,1.768,1.769,1.771,1.772,1.774,1.776,1.778,1.78 ,1.782,1.785,1.787,1.79 ,1.793,1.796,1.8  ,1.804,1.808,1.813,1.818,1.824,1.83 ,1.837,1.845,1.854,1.865,1.877,1.892,1.91 ,1.937,1.991,1.38 ,1.915,1.971,2.019};
+  double PhotonEnergyNlak33a[76] = {1, 1.2511, 1.26386, 1.27687, 1.29016, 1.30372, 1.31758, 1.33173, 1.34619, 1.36097, 1.37607, 1.39152, 1.40731, 1.42347, 1.44, 1.45692, 1.47425, 1.49199, 1.51016, 1.52878, 1.54787, 1.56744, 1.58751, 1.6081, 1.62923, 1.65092, 1.6732, 1.69609, 1.71961, 1.7438, 1.76868, 1.79427, 1.82062, 1.84775, 1.87571, 1.90452, 1.93423, 1.96488, 1.99652, 2.0292, 2.06296, 2.09787, 2.13398, 2.17135, 2.21006, 2.25017, 2.29176, 2.33492, 2.37973, 2.42631, 2.47473, 2.52514, 2.57763, 2.63236, 2.68946, 2.7491, 2.81143, 2.87666, 2.94499, 3.01665, 3.09187, 3.17095, 3.25418, 3.34189, 3.43446, 3.53231, 3.6359, 3.74575, 3.86244, 3.98663, 4.11908, 4.26062, 4.41225, 4.57506, 4.75035, 4.93961};
 
-  const int n_Sapphire=57;
-  double en_Sapphire[] = {1.02212,1.05518,1.09045,1.12610,1.16307,1.20023,1.23984,1.28043,1.32221,1.36561,1.41019,1.45641,1.50393,1.55310,1.60393,1.65643,1.71059,1.76665,1.82437,1.88397,1.94576,2.00946,2.07504,2.14283,2.21321,2.28542,2.36025,2.43727,2.51693,2.59924,2.68480,2.77245,2.86337,2.95693,3.05379,3.15320,3.25674,3.36273,3.47294,3.58646,3.70433,3.82549,3.94979,4.07976,4.21285,4.35032,4.49380,4.64012,4.79258,4.94946,5.11064,5.27816,5.44985,5.62797,5.81266,6.00407,6.19920};
-  double ref_Sapphire[] = {1.75188,1.75253,1.75319,1.75382,1.75444,1.75505,1.75567,1.75629,1.75691,1.75754,1.75818,1.75883,1.75949,1.76017,1.76088,1.76160,1.76235,1.76314,1.76395,1.76480,1.76570,1.76664,1.76763,1.76867,1.76978,1.77095,1.77219,1.77350,1.77490,1.77639,1.77799,1.77968,1.78150,1.78343,1.78551,1.78772,1.79011,1.79265,1.79540,1.79835,1.80154,1.80497,1.80864,1.81266,1.81696,1.82163,1.82674,1.83223,1.83825,1.84480,1.85191,1.85975,1.86829,1.87774,1.88822,1.89988,1.91270};
+  int n_PbF2 = 56;
+  double en_PbF2[] = {1.55, 1.569, 1.59, 1.61, 1.631, 1.653, 1.675, 1.698, 1.722, 1.746, 1.771, 1.797, 1.823, 1.851, 1.879, 1.907, 1.937, 1.968, 2, 2.033, 2.066, 2.101, 2.138, 2.175, 2.214, 2.254, 2.296, 2.339, 2.384, 2.431, 2.48, 2.53, 2.583, 2.638, 2.695, 2.755, 2.818, 2.883, 2.952, 3.024, 3.1, 3.179, 3.263, 3.351, 3.444, 3.542, 3.647, 3.757, 3.875, 3.999, 4.133, 4.275, 4.428, 4.592, 4.769, 4.959};
+  double ab_PbF2[] = {407, 403.3, 379.1, 406.3, 409.7, 408.9, 406.7, 404.7, 391.7, 397.7, 409.6, 403.7, 403.8, 409.7, 404.9, 404.2, 407.1, 411.1, 403.1, 406.1, 415.4, 399.1, 405.8, 408.2, 385.7, 405.6, 405.2, 401.6, 402.6, 407.1, 417.7, 401.1, 389.9, 411.9, 400.9, 398.3, 402.1, 408.7, 384.8, 415.8, 413.1, 385.7, 353.7, 319.1, 293.6, 261.9, 233.6, 204.4, 178.3, 147.6, 118.2, 78.7, 51.6, 41.5, 24.3, 8.8};
+  double ref_PbF2[] = {1.749, 1.749, 1.75, 1.75, 1.751, 1.752, 1.752, 1.753, 1.754, 1.754, 1.755, 1.756, 1.757, 1.757, 1.758, 1.759, 1.76, 1.761, 1.762, 1.764, 1.765, 1.766, 1.768, 1.769, 1.771, 1.772, 1.774, 1.776, 1.778, 1.78, 1.782, 1.785, 1.787, 1.79, 1.793, 1.796, 1.8, 1.804, 1.808, 1.813, 1.818, 1.824, 1.83, 1.837, 1.845, 1.854, 1.865, 1.877, 1.892, 1.91, 1.937, 1.991, 1.38, 1.915, 1.971, 2.019};
+
+  const int n_Sapphire = 57;
+  double en_Sapphire[] = {1.02212, 1.05518, 1.09045, 1.12610, 1.16307, 1.20023, 1.23984, 1.28043, 1.32221, 1.36561, 1.41019, 1.45641, 1.50393, 1.55310, 1.60393, 1.65643, 1.71059, 1.76665, 1.82437, 1.88397, 1.94576, 2.00946, 2.07504, 2.14283, 2.21321, 2.28542, 2.36025, 2.43727, 2.51693, 2.59924, 2.68480, 2.77245, 2.86337, 2.95693, 3.05379, 3.15320, 3.25674, 3.36273, 3.47294, 3.58646, 3.70433, 3.82549, 3.94979, 4.07976, 4.21285, 4.35032, 4.49380, 4.64012, 4.79258, 4.94946, 5.11064, 5.27816, 5.44985, 5.62797, 5.81266, 6.00407, 6.19920};
+  double ref_Sapphire[] = {1.75188, 1.75253, 1.75319, 1.75382, 1.75444, 1.75505, 1.75567, 1.75629, 1.75691, 1.75754, 1.75818, 1.75883, 1.75949, 1.76017, 1.76088, 1.76160, 1.76235, 1.76314, 1.76395, 1.76480, 1.76570, 1.76664, 1.76763, 1.76867, 1.76978, 1.77095, 1.77219, 1.77350, 1.77490, 1.77639, 1.77799, 1.77968, 1.78150, 1.78343, 1.78551, 1.78772, 1.79011, 1.79265, 1.79540, 1.79835, 1.80154, 1.80497, 1.80864, 1.81266, 1.81696, 1.82163, 1.82674, 1.83223, 1.83825, 1.84480, 1.85191, 1.85975, 1.86829, 1.87774, 1.88822, 1.89988, 1.91270};
 
   double ab_Sapphire[n_Sapphire];
   //crystan standard grade 2mm
-  double transmitance_Sapphire[]= {0.845,0.844,0.843,0.843,0.843,0.843,0.843,0.843,0.843,0.843,0.843,0.843,0.843,0.843,0.843,0.843,0.843,0.843,0.843,0.843,0.842,0.842,0.842,0.842,0.838,0.838,0.838,0.838,0.838,0.838,0.836,0.836,0.836,0.836,0.834,0.834,0.833,0.832,0.832,0.831,0.831,0.83,0.828,0.828,0.828,0.828,0.828,0.828,0.828,0.828,0.828,0.825,0.80,0.67,0.47,0.23,0.22};
-  for(int i=0;i<n_Sapphire;i++)  ab_Sapphire[i] = (-1)/log(transmitance_Sapphire[i]+2*0.077007)*2*mm;
+  double transmitance_Sapphire[] = {0.845, 0.844, 0.843, 0.843, 0.843, 0.843, 0.843, 0.843, 0.843, 0.843, 0.843, 0.843, 0.843, 0.843, 0.843, 0.843, 0.843, 0.843, 0.843, 0.843, 0.842, 0.842, 0.842, 0.842, 0.838, 0.838, 0.838, 0.838, 0.838, 0.838, 0.836, 0.836, 0.836, 0.836, 0.834, 0.834, 0.833, 0.832, 0.832, 0.831, 0.831, 0.83, 0.828, 0.828, 0.828, 0.828, 0.828, 0.828, 0.828, 0.828, 0.828, 0.825, 0.80, 0.67, 0.47, 0.23, 0.22};
+  for (int i = 0; i < n_Sapphire; i++) ab_Sapphire[i] = (-1) / log(transmitance_Sapphire[i] + 2 * 0.077007) * 2 * mm;
 
-  
   /*************************** ABSORPTION COEFFICIENTS *****************************/
 
   // absorption of KamLandOil per 50 cm - from jjv
-  double KamLandOilAbsorption[num]=
-    {0.97469022,0.976603956,0.978511548,0.980400538,0.982258449,0.984072792,
-     0.985831062,0.987520743,0.989129303,0.990644203,0.992052894,
-     0.993342822,0.994501428,0.995516151,0.996374433,0.997063719,
-     0.997571464,0.997885132,0.997992205,0.997880183,0.997536591,
-     0.99,0.98,0.97,0.96,0.94,0.93,0.924507,0.89982,0.883299,
-     0.85657,0.842637,0.77020213,0.65727,0.324022,0.019192};
+  double KamLandOilAbsorption[num] =
+      {0.97469022, 0.976603956, 0.978511548, 0.980400538, 0.982258449, 0.984072792,
+       0.985831062, 0.987520743, 0.989129303, 0.990644203, 0.992052894,
+       0.993342822, 0.994501428, 0.995516151, 0.996374433, 0.997063719,
+       0.997571464, 0.997885132, 0.997992205, 0.997880183, 0.997536591,
+       0.99, 0.98, 0.97, 0.96, 0.94, 0.93, 0.924507, 0.89982, 0.883299,
+       0.85657, 0.842637, 0.77020213, 0.65727, 0.324022, 0.019192};
 
   // absorption of quartz per 1 m - from jjv
-  double QuartzAbsorption[num] = 
-    {0.999572036,0.999544661,0.999515062,0.999483019,0.999448285,
-     0.999410586,0.999369611,0.999325013,0.999276402,0.999223336,
-     0.999165317,0.999101778,0.999032079,0.998955488,0.998871172,
-     0.998778177,0.99867541,0.998561611,0.998435332,0.998294892,0.998138345,
-     0.997963425,0.997767484,0.997547418,
-     0.99729958,0.99701966,0.99670255,0.996342167,0.995931242,0.995461041,
-     0.994921022,0.994298396,0.993577567,0.992739402,0.991760297,0.990610945};
-  
+  double QuartzAbsorption[num] =
+      {0.999572036, 0.999544661, 0.999515062, 0.999483019, 0.999448285,
+       0.999410586, 0.999369611, 0.999325013, 0.999276402, 0.999223336,
+       0.999165317, 0.999101778, 0.999032079, 0.998955488, 0.998871172,
+       0.998778177, 0.99867541, 0.998561611, 0.998435332, 0.998294892, 0.998138345,
+       0.997963425, 0.997767484, 0.997547418,
+       0.99729958, 0.99701966, 0.99670255, 0.996342167, 0.995931242, 0.995461041,
+       0.994921022, 0.994298396, 0.993577567, 0.992739402, 0.991760297, 0.990610945};
+
   // absorption of epotek per one layer - thicknes 0.001'' - from jjv
-  double EpotekAbsorption[num] = 
-    {0.99999999,0.99999999,0.99999999,0.99999999,0.99999999,
-     0.99999999,0.99999999,0.99999999,0.99999999,0.99999999,
-     0.99999999,0.99999999,0.99999999,0.99999999,0.99999999,
-     0.99999999,0.99999999,0.99999999,0.99999999,0.99999999,
-     0.99999999,0.99999999,0.99999999,0.99999999,0.99999999,
-     0.9999,0.9998,0.9995,0.999,0.998,0.997,0.996,0.9955,0.993,
-     0.9871,0.9745};
+  double EpotekAbsorption[num] =
+      {0.99999999, 0.99999999, 0.99999999, 0.99999999, 0.99999999,
+       0.99999999, 0.99999999, 0.99999999, 0.99999999, 0.99999999,
+       0.99999999, 0.99999999, 0.99999999, 0.99999999, 0.99999999,
+       0.99999999, 0.99999999, 0.99999999, 0.99999999, 0.99999999,
+       0.99999999, 0.99999999, 0.99999999, 0.99999999, 0.99999999,
+       0.9999, 0.9998, 0.9995, 0.999, 0.998, 0.997, 0.996, 0.9955, 0.993,
+       0.9871, 0.9745};
 
   //N-Lak 33a
-  double Nlak33aAbsorption[76]={371813,352095,331021,310814,291458,272937,255238,238342,222234,206897,192313,178463,165331,152896,141140,130043,119585,109747,100507,91846.3,83743.1,76176.7,69126.1,62570.2,56488,50858.3,45660.1,40872.4,36474.6,32445.8,28765.9,25414.6,22372.2,19619.3,17136.9,14906.5,12910.2,11130.3,9550.13,8153.3,6924.25,5848.04,4910.46,4098.04,3398.06,2798.54,2288.32,1856.99,1494.92,1193.28,943.973,739.657,573.715,440.228,333.94,250.229,185.064,134.967,96.9664,68.5529,47.6343,32.4882,21.7174,14.2056,9.07612,5.65267,3.4241,2.01226,1.14403,0.62722,0.330414,0.166558,0.0799649,0.0363677,0.0155708,0.00623089};
+  double Nlak33aAbsorption[76] = {371813, 352095, 331021, 310814, 291458, 272937, 255238, 238342, 222234, 206897, 192313, 178463, 165331, 152896, 141140, 130043, 119585, 109747, 100507, 91846.3, 83743.1, 76176.7, 69126.1, 62570.2, 56488, 50858.3, 45660.1, 40872.4, 36474.6, 32445.8, 28765.9, 25414.6, 22372.2, 19619.3, 17136.9, 14906.5, 12910.2, 11130.3, 9550.13, 8153.3, 6924.25, 5848.04, 4910.46, 4098.04, 3398.06, 2798.54, 2288.32, 1856.99, 1494.92, 1193.28, 943.973, 739.657, 573.715, 440.228, 333.94, 250.229, 185.064, 134.967, 96.9664, 68.5529, 47.6343, 32.4882, 21.7174, 14.2056, 9.07612, 5.65267, 3.4241, 2.01226, 1.14403, 0.62722, 0.330414, 0.166558, 0.0799649, 0.0363677, 0.0155708, 0.00623089};
 
-  double EpotekThickness = 0.001*2.54*cm;
-  for(int i=0;i<num;i++){
-    WaveLength[i]= (300 +i*10)*nanometer;
+  double EpotekThickness = 0.001 * 2.54 * cm;
+  for (int i = 0; i < num; i++)
+  {
+    WaveLength[i] = (300 + i * 10) * nanometer;
     //Absorption[i]= 100*m; // not true, just due to definiton -> not absorb any
-    AirAbsorption[i] = 4.*cm; // if photon in the air -> kill it immediately
-    AirRefractiveIndex[i] = 1.; 
-    PhotonEnergy[num-(i+1)]= LambdaE/WaveLength[i];
+    AirAbsorption[i] = 4. * cm;  // if photon in the air -> kill it immediately
+    AirRefractiveIndex[i] = 1.;
+    PhotonEnergy[num - (i + 1)] = LambdaE / WaveLength[i];
 
     /* as the absorption is given per length and G4 needs 
        mean free path length, calculate it here
        mean free path length - taken as probability equal 1/e
        that the photon will be absorbed */
-      
-    EpotekAbsorption[i] = (-1)/log(EpotekAbsorption[i])*EpotekThickness;
-    QuartzAbsorption[i] = (-1)/log(QuartzAbsorption[i])*100*cm;
-    KamLandOilAbsorption[i] = (-1)/log(KamLandOilAbsorption[i])*50*cm;
+
+    EpotekAbsorption[i] = (-1) / log(EpotekAbsorption[i]) * EpotekThickness;
+    QuartzAbsorption[i] = (-1) / log(QuartzAbsorption[i]) * 100 * cm;
+    KamLandOilAbsorption[i] = (-1) / log(KamLandOilAbsorption[i]) * 50 * cm;
   }
- 
 
-  
   /**************************** REFRACTIVE INDEXES ****************************/
-  
+
   // only phase refractive indexes are necessary -> g4 calculates group itself !!
-  
-  double QuartzRefractiveIndex[num]={
-    1.456535,1.456812,1.4571,1.457399,1.457712,1.458038,1.458378,
-    1.458735,1.459108,1.4595,1.459911,1.460344,1.460799,1.46128,
-    1.461789,1.462326,1.462897,1.463502,1.464146,1.464833,
-    1.465566,1.46635,1.46719,1.468094,1.469066,1.470116,1.471252,1.472485,
-    1.473826,1.475289,1.476891,1.478651,1.480592,1.482739,1.485127,1.487793};
 
-  double EpotekRefractiveIndex[num]={
-    1.554034,1.555575,1.55698,1.558266,1.559454,1.56056,1.561604,
-    1.562604,1.563579,1.564547,1.565526,1.566536,1.567595,
-    1.568721,1.569933,1.57125,1.57269,1.574271,1.576012,
-    1.577932,1.580049,1.582381,1.584948,1.587768,1.590859,
-    1.59424,1.597929,1.601946,1.606307,1.611033,1.616141,1.621651,1.62758,
-    1.633947,1.640771,1.64807};
+  double QuartzRefractiveIndex[num] = {
+      1.456535, 1.456812, 1.4571, 1.457399, 1.457712, 1.458038, 1.458378,
+      1.458735, 1.459108, 1.4595, 1.459911, 1.460344, 1.460799, 1.46128,
+      1.461789, 1.462326, 1.462897, 1.463502, 1.464146, 1.464833,
+      1.465566, 1.46635, 1.46719, 1.468094, 1.469066, 1.470116, 1.471252, 1.472485,
+      1.473826, 1.475289, 1.476891, 1.478651, 1.480592, 1.482739, 1.485127, 1.487793};
 
-  double KamLandOilRefractiveIndex[num]={
-    1.433055,1.433369,1.433698,1.434045,1.434409,1.434793,1.435198,
-    1.435626,1.436077,1.436555,1.4371,1.4376,1.4382,1.4388,1.4395,
-    1.4402,1.4409,1.4415,1.4425,1.4434,1.4444,1.4455,1.4464,1.4479,1.4501,
-    1.450428,1.451976,1.453666,1.455513,1.45754,1.45977,1.462231,1.464958,
-    1.467991,1.471377,1.475174};
+  double EpotekRefractiveIndex[num] = {
+      1.554034, 1.555575, 1.55698, 1.558266, 1.559454, 1.56056, 1.561604,
+      1.562604, 1.563579, 1.564547, 1.565526, 1.566536, 1.567595,
+      1.568721, 1.569933, 1.57125, 1.57269, 1.574271, 1.576012,
+      1.577932, 1.580049, 1.582381, 1.584948, 1.587768, 1.590859,
+      1.59424, 1.597929, 1.601946, 1.606307, 1.611033, 1.616141, 1.621651, 1.62758,
+      1.633947, 1.640771, 1.64807};
 
-  double Nlak33aRefractiveIndex[76]={1.73816,1.73836,1.73858,1.73881,1.73904,1.73928,1.73952,1.73976,1.74001,1.74026,1.74052,1.74078,1.74105,1.74132,1.7416,1.74189,1.74218,1.74249,1.74279,1.74311,1.74344,1.74378,1.74412,1.74448,1.74485,1.74522,1.74562,1.74602,1.74644,1.74687,1.74732,1.74779,1.74827,1.74878,1.7493,1.74985,1.75042,1.75101,1.75163,1.75228,1.75296,1.75368,1.75443,1.75521,1.75604,1.75692,1.75784,1.75882,1.75985,1.76095,1.76211,1.76335,1.76467,1.76608,1.76758,1.7692,1.77093,1.77279,1.7748,1.77698,1.77934,1.7819,1.7847,1.78775,1.79111,1.79481,1.79889,1.80343,1.8085,1.81419,1.82061,1.8279,1.83625,1.84589,1.85713,1.87039};
+  double KamLandOilRefractiveIndex[num] = {
+      1.433055, 1.433369, 1.433698, 1.434045, 1.434409, 1.434793, 1.435198,
+      1.435626, 1.436077, 1.436555, 1.4371, 1.4376, 1.4382, 1.4388, 1.4395,
+      1.4402, 1.4409, 1.4415, 1.4425, 1.4434, 1.4444, 1.4455, 1.4464, 1.4479, 1.4501,
+      1.450428, 1.451976, 1.453666, 1.455513, 1.45754, 1.45977, 1.462231, 1.464958,
+      1.467991, 1.471377, 1.475174};
+
+  double Nlak33aRefractiveIndex[76] = {1.73816, 1.73836, 1.73858, 1.73881, 1.73904, 1.73928, 1.73952, 1.73976, 1.74001, 1.74026, 1.74052, 1.74078, 1.74105, 1.74132, 1.7416, 1.74189, 1.74218, 1.74249, 1.74279, 1.74311, 1.74344, 1.74378, 1.74412, 1.74448, 1.74485, 1.74522, 1.74562, 1.74602, 1.74644, 1.74687, 1.74732, 1.74779, 1.74827, 1.74878, 1.7493, 1.74985, 1.75042, 1.75101, 1.75163, 1.75228, 1.75296, 1.75368, 1.75443, 1.75521, 1.75604, 1.75692, 1.75784, 1.75882, 1.75985, 1.76095, 1.76211, 1.76335, 1.76467, 1.76608, 1.76758, 1.7692, 1.77093, 1.77279, 1.7748, 1.77698, 1.77934, 1.7819, 1.7847, 1.78775, 1.79111, 1.79481, 1.79889, 1.80343, 1.8085, 1.81419, 1.82061, 1.8279, 1.83625, 1.84589, 1.85713, 1.87039};
 
   /* ASSIGNING REFRACTIVE AND ABSORPTION PROPERTIES TO THE GIVEN MATERIALS */
 
@@ -997,26 +1016,24 @@ void G4EicDircDetector::DefineMaterials()
     if (once)
     {
       once = false;
-      std::cout <<__PRETTY_FUNCTION__<<" : warning parameter disable_photon_sim = "<<
-          m_Params->get_int_param("disable_photon_sim")
-          <<" and photon simulation is disabled in DIRC!"<<std::endl;
+      std::cout << __PRETTY_FUNCTION__ << " : warning parameter disable_photon_sim = " << m_Params->get_int_param("disable_photon_sim")
+                << " and photon simulation is disabled in DIRC!" << std::endl;
     }
 
     // Quartz material => Si02
     G4MaterialPropertiesTable* QuartzMPT = new G4MaterialPropertiesTable();
-    QuartzMPT->AddProperty("RINDEX",       PhotonEnergy, QuartzRefractiveIndex,num);
-    QuartzMPT->AddProperty("ABSLENGTH",    PhotonEnergy, QuartzAbsorption,           num);
+    QuartzMPT->AddProperty("RINDEX", PhotonEnergy, QuartzRefractiveIndex, num);
+    QuartzMPT->AddProperty("ABSLENGTH", PhotonEnergy, QuartzAbsorption, num);
 
     // assign this parameter table to BAR material
     BarMaterial->SetMaterialPropertiesTable(QuartzMPT);
 
     // Air
     G4MaterialPropertiesTable* AirMPT = new G4MaterialPropertiesTable();
-    AirMPT->AddProperty("RINDEX",    PhotonEnergy, AirRefractiveIndex, num);
-    AirMPT->AddProperty("ABSLENGTH", PhotonEnergy, AirAbsorption,      num);
+    AirMPT->AddProperty("RINDEX", PhotonEnergy, AirRefractiveIndex, num);
+    AirMPT->AddProperty("ABSLENGTH", PhotonEnergy, AirAbsorption, num);
     //  assign this parameter table to the air
     defaultMaterial->SetMaterialPropertiesTable(AirMPT);
-
 
     // KamLandOil
     G4MaterialPropertiesTable* KamLandOilMPT = new G4MaterialPropertiesTable();
@@ -1028,21 +1045,20 @@ void G4EicDircDetector::DefineMaterials()
     // N-Lak 33a
     G4MaterialPropertiesTable* Nlak33aMPT = new G4MaterialPropertiesTable();
     Nlak33aMPT->AddProperty("RINDEX", PhotonEnergyNlak33a, Nlak33aRefractiveIndex, 76);
-    Nlak33aMPT->AddProperty("ABSLENGTH",PhotonEnergyNlak33a, Nlak33aAbsorption, 76);
+    Nlak33aMPT->AddProperty("ABSLENGTH", PhotonEnergyNlak33a, Nlak33aAbsorption, 76);
     Nlak33aMaterial->SetMaterialPropertiesTable(Nlak33aMPT);
 
     // PbF2
     G4MaterialPropertiesTable* PbF2MPT = new G4MaterialPropertiesTable();
     PbF2MPT->AddProperty("RINDEX", en_PbF2, ref_PbF2, n_PbF2);
-    PbF2MPT->AddProperty("ABSLENGTH",en_PbF2, ab_PbF2, n_PbF2);
+    PbF2MPT->AddProperty("ABSLENGTH", en_PbF2, ab_PbF2, n_PbF2);
     PbF2Material->SetMaterialPropertiesTable(PbF2MPT);
 
     // Sapphire
     G4MaterialPropertiesTable* SapphireMPT = new G4MaterialPropertiesTable();
     SapphireMPT->AddProperty("RINDEX", en_Sapphire, ref_Sapphire, n_Sapphire);
-    SapphireMPT->AddProperty("ABSLENGTH",en_Sapphire, ab_Sapphire, n_Sapphire);
+    SapphireMPT->AddProperty("ABSLENGTH", en_Sapphire, ab_Sapphire, n_Sapphire);
     SapphireMaterial->SetMaterialPropertiesTable(SapphireMPT);
-  
 
     // Epotek Glue
     G4MaterialPropertiesTable* EpotekMPT = new G4MaterialPropertiesTable();
@@ -1053,9 +1069,8 @@ void G4EicDircDetector::DefineMaterials()
   }
 }
 
-
-void G4EicDircDetector::SetVisualization(){
-
+void G4EicDircDetector::SetVisualization()
+{
   /*G4VisAttributes *waModuleEnvelope = new G4VisAttributes();
   waModuleEnvelope->SetVisibility(false);
   waModuleEnvelope->SetColour(G4Colour::Red());
@@ -1077,99 +1092,100 @@ void G4EicDircDetector::SetVisualization(){
   Log_Longitudinal_Support->SetVisAttributes(waSupport);
   Log_End_Support_inner->SetVisAttributes(waSupport);
   */
-  G4Colour DircColour = G4Colour(1.,1.0,0.);
+  G4Colour DircColour = G4Colour(1., 1.0, 0.);
 
   /*G4VisAttributes *waDirc = new G4VisAttributes(DircColour);
   waDirc->SetForceWireframe(true);
   waDirc->SetVisibility(false);
   lDirc->SetVisAttributes(waDirc);
   */
-  G4VisAttributes *waFd = new G4VisAttributes(DircColour);
+  G4VisAttributes* waFd = new G4VisAttributes(DircColour);
   waFd->SetForceWireframe(true);
   lFd->SetVisAttributes(waFd);
 
-  G4VisAttributes *waBar = new G4VisAttributes(G4Colour(0.,1.,0.9,0.05)); //0.05
+  G4VisAttributes* waBar = new G4VisAttributes(G4Colour(0., 1., 0.9, 0.05));  //0.05
   waBar->SetVisibility(true);
   lBarL->SetVisAttributes(waBar);
   lBarS->SetVisAttributes(waBar);
-  
-  G4VisAttributes *waGlue = new G4VisAttributes(G4Colour(0.,0.4,0.9,0.1));
+
+  G4VisAttributes* waGlue = new G4VisAttributes(G4Colour(0., 0.4, 0.9, 0.1));
   waGlue->SetVisibility(true);
   lGlue->SetVisAttributes(waGlue);
-  
-  G4VisAttributes *waMirror = new G4VisAttributes(G4Colour(1.,1.,0.9,0.2));
+
+  G4VisAttributes* waMirror = new G4VisAttributes(G4Colour(1., 1., 0.9, 0.2));
   waMirror->SetVisibility(true);
   lMirror->SetVisAttributes(waMirror);
 
   double transp = 0.4;
-  G4VisAttributes * vaLens = new G4VisAttributes(G4Colour(0.,1.,1.,transp));
+  G4VisAttributes* vaLens = new G4VisAttributes(G4Colour(0., 1., 1., transp));
   vaLens->SetForceWireframe(true);
   // vaLens->SetForceAuxEdgeVisible(true);
   // vaLens->SetForceLineSegmentsPerCircle(10);
   // vaLens->SetLineWidth(4);
-   
-  if(fLensId==100 )lLens3->SetVisAttributes(vaLens);    
-  
-  if(fLensId==2 || fLensId==3 || fLensId==6 ){
+
+  if (fLensId == 100) lLens3->SetVisAttributes(vaLens);
+
+  if (fLensId == 2 || fLensId == 3 || fLensId == 6)
+  {
     lLens1->SetVisAttributes(vaLens);
-    G4VisAttributes * vaLens2 = new G4VisAttributes(G4Colour(0.,1.,1.,transp));
-    vaLens2->SetColour(G4Colour(0.,0.5,1.,transp));
+    G4VisAttributes* vaLens2 = new G4VisAttributes(G4Colour(0., 1., 1., transp));
+    vaLens2->SetColour(G4Colour(0., 0.5, 1., transp));
     vaLens2->SetForceWireframe(true);
     lLens2->SetVisAttributes(vaLens2);
-    if(fLensId==3 || fLensId==6) lLens3->SetVisAttributes(vaLens);
+    if (fLensId == 3 || fLensId == 6) lLens3->SetVisAttributes(vaLens);
   }
 
-  G4VisAttributes *waPrizm = new G4VisAttributes(G4Colour(0.,0.9,0.9,0.4)); //0.4
+  G4VisAttributes* waPrizm = new G4VisAttributes(G4Colour(0., 0.9, 0.9, 0.4));  //0.4
   // waPrizm->SetForceAuxEdgeVisible(true);
   // waPrizm->SetForceSolid(true);
   lPrizm->SetVisAttributes(waPrizm);
 
   // G4VisAttributes *waMcp = new G4VisAttributes(G4Colour(0.1,0.1,0.9,0.3));
-  G4VisAttributes *waMcp = new G4VisAttributes(G4Colour(1.0,0.,0.1,0.4));
+  G4VisAttributes* waMcp = new G4VisAttributes(G4Colour(1.0, 0., 0.1, 0.4));
   // waMcp->SetForceWireframe(true);
   waMcp->SetForceSolid(true);
   lMcp->SetVisAttributes(waMcp);
 
-  G4VisAttributes *waPixel = new G4VisAttributes(G4Colour(0.7,0.0,0.1,0.5));
+  G4VisAttributes* waPixel = new G4VisAttributes(G4Colour(0.7, 0.0, 0.1, 0.5));
   waPixel->SetForceWireframe(true);
-  if(fMcpLayout==3) waPixel->SetVisibility(false);
-  else waPixel->SetVisibility(true);
+  if (fMcpLayout == 3)
+    waPixel->SetVisibility(false);
+  else
+    waPixel->SetVisibility(true);
   lPixel->SetVisAttributes(waPixel);
-
 }
 
-
-void G4EicDircDetector::SetQuantumEfficiency(int id){
+void G4EicDircDetector::SetQuantumEfficiency(int id)
+{
   const int num = 36;
   //ideal pmt quantum efficiency
-  double QuantumEfficiencyIdial[num]=
-    {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,
-     1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,
-     1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,
-     1.0,1.0,1.0,1.0,1.0,1.0};
+  double QuantumEfficiencyIdial[num] =
+      {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+       1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+       1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+       1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
 
-  // Burle PMT's 
+  // Burle PMT's
   double QuantumEfficiencyB[num] =
-    {0.,0.001,0.002,0.005,0.01,0.015,0.02,0.03,0.04,0.05,0.06,
-     0.07,0.09,0.1,0.13,0.15,0.17,0.2,0.24,0.26,0.28,0.282,0.284,0.286,
-     0.288,0.29,0.28,0.26,0.24,0.22,0.20,0.18,0.15,0.13,0.12,0.10};
-  
+      {0., 0.001, 0.002, 0.005, 0.01, 0.015, 0.02, 0.03, 0.04, 0.05, 0.06,
+       0.07, 0.09, 0.1, 0.13, 0.15, 0.17, 0.2, 0.24, 0.26, 0.28, 0.282, 0.284, 0.286,
+       0.288, 0.29, 0.28, 0.26, 0.24, 0.22, 0.20, 0.18, 0.15, 0.13, 0.12, 0.10};
+
   //hamamatsu pmt quantum efficiency
-  double QuantumEfficiencyPMT[num]=
-    {0.001,0.002,0.004,0.007,0.011,0.015,0.020,0.026,0.033,0.040,0.045,
-     0.056,0.067,0.085,0.109,0.129,0.138,0.147,0.158,0.170,
-     0.181,0.188,0.196,0.203,0.206,0.212,0.218,0.219,0.225,0.230,
-     0.228,0.222,0.217,0.210,0.199,0.177};
-  
-  if(id == 0 ) fQuantumEfficiency = QuantumEfficiencyIdial;
-  if(id == 1 ) fQuantumEfficiency = QuantumEfficiencyPMT;
-  if(id == 2 ) fQuantumEfficiency = QuantumEfficiencyB;
+  double QuantumEfficiencyPMT[num] =
+      {0.001, 0.002, 0.004, 0.007, 0.011, 0.015, 0.020, 0.026, 0.033, 0.040, 0.045,
+       0.056, 0.067, 0.085, 0.109, 0.129, 0.138, 0.147, 0.158, 0.170,
+       0.181, 0.188, 0.196, 0.203, 0.206, 0.212, 0.218, 0.219, 0.225, 0.230,
+       0.228, 0.222, 0.217, 0.210, 0.199, 0.177};
+
+  if (id == 0) fQuantumEfficiency = QuantumEfficiencyIdial;
+  if (id == 1) fQuantumEfficiency = QuantumEfficiencyPMT;
+  if (id == 2) fQuantumEfficiency = QuantumEfficiencyB;
 
   G4RunManager::GetRunManager()->GeometryHasBeenModified();
-
 }
 
-void G4EicDircDetector::Print(const std::string &what) const
+void G4EicDircDetector::Print(const std::string& what) const
 {
   std::cout << "EIC Dirc Detector:" << std::endl;
   if (what == "ALL" || what == "VOLUME")
@@ -1180,4 +1196,3 @@ void G4EicDircDetector::Print(const std::string &what) const
   }
   return;
 }
-

--- a/simulation/g4simulation/g4eicdirc/G4EicDircDetector.cc
+++ b/simulation/g4simulation/g4eicdirc/G4EicDircDetector.cc
@@ -990,55 +990,67 @@ void G4EicDircDetector::DefineMaterials()
 
   /* ASSIGNING REFRACTIVE AND ABSORPTION PROPERTIES TO THE GIVEN MATERIALS */
 
-  // Quartz material => Si02
-  G4MaterialPropertiesTable* QuartzMPT = new G4MaterialPropertiesTable();
-  QuartzMPT->AddProperty("RINDEX",       PhotonEnergy, QuartzRefractiveIndex,num);
-  QuartzMPT->AddProperty("ABSLENGTH",    PhotonEnergy, QuartzAbsorption,           num);
+  if (m_Params->get_int_param("disable_photon_sim") == 0)
+  {
+    // option disable photon simulation if explicitly set via macro
+    static bool once = true;
+    if (once)
+    {
+      once = false;
+      std::cout <<__PRETTY_FUNCTION__<<" : warning parameter disable_photon_sim = "<<
+          m_Params->get_int_param("disable_photon_sim")
+          <<" and photon simulation is disabled in DIRC!"<<std::endl;
+    }
 
-  // assign this parameter table to BAR material
-  BarMaterial->SetMaterialPropertiesTable(QuartzMPT);
+    // Quartz material => Si02
+    G4MaterialPropertiesTable* QuartzMPT = new G4MaterialPropertiesTable();
+    QuartzMPT->AddProperty("RINDEX",       PhotonEnergy, QuartzRefractiveIndex,num);
+    QuartzMPT->AddProperty("ABSLENGTH",    PhotonEnergy, QuartzAbsorption,           num);
 
-  // Air
-  G4MaterialPropertiesTable* AirMPT = new G4MaterialPropertiesTable();
-  AirMPT->AddProperty("RINDEX",    PhotonEnergy, AirRefractiveIndex, num);
-  AirMPT->AddProperty("ABSLENGTH", PhotonEnergy, AirAbsorption,      num);
-  //  assign this parameter table to the air 
-  defaultMaterial->SetMaterialPropertiesTable(AirMPT);
+    // assign this parameter table to BAR material
+    BarMaterial->SetMaterialPropertiesTable(QuartzMPT);
+
+    // Air
+    G4MaterialPropertiesTable* AirMPT = new G4MaterialPropertiesTable();
+    AirMPT->AddProperty("RINDEX",    PhotonEnergy, AirRefractiveIndex, num);
+    AirMPT->AddProperty("ABSLENGTH", PhotonEnergy, AirAbsorption,      num);
+    //  assign this parameter table to the air
+    defaultMaterial->SetMaterialPropertiesTable(AirMPT);
 
 
-  // KamLandOil                                                
-  G4MaterialPropertiesTable* KamLandOilMPT = new G4MaterialPropertiesTable();
-  KamLandOilMPT->AddProperty("RINDEX", PhotonEnergy, KamLandOilRefractiveIndex, num);
-  KamLandOilMPT->AddProperty("ABSLENGTH", PhotonEnergy, KamLandOilAbsorption, num);
-  // assing this parameter table  to the KamLandOil
-  OilMaterial->SetMaterialPropertiesTable(KamLandOilMPT);  
+    // KamLandOil
+    G4MaterialPropertiesTable* KamLandOilMPT = new G4MaterialPropertiesTable();
+    KamLandOilMPT->AddProperty("RINDEX", PhotonEnergy, KamLandOilRefractiveIndex, num);
+    KamLandOilMPT->AddProperty("ABSLENGTH", PhotonEnergy, KamLandOilAbsorption, num);
+    // assing this parameter table  to the KamLandOil
+    OilMaterial->SetMaterialPropertiesTable(KamLandOilMPT);
 
-  // N-Lak 33a                                                
-  G4MaterialPropertiesTable* Nlak33aMPT = new G4MaterialPropertiesTable();
-  Nlak33aMPT->AddProperty("RINDEX", PhotonEnergyNlak33a, Nlak33aRefractiveIndex, 76);
-  Nlak33aMPT->AddProperty("ABSLENGTH",PhotonEnergyNlak33a, Nlak33aAbsorption, 76);
-  Nlak33aMaterial->SetMaterialPropertiesTable(Nlak33aMPT);
+    // N-Lak 33a
+    G4MaterialPropertiesTable* Nlak33aMPT = new G4MaterialPropertiesTable();
+    Nlak33aMPT->AddProperty("RINDEX", PhotonEnergyNlak33a, Nlak33aRefractiveIndex, 76);
+    Nlak33aMPT->AddProperty("ABSLENGTH",PhotonEnergyNlak33a, Nlak33aAbsorption, 76);
+    Nlak33aMaterial->SetMaterialPropertiesTable(Nlak33aMPT);
 
-  // PbF2
-  G4MaterialPropertiesTable* PbF2MPT = new G4MaterialPropertiesTable();
-  PbF2MPT->AddProperty("RINDEX", en_PbF2, ref_PbF2, n_PbF2);
-  PbF2MPT->AddProperty("ABSLENGTH",en_PbF2, ab_PbF2, n_PbF2);
-  PbF2Material->SetMaterialPropertiesTable(PbF2MPT);
+    // PbF2
+    G4MaterialPropertiesTable* PbF2MPT = new G4MaterialPropertiesTable();
+    PbF2MPT->AddProperty("RINDEX", en_PbF2, ref_PbF2, n_PbF2);
+    PbF2MPT->AddProperty("ABSLENGTH",en_PbF2, ab_PbF2, n_PbF2);
+    PbF2Material->SetMaterialPropertiesTable(PbF2MPT);
 
-  // Sapphire
-  G4MaterialPropertiesTable* SapphireMPT = new G4MaterialPropertiesTable();
-  SapphireMPT->AddProperty("RINDEX", en_Sapphire, ref_Sapphire, n_Sapphire);
-  SapphireMPT->AddProperty("ABSLENGTH",en_Sapphire, ab_Sapphire, n_Sapphire);
-  SapphireMaterial->SetMaterialPropertiesTable(SapphireMPT);
-
+    // Sapphire
+    G4MaterialPropertiesTable* SapphireMPT = new G4MaterialPropertiesTable();
+    SapphireMPT->AddProperty("RINDEX", en_Sapphire, ref_Sapphire, n_Sapphire);
+    SapphireMPT->AddProperty("ABSLENGTH",en_Sapphire, ab_Sapphire, n_Sapphire);
+    SapphireMaterial->SetMaterialPropertiesTable(SapphireMPT);
   
-  // Epotek Glue                                        
-  G4MaterialPropertiesTable* EpotekMPT = new G4MaterialPropertiesTable();
-  EpotekMPT->AddProperty("RINDEX", PhotonEnergy, EpotekRefractiveIndex, num);
-  EpotekMPT->AddProperty("ABSLENGTH", PhotonEnergy, EpotekAbsorption, num);
-  // assign this parameter table to the epotek
-  epotekMaterial->SetMaterialPropertiesTable(EpotekMPT);
 
+    // Epotek Glue
+    G4MaterialPropertiesTable* EpotekMPT = new G4MaterialPropertiesTable();
+    EpotekMPT->AddProperty("RINDEX", PhotonEnergy, EpotekRefractiveIndex, num);
+    EpotekMPT->AddProperty("ABSLENGTH", PhotonEnergy, EpotekAbsorption, num);
+    // assign this parameter table to the epotek
+    epotekMaterial->SetMaterialPropertiesTable(EpotekMPT);
+  }
 }
 
 

--- a/simulation/g4simulation/g4eicdirc/G4EicDircDetector.h
+++ b/simulation/g4simulation/g4eicdirc/G4EicDircDetector.h
@@ -4,13 +4,13 @@
 #define G4EICDIRCDETECTOR_H
 
 #include <g4main/PHG4Detector.h>
-#include <Geant4/G4Types.hh>
-#include <Geant4/G4ThreeVector.hh>
-#include <Geant4/G4Material.hh>
 #include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4Material.hh>
+#include <Geant4/G4ThreeVector.hh>
+#include <Geant4/G4Types.hh>
 
-#include <set>
 #include <map>
+#include <set>
 #include <string>  // for string
 
 class G4EicDircDisplayAction;
@@ -24,38 +24,38 @@ class G4EicDircDetector : public PHG4Detector
 {
  public:
   //! constructor
-  G4EicDircDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam);
+  G4EicDircDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam);
 
   //! destructor
   virtual ~G4EicDircDetector() {}
 
   //! construct
-  virtual void ConstructMe(G4LogicalVolume *world) override;
+  virtual void ConstructMe(G4LogicalVolume* world) override;
 
   void SetVisualization();
   void SetQuantumEfficiency(G4int id);
 
-  virtual void Print(const std::string &what = "ALL") const override;
+  virtual void Print(const std::string& what = "ALL") const override;
 
   //!@name volume accessors
   //@{
-  int IsInDetector(G4VPhysicalVolume *) const;
+  int IsInDetector(G4VPhysicalVolume*) const;
   //@}
- 
-  void SuperDetector(const std::string &name) { m_SuperDetector = name; }
+
+  void SuperDetector(const std::string& name) { m_SuperDetector = name; }
   const std::string SuperDetector() const { return m_SuperDetector; }
   std::string name_base = "test";
-  
- private:
-  G4LogicalVolume* DetectorLog_Det;
-  G4LogicalVolume* log_module_envelope;
-  G4LogicalVolume* Log_End_Support;
-  G4LogicalVolume* Log_Longitudinal_Support;
-  G4LogicalVolume* log_module_envelope_inner;
-  G4LogicalVolume* Log_End_Support_inner;
-  G4LogicalVolume* Log_Longitudinal_Support_inner;
 
-  G4LogicalVolume* lDirc;
+ private:
+  //G4LogicalVolume* DetectorLog_Det;
+  //G4LogicalVolume* log_module_envelope;
+  //G4LogicalVolume* Log_End_Support;
+  //G4LogicalVolume* Log_Longitudinal_Support;
+  //G4LogicalVolume* log_module_envelope_inner;
+  //G4LogicalVolume* Log_End_Support_inner;
+  //G4LogicalVolume* Log_Longitudinal_Support_inner;
+
+  //G4LogicalVolume* lDirc;
   G4LogicalVolume* lFd;
   G4LogicalVolume *lBarL, *lBarS;
   G4LogicalVolume* lGlue;
@@ -66,20 +66,20 @@ class G4EicDircDetector : public PHG4Detector
   G4LogicalVolume* lPrizm;
   G4LogicalVolume* lMcp;
   G4LogicalVolume* lPixel;
-  G4VPhysicalVolume*   pDirc[100];
-  G4VPhysicalVolume* wGlue;
-  G4VPhysicalVolume* wMirror;
+  //G4VPhysicalVolume* pDirc[100];
+  //G4VPhysicalVolume* wGlue;
+  //G4VPhysicalVolume* wMirror;
 
-  G4Material*        defaultMaterial; // material for bars
-  G4Material*        BarMaterial; // material for bars
-  G4Material*        OilMaterial;
-  G4Material*        MirrorMaterial; // material of mirror
-  G4Material*        epotekMaterial;  
-  G4Material*        Nlak33aMaterial;
-  G4Material*        PbF2Material;
-  G4Material*        SapphireMaterial;
-  G4Material*        frontMaterial;
-  
+  G4Material* defaultMaterial;  // material for bars
+  G4Material* BarMaterial;      // material for bars
+  G4Material* OilMaterial;
+  G4Material* MirrorMaterial;  // material of mirror
+  G4Material* epotekMaterial;
+  G4Material* Nlak33aMaterial;
+  G4Material* PbF2Material;
+  G4Material* SapphireMaterial;
+  G4Material* frontMaterial;
+
   G4int fNRow;
   G4int fNCol;
   G4int fNBoxes;
@@ -104,22 +104,20 @@ class G4EicDircDetector : public PHG4Detector
   G4double zshift;
 
   //G4double fRotAngle;
-  G4RotationMatrix *fPrtRot;
-  G4double *fQuantumEfficiency;
-
+  G4RotationMatrix* fPrtRot;
+  G4double* fQuantumEfficiency;
 
  protected:
   void DefineMaterials();
-  PHParameters *m_Params;
+  PHParameters* m_Params;
 
-  G4EicDircDisplayAction *m_DisplayAction;
+  G4EicDircDisplayAction* m_DisplayAction;
 
   // active volumes
   //std::map<G4VPhysicalVolume *, int> m_PhysicalVolumes_active;
-  std::map<G4LogicalVolume *, int> m_LogicalVolumes_active;
+  std::map<G4LogicalVolume*, int> m_LogicalVolumes_active;
 
   std::string m_SuperDetector;
-  
 };
 
 #endif  // G4EICDIRCDETECTOR_H

--- a/simulation/g4simulation/g4eicdirc/G4EicDircDisplayAction.cc
+++ b/simulation/g4simulation/g4eicdirc/G4EicDircDisplayAction.cc
@@ -22,7 +22,6 @@ G4EicDircDisplayAction::G4EicDircDisplayAction(const std::string &name, PHParame
 
 G4EicDircDisplayAction::~G4EicDircDisplayAction()
 {
-  
   delete m_VisAtt;
   delete m_Colour;
 }

--- a/simulation/g4simulation/g4eicdirc/G4EicDircDisplayAction.h
+++ b/simulation/g4simulation/g4eicdirc/G4EicDircDisplayAction.h
@@ -5,8 +5,8 @@
 
 #include <g4main/PHG4DisplayAction.h>
 
-#include <string>  // for string
 #include <map>
+#include <string>  // for string
 
 class G4Colour;
 class G4VisAttributes;

--- a/simulation/g4simulation/g4eicdirc/G4EicDircOpBoundaryProcess.cc
+++ b/simulation/g4simulation/g4eicdirc/G4EicDircOpBoundaryProcess.cc
@@ -1,16 +1,16 @@
 #include "G4EicDircOpBoundaryProcess.h"
 
 #include <Geant4/G4Step.hh>
-#include <Geant4/G4Track.hh>
 #include <Geant4/G4TouchableHistory.hh>
+#include <Geant4/G4Track.hh>
 
 #include <set>
 
 G4VParticleChange* G4EicDircOpBoundaryProcess::PostStepDoIt(const G4Track& aTrack, const G4Step& aStep)
-{  
-  G4StepPoint* pPreStepPoint  = aStep.GetPreStepPoint();
+{
+  G4StepPoint* pPreStepPoint = aStep.GetPreStepPoint();
   G4StepPoint* pPostStepPoint = aStep.GetPostStepPoint();
-  G4VParticleChange *pParticleChange = G4OpBoundaryProcess::PostStepDoIt(aTrack, aStep);
+  G4VParticleChange* pParticleChange = G4OpBoundaryProcess::PostStepDoIt(aTrack, aStep);
   // static std::set<std::string> prevol;
   // static std::set<std::string> postvol;
   // std::string prevolnam = pPreStepPoint->GetPhysicalVolume()->GetName();
@@ -59,21 +59,20 @@ G4VParticleChange* G4EicDircOpBoundaryProcess::PostStepDoIt(const G4Track& aTrac
     pParticleChange->ProposeTrackStatus(fStopAndKill);
     }*/
 
-  if(aStep.GetPreStepPoint()->GetPhysicalVolume()->GetName()=="wLens3" && pPostStepPoint->GetPosition().z()>pPreStepPoint->GetPosition().z()){
+  if (aStep.GetPreStepPoint()->GetPhysicalVolume()->GetName() == "wLens3" && pPostStepPoint->GetPosition().z() > pPreStepPoint->GetPosition().z())
+  {
     pParticleChange->ProposeTrackStatus(fStopAndKill);
   }
-  
-  
+
   // kill photons outside bar and prizm
 
-  if(GetStatus() == FresnelRefraction 
-     && aStep.GetPostStepPoint()->GetPhysicalVolume()->GetName()=="wDirc"){
+  if (GetStatus() == FresnelRefraction && aStep.GetPostStepPoint()->GetPhysicalVolume()->GetName() == "wDirc")
+  {
     pParticleChange->ProposeTrackStatus(fStopAndKill);
-    }
+  }
 
-  if((aStep.GetPreStepPoint()->GetPhysicalVolume()->GetName()=="wLens1" 
-      || aStep.GetPreStepPoint()->GetPhysicalVolume()->GetName()=="wLens2")
-     &&  aStep.GetPostStepPoint()->GetPhysicalVolume()->GetName()=="wDirc"){
+  if ((aStep.GetPreStepPoint()->GetPhysicalVolume()->GetName() == "wLens1" || aStep.GetPreStepPoint()->GetPhysicalVolume()->GetName() == "wLens2") && aStep.GetPostStepPoint()->GetPhysicalVolume()->GetName() == "wDirc")
+  {
     pParticleChange->ProposeTrackStatus(fStopAndKill);
   }
 
@@ -84,18 +83,15 @@ G4VParticleChange* G4EicDircOpBoundaryProcess::PostStepDoIt(const G4Track& aTrac
   // 	 &&  aStep.GetPostStepPoint()->GetPhysicalVolume()->GetName()=="wLens3")){
   //   pParticleChange->ProposeTrackStatus(fStopAndKill);
   // }
-  
-  
-  if(aStep.GetPreStepPoint()->GetPhysicalVolume()->GetName()=="wLens1" 
-     && aStep.GetPostStepPoint()->GetPhysicalVolume()->GetName()=="wLens1"){
+
+  if (aStep.GetPreStepPoint()->GetPhysicalVolume()->GetName() == "wLens1" && aStep.GetPostStepPoint()->GetPhysicalVolume()->GetName() == "wLens1")
+  {
     pParticleChange->ProposeTrackStatus(fStopAndKill);
   }
-  if(aStep.GetPreStepPoint()->GetPhysicalVolume()->GetName()=="wLens2" 
-     && aStep.GetPostStepPoint()->GetPhysicalVolume()->GetName()=="wLens2"){
+  if (aStep.GetPreStepPoint()->GetPhysicalVolume()->GetName() == "wLens2" && aStep.GetPostStepPoint()->GetPhysicalVolume()->GetName() == "wLens2")
+  {
     pParticleChange->ProposeTrackStatus(fStopAndKill);
-    }
-  
+  }
 
   return pParticleChange;
-
 }

--- a/simulation/g4simulation/g4eicdirc/G4EicDircOpBoundaryProcess.h
+++ b/simulation/g4simulation/g4eicdirc/G4EicDircOpBoundaryProcess.h
@@ -7,10 +7,12 @@
 
 class G4EicDircOpBoundaryProcess : public G4OpBoundaryProcess
 {
-public:
+ public:
   explicit G4EicDircOpBoundaryProcess(const G4String& processName = "G4EicDircOpBoundary",
-				    G4ProcessType type = fOptical) : G4OpBoundaryProcess()
-{}
+                                      G4ProcessType type = fOptical)
+    : G4OpBoundaryProcess()
+  {
+  }
 
   virtual ~G4EicDircOpBoundaryProcess() override {}
 
@@ -18,13 +20,11 @@ public:
 
   G4VParticleChange* PostStepDoIt(const G4Track& aTrack, const G4Step& aStep) override;
 
-private:
-
+ private:
 };
 
-inline
-G4bool G4EicDircOpBoundaryProcess::IsApplicable(const G4ParticleDefinition&
-                                                       aParticleType)
+inline G4bool G4EicDircOpBoundaryProcess::IsApplicable(const G4ParticleDefinition&
+                                                           aParticleType)
 {
   return (&aParticleType == G4OpticalPhoton::OpticalPhoton());
 }

--- a/simulation/g4simulation/g4eicdirc/G4EicDircStackingAction.cc
+++ b/simulation/g4simulation/g4eicdirc/G4EicDircStackingAction.cc
@@ -64,18 +64,17 @@ G4EicDircStackingAction::~G4EicDircStackingAction()
 
 G4ClassificationOfNewTrack G4EicDircStackingAction::ClassifyNewTrack(const G4Track* aTrack)
 {
-//  std::cout << "calling stacking action" << std::endl;
+  //  std::cout << "calling stacking action" << std::endl;
   G4VPhysicalVolume* volume = aTrack->GetVolume();
 
-
-  if(aTrack->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition())
-  { // particle is optical photon
-    if(aTrack->GetParentID()>0)
-    { // particle is secondary
-      if(aTrack->GetCreatorProcess()->GetProcessName() == "Scintillation")
+  if (aTrack->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition())
+  {  // particle is optical photon
+    if (aTrack->GetParentID() > 0)
+    {  // particle is secondary
+      if (aTrack->GetCreatorProcess()->GetProcessName() == "Scintillation")
         fScintillationCounter++;
-      if(aTrack->GetCreatorProcess()->GetProcessName() == "Cerenkov")
-      fCerenkovCounter++;
+      if (aTrack->GetCreatorProcess()->GetProcessName() == "Cerenkov")
+        fCerenkovCounter++;
     }
   }
 
@@ -87,7 +86,6 @@ G4ClassificationOfNewTrack G4EicDircStackingAction::ClassifyNewTrack(const G4Tra
     return fUrgent;
   }
 
-
   std::string particlename = aTrack->GetDefinition()->GetParticleName();
   if (particlename == "opticalphoton")
   {
@@ -98,22 +96,19 @@ G4ClassificationOfNewTrack G4EicDircStackingAction::ClassifyNewTrack(const G4Tra
     Double_t lambda = 197.0 * 2.0 * M_PI / (aTrack->GetMomentum().mag() * 1.0E6);
     Double_t ra = gsl_rng_uniform(m_RandomGenerator);
     if (ra > fDetEff[1]->Eval(lambda))
-    {      
+    {
       return fKill;
     }
   }
 
   return fUrgent;
-
 }
-
 
 void G4EicDircStackingAction::PrepareNewEvent()
 {
-  if (Verbosity ()) G4cout << "Number of Cerenkov photons produced in this event : " << fCerenkovCounter << G4endl;
+  if (Verbosity()) G4cout << "Number of Cerenkov photons produced in this event : " << fCerenkovCounter << G4endl;
   //  std::cout << "calling prepare new event" << std::endl;
   fCerenkovCounter = 0;
   fScintillationCounter = 0;
   return;
 }
-

--- a/simulation/g4simulation/g4eicdirc/G4EicDircStackingAction.h
+++ b/simulation/g4simulation/g4eicdirc/G4EicDircStackingAction.h
@@ -20,7 +20,6 @@ class G4EicDircStackingAction : public PHG4StackingAction
   G4ClassificationOfNewTrack ClassifyNewTrack(const G4Track* aTrack) override;
   void PrepareNewEvent() override;
 
-
  private:
   gsl_rng* m_RandomGenerator = nullptr;
   G4EicDircDetector* m_Detector = nullptr;

--- a/simulation/g4simulation/g4eicdirc/G4EicDircSteppingAction.cc
+++ b/simulation/g4simulation/g4eicdirc/G4EicDircSteppingAction.cc
@@ -26,17 +26,17 @@
 #include <Geant4/G4StepStatus.hh>  // for fGeomBoundary, fAtRest...
 #include <Geant4/G4String.hh>      // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
-#include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
-#include <Geant4/G4Track.hh>                  // for G4Track
-#include <Geant4/G4TrackStatus.hh>            // for fStopAndKill
-#include <Geant4/G4Types.hh>                  // for G4double
-#include <Geant4/G4VPhysicalVolume.hh>        // for G4VPhysicalVolume
+#include <Geant4/G4ThreeVector.hh>      // for G4ThreeVector
+#include <Geant4/G4TouchableHandle.hh>  // for G4TouchableHandle
+#include <Geant4/G4Track.hh>            // for G4Track
+#include <Geant4/G4TrackStatus.hh>      // for fStopAndKill
+#include <Geant4/G4TransportationManager.hh>
+#include <Geant4/G4Types.hh>            // for G4double
+#include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
+#include <Geant4/G4VProcess.hh>
 #include <Geant4/G4VTouchable.hh>             // for G4VTouchable
 #include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
-#include <Geant4/G4TransportationManager.hh>
 #include <Geant4/Randomize.hh>
-#include <Geant4/G4VProcess.hh>
 
 #include <cmath>  // for isfinite
 #include <iostream>
@@ -45,7 +45,7 @@
 class PHCompositeNode;
 //____________________________________________________________________________..
 G4EicDircSteppingAction::G4EicDircSteppingAction(
-    G4EicDircDetector *detector, const PHParameters *parameters)
+    G4EicDircDetector* detector, const PHParameters* parameters)
   : PHG4SteppingAction(detector->GetName())
   , m_Detector(detector)
   , m_Params(parameters)
@@ -63,22 +63,21 @@ G4EicDircSteppingAction::~G4EicDircSteppingAction()
   delete m_Hit;
 }
 
-
 //____________________________________________________________________________..
-bool G4EicDircSteppingAction::UserSteppingAction(const G4Step *aStep,
+bool G4EicDircSteppingAction::UserSteppingAction(const G4Step* aStep,
                                                  bool was_used)
 {
   G4TouchableHandle touch = aStep->GetPreStepPoint()->GetTouchableHandle();
   G4TouchableHandle touchpost = aStep->GetPostStepPoint()->GetTouchableHandle();
   // get volume of the current step
-  G4VPhysicalVolume *volume = touch->GetVolume();
-  G4VPhysicalVolume *volume_post = touchpost->GetVolume();
+  G4VPhysicalVolume* volume = touch->GetVolume();
+  //G4VPhysicalVolume* volume_post = touchpost->GetVolume();
   // IsInDetector(volume) returns
   //  == 0 outside of detector
   //   > 0 for hits in active volume
   //  < 0 for hits in passive material
   int whichactive_int = m_Detector->IsInDetector(volume);
-  int whichactive_int_post = m_Detector->IsInDetector(volume_post);
+  //int whichactive_int_post = m_Detector->IsInDetector(volume_post);
   bool whichactive = (whichactive_int > 0 && whichactive_int < 12);
 
   //int whichactive = m_Detector->IsInDetector(volume);
@@ -86,7 +85,6 @@ bool G4EicDircSteppingAction::UserSteppingAction(const G4Step *aStep,
   {
     return false;
   }
-
 
   // collect energy and track length step by step
   const G4Track* aTrack = aStep->GetTrack();
@@ -121,21 +119,21 @@ bool G4EicDircSteppingAction::UserSteppingAction(const G4Step *aStep,
     int prepointstatus = prePoint->GetStepStatus();
     if (prepointstatus == fGeomBoundary ||
         prepointstatus == fUndefined ||
-        (prepointstatus == fPostStepDoItProc && m_SavePostStepStatus == fGeomBoundary) )
+        (prepointstatus == fPostStepDoItProc && m_SavePostStepStatus == fGeomBoundary))
     {
       if (prepointstatus == fPostStepDoItProc && m_SavePostStepStatus == fGeomBoundary)
       {
         std::cout << GetName() << ": New Hit for  " << std::endl;
         std::cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-             << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-             << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
-             << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
+                  << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+                  << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
+                  << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
         std::cout << "last track: " << m_SaveTrackId
-             << ", current trackid: " << aTrack->GetTrackID() << std::endl;
+                  << ", current trackid: " << aTrack->GetTrackID() << std::endl;
         std::cout << "phys pre vol: " << volume->GetName()
-             << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
+                  << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
         std::cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
-             << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
+                  << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
       }
       if (!m_Hit)
       {
@@ -177,15 +175,15 @@ bool G4EicDircSteppingAction::UserSteppingAction(const G4Step *aStep,
     {
       std::cout << GetName() << ": hit was not created" << std::endl;
       std::cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-           << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-           << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
-           << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
+                << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+                << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
+                << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
       std::cout << "last track: " << m_SaveTrackId
-           << ", current trackid: " << aTrack->GetTrackID() << std::endl;
+                << ", current trackid: " << aTrack->GetTrackID() << std::endl;
       std::cout << "phys pre vol: " << volume->GetName()
-           << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
+                << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
       std::cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
-           << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
+                << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
       exit(1);
     }
     m_SavePostStepStatus = postPoint->GetStepStatus();
@@ -194,8 +192,8 @@ bool G4EicDircSteppingAction::UserSteppingAction(const G4Step *aStep,
     {
       std::cout << "hits do not belong to the same track" << std::endl;
       std::cout << "saved track: " << m_SaveTrackId
-           << ", current trackid: " << aTrack->GetTrackID()
-           << std::endl;
+                << ", current trackid: " << aTrack->GetTrackID()
+                << std::endl;
       exit(1);
     }
     m_SavePreStepStatus = prePoint->GetStepStatus();
@@ -249,7 +247,7 @@ bool G4EicDircSteppingAction::UserSteppingAction(const G4Step *aStep,
     if (postPoint->GetStepStatus() == fGeomBoundary ||
         postPoint->GetStepStatus() == fWorldBoundary ||
         postPoint->GetStepStatus() == fAtRestDoItProc ||
-        aTrack->GetTrackStatus() == fStopAndKill )
+        aTrack->GetTrackStatus() == fStopAndKill)
     {
       // save only hits with energy deposit (or -1 for geantino)
       if (m_Hit->get_edep())
@@ -277,7 +275,7 @@ bool G4EicDircSteppingAction::UserSteppingAction(const G4Step *aStep,
 }
 
 //____________________________________________________________________________..
-void G4EicDircSteppingAction::SetInterfacePointers(PHCompositeNode *topNode)
+void G4EicDircSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
 {
   if (!m_HitNodeName.empty())
   {
@@ -290,29 +288,23 @@ void G4EicDircSteppingAction::SetInterfacePointers(PHCompositeNode *topNode)
     {
       if (Verbosity() > 0)
       {
-	std::cout << "G4EicDircSteppingAction::SetTopNode - unable to find " << m_AbsorberNodeName << std::endl;
+        std::cout << "G4EicDircSteppingAction::SetTopNode - unable to find " << m_AbsorberNodeName << std::endl;
       }
     }
   }
-  if (! m_SupportNodeName.empty())
+  if (!m_SupportNodeName.empty())
   {
     m_SupportHitContainer = findNode::getClass<PHG4HitContainer>(topNode, m_SupportNodeName);
     if (!m_SupportHitContainer)
     {
       if (Verbosity() > 0)
       {
-	std::cout << "G4EicDircSteppingAction::SetTopNode - unable to find " << m_SupportNodeName << std::endl;
+        std::cout << "G4EicDircSteppingAction::SetTopNode - unable to find " << m_SupportNodeName << std::endl;
       }
     }
-
   }
   if (!m_HitContainer)
   {
     std::cout << "G4EicDircSteppingAction::SetTopNode - unable to find " << m_HitNodeName << std::endl;
   }
-
 }
-
-
-
-

--- a/simulation/g4simulation/g4eicdirc/G4EicDircSteppingAction.cc
+++ b/simulation/g4simulation/g4eicdirc/G4EicDircSteppingAction.cc
@@ -36,6 +36,7 @@
 #include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 #include <Geant4/G4TransportationManager.hh>
 #include <Geant4/Randomize.hh>
+#include <Geant4/G4VProcess.hh>
 
 #include <cmath>  // for isfinite
 #include <iostream>
@@ -88,9 +89,9 @@ bool G4EicDircSteppingAction::UserSteppingAction(const G4Step *aStep,
 
 
   // collect energy and track length step by step
+  const G4Track* aTrack = aStep->GetTrack();
   G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
   G4double eion = (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) / GeV;
-  const G4Track* aTrack = aStep->GetTrack();
 
   // if this block stops everything, just put all kinetic energy into edep
   if (m_BlackHoleFlag)
@@ -144,6 +145,10 @@ bool G4EicDircSteppingAction::UserSteppingAction(const G4Step *aStep,
       m_Hit->set_x(0, prePoint->GetPosition().x() / cm);
       m_Hit->set_y(0, prePoint->GetPosition().y() / cm);
       m_Hit->set_z(0, prePoint->GetPosition().z() / cm);
+
+      m_Hit->set_px(0, prePoint->GetMomentum().x() / GeV);
+      m_Hit->set_py(0, prePoint->GetMomentum().y() / GeV);
+      m_Hit->set_pz(0, prePoint->GetMomentum().z() / GeV);
       // time in ns
       m_Hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
       //set the track ID
@@ -205,9 +210,9 @@ bool G4EicDircSteppingAction::UserSteppingAction(const G4Step *aStep,
     m_Hit->set_y(1, postPoint->GetPosition().y() / cm);
     m_Hit->set_z(1, postPoint->GetPosition().z() / cm);
 
-    m_Hit->set_px(0, prePoint->GetMomentum().x() / GeV);
-    m_Hit->set_py(0, prePoint->GetMomentum().y() / GeV);
-    m_Hit->set_pz(0, prePoint->GetMomentum().z() / GeV);
+    m_Hit->set_px(1, postPoint->GetMomentum().x() / GeV);
+    m_Hit->set_py(1, postPoint->GetMomentum().y() / GeV);
+    m_Hit->set_pz(1, postPoint->GetMomentum().z() / GeV);
 
     m_Hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
     //sum up the energy to get total deposited

--- a/simulation/g4simulation/g4eicdirc/G4EicDircSteppingAction.cc
+++ b/simulation/g4simulation/g4eicdirc/G4EicDircSteppingAction.cc
@@ -205,6 +205,10 @@ bool G4EicDircSteppingAction::UserSteppingAction(const G4Step *aStep,
     m_Hit->set_y(1, postPoint->GetPosition().y() / cm);
     m_Hit->set_z(1, postPoint->GetPosition().z() / cm);
 
+    m_Hit->set_px(0, prePoint->GetMomentum().x() / GeV);
+    m_Hit->set_py(0, prePoint->GetMomentum().y() / GeV);
+    m_Hit->set_pz(0, prePoint->GetMomentum().z() / GeV);
+
     m_Hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
     //sum up the energy to get total deposited
     m_Hit->set_edep(m_Hit->get_edep() + edep);

--- a/simulation/g4simulation/g4eicdirc/G4EicDircSteppingAction.cc
+++ b/simulation/g4simulation/g4eicdirc/G4EicDircSteppingAction.cc
@@ -79,6 +79,7 @@ bool G4EicDircSteppingAction::UserSteppingAction(const G4Step *aStep,
   int whichactive_int = m_Detector->IsInDetector(volume);
   int whichactive_int_post = m_Detector->IsInDetector(volume_post);
   bool whichactive = (whichactive_int > 0 && whichactive_int < 12);
+
   //int whichactive = m_Detector->IsInDetector(volume);
   if (!whichactive)
   {
@@ -88,450 +89,182 @@ bool G4EicDircSteppingAction::UserSteppingAction(const G4Step *aStep,
 
   // collect energy and track length step by step
   G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
-  G4double eion =
-      (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) /
-      GeV;
-  const G4Track *aTrack = aStep->GetTrack();
+  G4double eion = (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) / GeV;
+  const G4Track* aTrack = aStep->GetTrack();
 
-
-  /*if(aTrack->GetCurrentStepNumber()>50000 || aTrack->GetTrackLength() > 30000) 
-    {
-      G4Track *killtrack0 = const_cast<G4Track *>(aTrack);
-      killtrack0->SetTrackStatus(fStopAndKill);
-      //return false;
-      }*/
-
-
-  /*if((whichactive_int == 10 && whichactive_int_post == 1) || (whichactive_int == 2 && whichactive_int_post == 1))
-    {
-      G4Track *killtrack = const_cast<G4Track *>(aTrack);
-      killtrack->SetTrackStatus(fStopAndKill);
-    }
-  */
- 
   // if this block stops everything, just put all kinetic energy into edep
   if (m_BlackHoleFlag)
   {
     edep = aTrack->GetKineticEnergy() / GeV;
-    G4Track *killtrack = const_cast<G4Track *>(aTrack);
+    G4Track* killtrack = const_cast<G4Track*>(aTrack);
     killtrack->SetTrackStatus(fStopAndKill);
   }
 
-
-  int detector_id = 0;  // we use here only one detector in this simple example
-  bool geantino = false;
-  // the check for the pdg code speeds things up, I do not want to make
-  // an expensive string compare for every track when we know
-  // geantino or chargedgeantino has pid=0
-  if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
-      aTrack->GetParticleDefinition()->GetParticleName().find("geantino") !=
-          std::string::npos)  // this also accounts for "chargedgeantino"
+  // make sure we are in a volume
+  if (m_ActiveFlag)
   {
-    geantino = true;
-  }
-  G4StepPoint *prePoint = aStep->GetPreStepPoint();
-  G4StepPoint *postPoint = aStep->GetPostStepPoint();
-  // cout << "track id " << aTrack->GetTrackID() << endl;
-  //       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
-  //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
-
-  G4String prePointVolName = prePoint->GetPhysicalVolume()->GetName();
-  G4String postPointVolName = postPoint->GetPhysicalVolume()->GetName();    
-
-  switch (prePoint->GetStepStatus())
-  {
-  case fPostStepDoItProc:
-    if (m_SavePostStepStatus != fGeomBoundary)
+    bool geantino = false;
+    // the check for the pdg code speeds things up, I do not want to make
+    // an expensive string compare for every track when we know
+    // geantino or chargedgeantino has pid=0
+    if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
+        aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != std::string::npos)
     {
-      break;
+      geantino = true;
     }
-    else
+    G4StepPoint* prePoint = aStep->GetPreStepPoint();
+    G4StepPoint* postPoint = aStep->GetPostStepPoint();
+    //       std::cout << "track id " << aTrack->GetTrackID() << std::endl;
+    //       std::cout << "time prepoint: " << prePoint->GetGlobalTime() << std::endl;
+    //       std::cout << "time postpoint: " << postPoint->GetGlobalTime() << std::endl;
+    int prepointstatus = prePoint->GetStepStatus();
+    if (prepointstatus == fGeomBoundary ||
+        prepointstatus == fUndefined ||
+        (prepointstatus == fPostStepDoItProc && m_SavePostStepStatus == fGeomBoundary) )
     {
-      // this is bad from G4 print out diagnostic to help debug, not sure if
-      // this is still with us
-      std::cout << GetName() << ": New Hit for  " << std::endl;
-      std::cout << "prestep status: "
-                << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-                << ", poststep status: "
-                << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-                << ", last pre step status: "
-                << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
-                << ", last post step status: "
-                << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
+      if (prepointstatus == fPostStepDoItProc && m_SavePostStepStatus == fGeomBoundary)
+      {
+        std::cout << GetName() << ": New Hit for  " << std::endl;
+        std::cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+             << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+             << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
+             << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
+        std::cout << "last track: " << m_SaveTrackId
+             << ", current trackid: " << aTrack->GetTrackID() << std::endl;
+        std::cout << "phys pre vol: " << volume->GetName()
+             << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
+        std::cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
+             << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
+      }
+      if (!m_Hit)
+      {
+        m_Hit = new PHG4Hitv1();
+      }
+      //here we set the entrance values in cm
+      m_Hit->set_x(0, prePoint->GetPosition().x() / cm);
+      m_Hit->set_y(0, prePoint->GetPosition().y() / cm);
+      m_Hit->set_z(0, prePoint->GetPosition().z() / cm);
+      // time in ns
+      m_Hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
+      //set the track ID
+      m_Hit->set_trkid(aTrack->GetTrackID());
+      m_SaveTrackId = aTrack->GetTrackID();
+
+      //set the initial energy deposit
+      m_Hit->set_edep(0);
+      if (!geantino && !m_BlackHoleFlag && m_ActiveFlag)
+      {
+        m_Hit->set_eion(0);
+      }
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          m_Hit->set_trkid(pp->GetUserTrackId());
+          m_Hit->set_shower_id(pp->GetShower()->get_id());
+        }
+      }
+    }
+
+    // some sanity checks for inconsistencies
+    // check if this hit was created, if not print out last post step status
+    if (!m_Hit || !isfinite(m_Hit->get_x(0)))
+    {
+      std::cout << GetName() << ": hit was not created" << std::endl;
+      std::cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+           << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+           << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
+           << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
       std::cout << "last track: " << m_SaveTrackId
-                << ", current trackid: " << aTrack->GetTrackID() << std::endl;
+           << ", current trackid: " << aTrack->GetTrackID() << std::endl;
       std::cout << "phys pre vol: " << volume->GetName()
-                << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
+           << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
       std::cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
-                << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
+           << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
+      exit(1);
     }
- 
-  case fGeomBoundary:
-  case fUndefined:
-    if (!m_Hit)
+    m_SavePostStepStatus = postPoint->GetStepStatus();
+    // check if track id matches the initial one when the hit was created
+    if (aTrack->GetTrackID() != m_SaveTrackId)
+    {
+      std::cout << "hits do not belong to the same track" << std::endl;
+      std::cout << "saved track: " << m_SaveTrackId
+           << ", current trackid: " << aTrack->GetTrackID()
+           << std::endl;
+      exit(1);
+    }
+    m_SavePreStepStatus = prePoint->GetStepStatus();
+    m_SavePostStepStatus = postPoint->GetStepStatus();
+    m_SaveVolPre = volume;
+    m_SaveVolPost = touchpost->GetVolume();
+
+    // here we just update the exit values, it will be overwritten
+    // for every step until we leave the volume or the particle
+    // ceases to exist
+    m_Hit->set_x(1, postPoint->GetPosition().x() / cm);
+    m_Hit->set_y(1, postPoint->GetPosition().y() / cm);
+    m_Hit->set_z(1, postPoint->GetPosition().z() / cm);
+
+    m_Hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
+    //sum up the energy to get total deposited
+    m_Hit->set_edep(m_Hit->get_edep() + edep);
+    // update ionization energy only for active volumes, not for black holes or geantinos
+    // if the hit is created without eion, get_eion() returns NAN
+    // if you see NANs check the creation of the hit
+    if (m_ActiveFlag && !m_BlackHoleFlag && !geantino)
+    {
+      m_Hit->set_eion(m_Hit->get_eion() + eion);
+    }
+    if (geantino)
+    {
+      m_Hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+    }
+    if (edep > 0)
+    {
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
       {
-      //m_Hit = new PHG4Hitv1();
-      m_Hit = new PrtHit();
-      }
-  
-    // for momentum direction at bar
-    //if((prePointVolName.contains("wBar")) && (aStep->IsFirstStepInVolume()) && (aTrack->GetParentID() == 0))
-    
-	//m_SaveHitContainer->AddHit(detector_id, m_Hit);
-	// ownership has been transferred to container, set to null                                                                                  
-    	// so we will create a new hit for the next track                                                                                            
-     
-    m_Hit->set_layer(detector_id);
-    // here we set the entrance values in cm
-    m_Hit->set_x(0, prePoint->GetPosition().x() / cm);
-    m_Hit->set_y(0, prePoint->GetPosition().y() / cm);
-    m_Hit->set_z(0, prePoint->GetPosition().z() / cm);
-    // time in ns
-    m_Hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
-    // set the track ID
-    m_Hit->set_trkid(aTrack->GetTrackID());
-    m_SaveTrackId = aTrack->GetTrackID();
-
-    // set the initial energy deposit
-    m_EdepSum = 0;
-    if (whichactive > 0)
-    {
-      m_EionSum = 0;  // assuming the ionization energy is only needed for active
-                      // volumes (scintillators)
-      m_Hit->set_eion(0);
-      m_SaveHitContainer = m_HitContainer;
-    }
-    else
-    {
-      std::cout << "implement stuff for whichactive < 0 (inactive volumes)" << std::endl;
-      gSystem->Exit(1);
-    }
-    // this is for the tracking of the truth info
-    if (G4VUserTrackInformation *p = aTrack->GetUserInformation())
-    {
-      if (PHG4TrackUserInfoV1 *pp = dynamic_cast<PHG4TrackUserInfoV1 *>(p))
-      {
-        m_Hit->set_trkid(pp->GetUserTrackId());
-        pp->GetShower()->add_g4hit_id(m_SaveHitContainer->GetID(),
-                                      m_Hit->get_hit_id());
-      }
-    }
-
-    break;
-  default:
-    break;
-  }
-  //cout << "detector id = " << detector_id << endl;
-
-  // some sanity checks for inconsistencies (aka bugs)
-  // check if this hit was created, if not print out last post step status
-  if (!m_Hit || !isfinite(m_Hit->get_x(0)))
-  {
-    std::cout << GetName() << ": hit was not created" << std::endl;
-    std::cout << "prestep status: "
-              << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-              << ", poststep status: "
-              << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-              << ", last pre step status: "
-              << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
-              << ", last post step status: "
-              << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
-    std::cout << "last track: " << m_SaveTrackId
-              << ", current trackid: " << aTrack->GetTrackID() << std::endl;
-    std::cout << "phys pre vol: " << volume->GetName()
-              << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
-    std::cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
-              << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
-    gSystem->Exit(1);
-  }
-  // check if track id matches the initial one when the hit was created
-  if (aTrack->GetTrackID() != m_SaveTrackId)
-  {
-    std::cout << GetName() << ": hits do not belong to the same track" << std::endl;
-    std::cout << "saved track: " << m_SaveTrackId
-              << ", current trackid: " << aTrack->GetTrackID()
-              << ", prestep status: " << prePoint->GetStepStatus()
-              << ", previous post step status: " << m_SavePostStepStatus << std::endl;
-
-    gSystem->Exit(1);
-  }
-  m_SavePreStepStatus = prePoint->GetStepStatus();
-  m_SavePostStepStatus = postPoint->GetStepStatus();
-  m_SaveVolPre = volume;
-  m_SaveVolPost = touchpost->GetVolume();
-
-  // here we just update the exit values, it will be overwritten
-  // for every step until we leave the volume or the particle
-  // ceases to exist
-  // sum up the energy to get total deposited
-  m_EdepSum += edep;
-  if (whichactive > 0)
-  {
-    m_EionSum += eion;
-  }
-
-	    	        
-  // if any of these conditions is true this is the last step in
-  // this volume and we need to save the hit
-  // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
-  // postPoint->GetStepStatus() == fWorldBoundary: track leaves this world
-  // (happens when your detector goes outside world volume)
-  // postPoint->GetStepStatus() == fAtRestDoItProc: track stops (typically
-  // aTrack->GetTrackStatus() == fStopAndKill is also set)
-  // aTrack->GetTrackStatus() == fStopAndKill: track ends
-  if (postPoint->GetStepStatus() == fGeomBoundary ||
-      postPoint->GetStepStatus() == fWorldBoundary ||
-      postPoint->GetStepStatus() == fAtRestDoItProc ||
-      aTrack->GetTrackStatus() == fStopAndKill)
-  {       
-    //if((prePoint->GetStepStatus() == fGeomBoundary) && 
-    //if(whichactive_int == 9 || whichactive_int == 7 || whichactive_int == 8) // for relection information (7-wLens2, 8-wLens3, 9-wPrizm) 
-      if(whichactive_int == 7 || whichactive_int == 8 || whichactive_int == 9) // for relection information (7-lLens2, 8-lLens3, 9-lPrizm)
-      {	 
-	  G4String vname = touch->GetVolume()->GetName();
-	     
-	  // normal to the closest boundary
-	  G4Navigator* theNavigator = G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking();
-
-	  Int_t nid = 0;	
-	  G4bool valid;
-	  G4ThreeVector normal = theNavigator->GetLocalExitNormal(&valid);
-	  G4ThreeVector gnormal = theNavigator->GetLocalToGlobalTransform().TransformAxis(-normal);
-	  normal = touch->GetHistory()->GetTransform(1).TransformAxis(gnormal); // in lDirc
-
-	  //Int_t prizm_hit_trackid = aTrack->GetTrackID();
-	  Int_t prizm_hit_trackid = m_SaveTrackId;
-  
-	  if (valid)
-	    {
-	      if(vname=="wPrizm")
-		{
-		  if(normal.y()> 0.99) nid = 1; // right
-		  if(normal.y()<-0.99) nid = 2; // left
-		  if(normal.x()>0.99) nid = 3; // bottom
-		  if(fabs(normal.x()+0.866025)<0.1 ) nid = 4;
-		}
-	      else if(vname=="wLens3")
-		{
-		  if(normal.y()> 0.99) nid = 5; // right
-		  if(normal.y()<-0.99) nid = 6; // left
-		  if(normal.x()>0.99) nid = 7; // bottom
-		  if(normal.x()<-0.99) nid = 8; // top
-		}
-	      else if(vname=="wLens2")
-		{
-		  nid = 9;
-		}
-	     
-	      if(nid > 0)
-		{		 
-		  vector_trackid.push_back(prizm_hit_trackid);
-		  vector_nid.push_back(nid);
-		}
-	     
-	    }
-	}   
-  
-
-   // save only hits with energy deposit (or geantino)
-    
-    if (m_EdepSum > 0 || geantino)
-    {
-      // update values at exit coordinates and set keep flag
-      // of track to keep
-      m_Hit->set_x(1, postPoint->GetPosition().x() / cm);
-      m_Hit->set_y(1, postPoint->GetPosition().y() / cm);
-      m_Hit->set_z(1, postPoint->GetPosition().z() / cm);
-
-      m_Hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
-            	      
-      if(whichactive_int_post == 11) // post step in Pixel ---------------
-	{
-      // Get cell id 
-      //G4int layerNumber = touchpost->GetReplicaNumber(0);
-      //const G4DynamicParticle* dynParticle = aTrack->GetDynamicParticle();
-      //G4ParticleDefinition* particle = dynParticle->GetDefinition();  
-      //G4String ParticleName = particle->GetParticleName();
-	  
-      G4ThreeVector globalpos = aStep->GetPostStepPoint()->GetPosition();
-      G4ThreeVector localpos = touchpost->GetHistory()->GetTopTransform().TransformPoint(globalpos);
-      G4ThreeVector translation = touchpost->GetHistory()->GetTopTransform().Inverse().TransformPoint(G4ThreeVector(0,0,0));
-      G4ThreeVector inPrismpos = touchpost->GetHistory()->GetTransform( 1 ).TransformPoint(globalpos);
-      G4ThreeVector g4mom = aTrack->GetVertexMomentumDirection();//GetMomentum();
-      G4ThreeVector g4pos = aTrack->GetVertexPosition();
- 
-      //G4ThreeVector localvec = touchpost->GetHistory()->GetTopTransform().TransformAxis(g4mom);
-
-      TVector3 globalPos(inPrismpos.x(),inPrismpos.y(),inPrismpos.z());
-      TVector3 localPos(localpos.x(),localpos.y(),localpos.z());
-      TVector3 digiPos(translation.x(),translation.y(),translation.z());
-      TVector3 momentum(g4mom.x(),g4mom.y(),g4mom.z());
-      TVector3 position(g4pos.x(),g4pos.y(),g4pos.z());
-
-      // information from prizm
-      double time = aStep->GetPreStepPoint()->GetLocalTime();
-
-      int mcp = touchpost->GetReplicaNumber(1);
-      int pix = touchpost->GetReplicaNumber(0);     
-     
-      Double_t wavelength = 1.2398/(aTrack->GetMomentum().mag()*1E6)*1000;
-      
-      // transport efficiency ----
-
-      /*double pi(4 * atan(1));
-      double roughness(0.5); // nm
-      double angleX = localvec.angle(G4ThreeVector(1, 0, 0));
-      double angleY = localvec.angle(G4ThreeVector(0, 1, 0));
-      if (angleX > 0.5 * pi) angleX = pi - angleX;
-      if (angleY > 0.5 * pi) angleY = pi - angleY;
-      double length = aTrack->GetTrackLength() - 400; // 400 - average path in EV
-      double lengthx = fabs(length * localvec.x());  // along the bar
-      double lengthy = fabs(length * localvec.y());
-
-      //cout << "track length = " << aTrack->GetTrackLength() << endl;
-
-      int nBouncesX = (int)(lengthx) / 17;
-      int nBouncesY = (int)(lengthy) / (358.5/11);
-
-      double ll = wavelength * wavelength;
-      double n_quartz = sqrt(1. + (0.696 * ll / (ll - pow(0.068, 2))) +
-			     (0.407 * ll / (ll - pow(0.116, 2))) + 0.897 * ll / (ll - pow(9.896, 2)));
-      double bounce_probX = 1 - pow(4 * pi * cos(angleX) * roughness * n_quartz / wavelength, 2);
-      double bounce_probY = 1 - pow(4 * pi * cos(angleY) * roughness * n_quartz / wavelength, 2);
-
-      double totalProb = pow(bounce_probX, nBouncesX) * pow(bounce_probY, nBouncesY);
-
-      if (G4UniformRand() < totalProb) //{
-      */     
-
-      // time since track created
-      m_Hit->SetLeadTime(time);
-      m_Hit->SetTotTime(wavelength); //set photon wavelength
-      m_Hit->SetMcpId(mcp);
-      m_Hit->SetPixelId(pix);
-      m_Hit->SetGlobalPos(globalPos);
-      m_Hit->SetLocalPos(localPos);
-      m_Hit->SetDigiPos(digiPos);
-      m_Hit->SetPosition(position);
-      m_Hit->SetMomentum(momentum);
-                  
-      int refl = 0;
-      //Int_t normal_id = 0;
-      Long64_t pathId = 0;
-      //TVector3 mom_bar;
-      //TVector3 pos_bar;
-
-      for(std::vector<Int_t>::size_type i = 0; i < vector_trackid.size(); i++)
-	{
-	  //if(aTrack->GetTrackID() == vector_trackid[i]) 
-	  if(m_SaveTrackId == vector_trackid[i])
-	    {
-	      ++refl;
-	      Int_t normal_id = vector_nid[i];
-		    //std::cout << "nid = " << normal_id << std::endl;
-	      pathId = (pathId * 10L) + normal_id;
-	    }
-	}
-	    
-      //std::cout << "nrefl = " << refl << std::endl;
-      //std::cout << "path id = " << pathId << std::endl;		  
-
-      m_Hit->SetNreflectionsInPrizm(refl);
-      m_Hit->SetPathInPrizm(pathId);
-      
-      /*for(std::vector<Int_t>::size_type i = 0; i < vector_bar_hit_trackid.size(); i++)
-	{
-	  if(aTrack->GetParentID() == vector_bar_hit_trackid[i])
-	    {
-	      mom_bar = vector_p_bar[i];
-	      pos_bar = vector_hit_pos_bar[i];
-	    }
-	}
-      
-      m_Hit->SetMomentumAtBar(mom_bar);
-      m_Hit->SetPositionAtBar(pos_bar);
-      */
-
-      //m_Hit->SetParticleId(aTrack->GetTrackID());
-      //hit.SetParentParticleId(aTrack->GetParentID());
-      
-
-      
-      //if((prePointVolName.contains("World")) && (postPointVolName.contains("wBar")) && (aTrack->GetParentID() == 0))
-      //{
-	/*if (!m_Hit)
-	  {
-	    m_Hit = new PrtHit();
-	    }*/
-	  
-	/*G4ThreeVector momentum_at_bar = aTrack->GetMomentum();
-	G4ThreeVector position_at_bar = prePoint->GetPosition();
-
-	TVector3 p_bar(momentum_at_bar.x(), momentum_at_bar.y(), momentum_at_bar.z());
-	TVector3 hit_pos_bar(position_at_bar.x(), position_at_bar.y(), position_at_bar.z());
-	
-	Int_t bar_hit_trackid = aTrack->GetTrackID();
-	//detector_id = 1;
-	
-	//vector_bar_hit_trackid.push_back(bar_hit_trackid);
-	//vector_p_bar.push_back(p_bar);
-	//vector_hit_pos_bar.push_back(hit_pos_bar);
-
-	//bar_vectors::vector_p_bar.push_back(p_bar); 
-	//bar_vectors::vector_hit_pos_bar.push_back(hit_pos_bar);
-
-	TVector3 mom_bar = p_bar;                                                                                                                  
-	TVector3 pos_bar = hit_pos_bar;
-	m_Hit->SetMomentumAtBar(mom_bar);                                                                                                          
-      	m_Hit->SetPositionAtBar(pos_bar);
-	*/
-      if (G4VUserTrackInformation *p = aTrack->GetUserInformation())
-      {
-        if (PHG4TrackUserInfoV1 *pp = dynamic_cast<PHG4TrackUserInfoV1 *>(p))
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
         {
           pp->SetKeep(1);  // we want to keep the track
         }
       }
-      if (geantino)
+    }
+    // if any of these conditions is true this is the last step in
+    // this volume and we need to save the hit
+    // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
+    // postPoint->GetStepStatus() == fWorldBoundary: track leaves this world
+    // (happens when your detector goes outside world volume)
+    // postPoint->GetStepStatus() == fAtRestDoItProc: track stops (typically
+    // aTrack->GetTrackStatus() == fStopAndKill is also set)
+    // aTrack->GetTrackStatus() == fStopAndKill: track ends
+    if (postPoint->GetStepStatus() == fGeomBoundary ||
+        postPoint->GetStepStatus() == fWorldBoundary ||
+        postPoint->GetStepStatus() == fAtRestDoItProc ||
+        aTrack->GetTrackStatus() == fStopAndKill )
+    {
+      // save only hits with energy deposit (or -1 for geantino)
+      if (m_Hit->get_edep())
       {
-        m_Hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way
-                              // geantinos survive the g4hit compression
-        if (whichactive > 0)
-        {
-          m_Hit->set_eion(-1);
-        }
+        m_HitContainer->AddHit(0, m_Hit);
+        // ownership has been transferred to container, set to null
+        // so we will create a new hit for the next track
+        m_Hit = nullptr;
       }
       else
       {
-        m_Hit->set_edep(m_EdepSum);
+        // if this hit has no energy deposit, just reset it for reuse
+        // this means we have to delete it in the dtor. If this was
+        // the last hit we processed the memory is still allocated
+        m_Hit->Reset();
       }
-      if (whichactive > 0)
-      {
-        m_Hit->set_eion(m_EionSum);
-      }
-      //} // pixel volume ends
-
-      m_SaveHitContainer->AddHit(detector_id, m_Hit);
-	    	
-      // ownership has been transferred to container, set to null
-      // so we will create a new hit for the next track
-      //m_Hit = nullptr;
-      m_Hit = nullptr;
-	}
     }
-    
-    else
-    {
-      // if this hit has no energy deposit, just reset it for reuse
-      // this means we have to delete it in the dtor. If this was
-      // the last hit we processed the memory is still allocated
-      m_Hit->Reset();
-    }
+    // return true to indicate the hit was used
+    return true;
   }
-
-  // return true to indicate the hit was used
-  return true;
-
+  else
+  {
+    return false;
+  }
 }
 
 //____________________________________________________________________________..

--- a/simulation/g4simulation/g4eicdirc/G4EicDircSteppingAction.h
+++ b/simulation/g4simulation/g4eicdirc/G4EicDircSteppingAction.h
@@ -3,10 +3,10 @@
 #ifndef G4EICDIRCSTEPPINGACTION_H
 #define G4EICDIRCSTEPPINGACTION_H
 
-#include <g4main/PHG4SteppingAction.h>
-#include <vector>
 #include <Rtypes.h>
 #include <TVector3.h>
+#include <g4main/PHG4SteppingAction.h>
+#include <vector>
 
 class G4Step;
 class G4VPhysicalVolume;
@@ -38,7 +38,6 @@ class G4EicDircSteppingAction : public PHG4SteppingAction
   void SetAbsorberNodeName(const std::string& nam) { m_AbsorberNodeName = nam; }
   void SetSupportNodeName(const std::string& nam) { m_SupportNodeName = nam; }
 
-  
   std::vector<Int_t> vector_nid;
   std::vector<Int_t> vector_trackid;
 
@@ -55,8 +54,8 @@ class G4EicDircSteppingAction : public PHG4SteppingAction
   PHG4HitContainer* m_AbsorberHitContainer = nullptr;
   PHG4HitContainer* m_SupportHitContainer = nullptr;
   PHG4Hit* m_Hit = nullptr;
-//  PrtHit* m_Hit = nullptr;
-  PHG4HitContainer* m_SaveHitContainer = nullptr;
+  //  PrtHit* m_Hit = nullptr;
+  //PHG4HitContainer* m_SaveHitContainer = nullptr;
 
   G4VPhysicalVolume* m_SaveVolPre = nullptr;
   G4VPhysicalVolume* m_SaveVolPost = nullptr;
@@ -65,8 +64,8 @@ class G4EicDircSteppingAction : public PHG4SteppingAction
   int m_SavePostStepStatus = -1;
   int m_ActiveFlag = 0;
   int m_BlackHoleFlag = 0;
-  double m_EdepSum = 0.;
-  double m_EionSum = 0.;
+  //double m_EdepSum = 0.;
+  //double m_EionSum = 0.;
 
   std::string m_HitNodeName;
   std::string m_AbsorberNodeName;

--- a/simulation/g4simulation/g4eicdirc/G4EicDircSteppingAction.h
+++ b/simulation/g4simulation/g4eicdirc/G4EicDircSteppingAction.h
@@ -54,8 +54,8 @@ class G4EicDircSteppingAction : public PHG4SteppingAction
   PHG4HitContainer* m_HitContainer = nullptr;
   PHG4HitContainer* m_AbsorberHitContainer = nullptr;
   PHG4HitContainer* m_SupportHitContainer = nullptr;
-  //PHG4Hit* m_Hit = nullptr;
-  PrtHit* m_Hit = nullptr;
+  PHG4Hit* m_Hit = nullptr;
+//  PrtHit* m_Hit = nullptr;
   PHG4HitContainer* m_SaveHitContainer = nullptr;
 
   G4VPhysicalVolume* m_SaveVolPre = nullptr;

--- a/simulation/g4simulation/g4eicdirc/G4EicDircSubsystem.cc
+++ b/simulation/g4simulation/g4eicdirc/G4EicDircSubsystem.cc
@@ -6,7 +6,6 @@
 #include "G4EicDircStackingAction.h"
 #include "G4EicDircSteppingAction.h"
 
-
 #include <phparameter/PHParameters.h>
 
 #include <g4main/PHG4HitContainer.h>
@@ -22,8 +21,8 @@
 
 #include <Geant4/G4ParticleTable.hh>
 #include <Geant4/G4ProcessManager.hh>
-#include <Geant4/G4ios.hh>
 #include <Geant4/G4SystemOfUnits.hh>
+#include <Geant4/G4ios.hh>
 
 #include <cmath>  // for isfinite
 
@@ -80,7 +79,7 @@ int G4EicDircSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     PHCompositeNode *DetNode = dstNode;
     if (SuperDetector() != "NONE")
     {
-      DetNode = dynamic_cast<PHCompositeNode*>(dstIter.findFirst("PHCompositeNode", SuperDetector()));
+      DetNode = dynamic_cast<PHCompositeNode *>(dstIter.findFirst("PHCompositeNode", SuperDetector()));
       if (!DetNode)
       {
         DetNode = new PHCompositeNode(SuperDetector());
@@ -89,7 +88,7 @@ int G4EicDircSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     }
     m_HitNodeName = "G4HIT_" + detector_suffix;
     nodes.insert(m_HitNodeName);
-   m_AbsorberNodeName = "G4HIT_ABSORBER_" + detector_suffix;
+    m_AbsorberNodeName = "G4HIT_ABSORBER_" + detector_suffix;
     if (GetParams()->get_int_param("absorberactive"))
     {
       nodes.insert(m_AbsorberNodeName);
@@ -101,7 +100,7 @@ int G4EicDircSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     }
     for (auto thisnode : nodes)
     {
-      PHG4HitContainer* g4_hits = findNode::getClass<PHG4HitContainer>(topNode, thisnode);
+      PHG4HitContainer *g4_hits = findNode::getClass<PHG4HitContainer>(topNode, thisnode);
       if (!g4_hits)
       {
         g4_hits = new PHG4HitContainer(thisnode);
@@ -180,24 +179,24 @@ void G4EicDircSubsystem::SetDefaultParameters()
   set_default_double_param("length", 287 + 168);
 
   set_default_double_param("NBars", 11);
-  set_default_double_param("Radius", 75.0*cm);
-  set_default_double_param("Prizm_width", 38.65*cm);
-  set_default_double_param("Prizm_length", 30.0*cm);
-  set_default_double_param("Prizm_height_at_lens", 5.0*cm);
-  set_default_double_param("Bar_thickness", 1.725*cm);
-  set_default_double_param("Bar_width", 3.5*cm);
-  set_default_double_param("BarL_length", 122.5*cm);
-  set_default_double_param("BarS_length", 56.0*cm);
-  set_default_double_param("Mirror_height", 2.0*cm);
-  set_default_double_param("z_shift", -43.75*cm);
-  set_default_int_param("Geom_type", 0); // 0-whole DIRC, 1-one bar box
-  set_default_int_param("Lens_id", 3); // 3- 3-layer spherical lens
+  set_default_double_param("Radius", 75.0 * cm);
+  set_default_double_param("Prizm_width", 38.65 * cm);
+  set_default_double_param("Prizm_length", 30.0 * cm);
+  set_default_double_param("Prizm_height_at_lens", 5.0 * cm);
+  set_default_double_param("Bar_thickness", 1.725 * cm);
+  set_default_double_param("Bar_width", 3.5 * cm);
+  set_default_double_param("BarL_length", 122.5 * cm);
+  set_default_double_param("BarS_length", 56.0 * cm);
+  set_default_double_param("Mirror_height", 2.0 * cm);
+  set_default_double_param("z_shift", -43.75 * cm);
+  set_default_int_param("Geom_type", 0);  // 0-whole DIRC, 1-one bar box
+  set_default_int_param("Lens_id", 3);    // 3- 3-layer spherical lens
   set_default_int_param("MCP_rows", 6);
   set_default_int_param("MCP_columns", 4);
-  set_default_int_param("NBoxes",12);
+  set_default_int_param("NBoxes", 12);
   set_default_int_param("Bar_pieces", 4);
 
-  set_default_int_param("disable_photon_sim", 0); // if true, disable photon simulations
+  set_default_int_param("disable_photon_sim", 0);  // if true, disable photon simulations
 
   set_default_string_param("material", "G4_Galactic");
 }

--- a/simulation/g4simulation/g4eicdirc/G4EicDircSubsystem.cc
+++ b/simulation/g4simulation/g4eicdirc/G4EicDircSubsystem.cc
@@ -197,5 +197,7 @@ void G4EicDircSubsystem::SetDefaultParameters()
   set_default_int_param("NBoxes",12);
   set_default_int_param("Bar_pieces", 4);
 
+  set_default_int_param("disable_photon_sim", 0); // if true, disable photon simulations
+
   set_default_string_param("material", "G4_Galactic");
 }

--- a/simulation/g4simulation/g4eicdirc/G4EicDircSubsystem.h
+++ b/simulation/g4simulation/g4eicdirc/G4EicDircSubsystem.h
@@ -86,7 +86,6 @@ class G4EicDircSubsystem : public PHG4DetectorSubsystem
   std::string m_HitNodeName;
   std::string m_AbsorberNodeName;
   std::string m_SupportNodeName;
-
 };
 
 #endif  // G4EICDIRCSUBSYSTEM_H

--- a/simulation/g4simulation/g4eicdirc/G4EventTree.h
+++ b/simulation/g4simulation/g4eicdirc/G4EventTree.h
@@ -18,7 +18,6 @@ typedef struct
   //Double_t track_mom_bar[3];
   //Double_t track_hit_pos_bar[3];
 
-
   // Hit level
   int nhits;
   int detid[MAXHIT];
@@ -44,7 +43,7 @@ typedef struct
   Double_t hit_pos[MAXHIT][3];
   Long64_t hit_pathId[MAXHIT];
   Int_t nrefl[MAXHIT];
-  
+
 } G4EventTree;
 
 #endif

--- a/simulation/g4simulation/g4eicdirc/PrtHit.h
+++ b/simulation/g4simulation/g4eicdirc/PrtHit.h
@@ -23,62 +23,60 @@
 
   }*/
 
-class PrtHit : public PHG4Hitv1 {
-
-public:   
- 
+class PrtHit : public PHG4Hitv1
+{
+ public:
   //Constructor
   PrtHit();
 
   ~PrtHit(){};
 
-  // Accessors 
-  Int_t GetParticleId()  { return fParticleId; }   
-  Int_t GetParentParticleId()  { return fParentParticleId; }  
+  // Accessors
+  Int_t GetParticleId() { return fParticleId; }
+  Int_t GetParentParticleId() { return fParentParticleId; }
 
-  Int_t GetNreflectionsInPrizm()  { return fNreflectionsInPrizm; }
-  Long64_t GetPathInPrizm()  { return fPathInPrizm; }
+  Int_t GetNreflectionsInPrizm() { return fNreflectionsInPrizm; }
+  Long64_t GetPathInPrizm() { return fPathInPrizm; }
 
-  TVector3 GetLocalPos()     { return fLocalPos; }
-  TVector3 GetGlobalPos()     { return fGlobalPos; }
-  TVector3 GetDigiPos()     { return fDigiPos; }
-  TVector3 GetMomentum()     { return fMomentum; }
-  TVector3 GetPosition()     { return fPosition; }
+  TVector3 GetLocalPos() { return fLocalPos; }
+  TVector3 GetGlobalPos() { return fGlobalPos; }
+  TVector3 GetDigiPos() { return fDigiPos; }
+  TVector3 GetMomentum() { return fMomentum; }
+  TVector3 GetPosition() { return fPosition; }
   TVector3 GetMomentumAtBar() const { return fMomBar; };
   TVector3 GetPositionAtBar() const { return fPosBar; };
-  
-  Int_t GetMcpId()       { return fMcpId; }
-  Int_t GetPixelId()     { return fPixelId; }
-  Int_t GetChannel() { return fChannel;}
-  Int_t GetMultiplicity() { return fMultiplicity; }
-  Double_t GetLeadTime() { return fLeadTime; } 
-  Double_t GetTotTime() { return fTotTime; } 
-    
-  // Mutators
-  void SetParticleId(Int_t val)  { fParticleId = val; }   
-  void SetParentParticleId(Int_t val)  { fParentParticleId = val; }  
-  
-  void SetNreflectionsInPrizm(Int_t val)  { fNreflectionsInPrizm = val; }
-  void SetPathInPrizm(Long64_t val) { fPathInPrizm = val; } 
 
-  void SetLocalPos(TVector3 val)   { fLocalPos = val; }
-  void SetGlobalPos(TVector3 val)  { fGlobalPos = val; }
-  void SetDigiPos(TVector3 val)    { fDigiPos = val; }
-  void SetMomentum(TVector3 val)    { fMomentum = val; }
-  void SetPosition(TVector3 val)    { fPosition = val; }
+  Int_t GetMcpId() { return fMcpId; }
+  Int_t GetPixelId() { return fPixelId; }
+  Int_t GetChannel() { return fChannel; }
+  Int_t GetMultiplicity() { return fMultiplicity; }
+  Double_t GetLeadTime() { return fLeadTime; }
+  Double_t GetTotTime() { return fTotTime; }
+
+  // Mutators
+  void SetParticleId(Int_t val) { fParticleId = val; }
+  void SetParentParticleId(Int_t val) { fParentParticleId = val; }
+
+  void SetNreflectionsInPrizm(Int_t val) { fNreflectionsInPrizm = val; }
+  void SetPathInPrizm(Long64_t val) { fPathInPrizm = val; }
+
+  void SetLocalPos(TVector3 val) { fLocalPos = val; }
+  void SetGlobalPos(TVector3 val) { fGlobalPos = val; }
+  void SetDigiPos(TVector3 val) { fDigiPos = val; }
+  void SetMomentum(TVector3 val) { fMomentum = val; }
+  void SetPosition(TVector3 val) { fPosition = val; }
   void SetMomentumAtBar(TVector3 val) { fMomBar = val; }
   void SetPositionAtBar(TVector3 val) { fPosBar = val; }
-  
-  void SetMcpId(Int_t val)   { fMcpId = val; }
+
+  void SetMcpId(Int_t val) { fMcpId = val; }
   void SetPixelId(Int_t val) { fPixelId = val; }
-  void SetChannel(Int_t val) { fChannel=val; }
+  void SetChannel(Int_t val) { fChannel = val; }
   void SetMultiplicity(Int_t val) { fMultiplicity = val; }
-  void SetLeadTime(Double_t val) { fLeadTime=val; } 
-  void SetTotTime(Double_t val) { fTotTime=val; } 
+  void SetLeadTime(Double_t val) { fLeadTime = val; }
+  void SetTotTime(Double_t val) { fTotTime = val; }
 
-protected:
-
-  Int_t fParticleId; 
+ protected:
+  Int_t fParticleId;
   Int_t fParentParticleId;
   Int_t fNreflectionsInPrizm;
   Long64_t fPathInPrizm;
@@ -94,10 +92,10 @@ protected:
   Int_t fPixelId;
   Int_t fChannel;
   Int_t fMultiplicity;
-  Double_t fLeadTime;    
-  Double_t fTotTime;  
+  Double_t fLeadTime;
+  Double_t fTotTime;
 
-  ClassDef(PrtHit,2)
+  ClassDef(PrtHit, 2)
 };
 
 #endif

--- a/simulation/g4simulation/g4eicdirc/PrtHitLinkDef.h
+++ b/simulation/g4simulation/g4eicdirc/PrtHitLinkDef.h
@@ -1,6 +1,6 @@
 #ifdef __CLING__
 
-#pragma link C++ class  PrtHit+;
-#pragma link C++ class  vector<PrtHit>;
+#pragma link C++ class PrtHit + ;
+#pragma link C++ class vector < PrtHit>;
 
 #endif

--- a/simulation/g4simulation/g4eicdirc/PrtOpBoundaryProcess.h
+++ b/simulation/g4simulation/g4eicdirc/PrtOpBoundaryProcess.h
@@ -1,26 +1,24 @@
 #ifndef PrtOpBoundaryProcess_h
 #define PrtOpBoundaryProcess_h
 
-#include <Geant4/globals.hh>
 #include <Geant4/G4OpBoundaryProcess.hh>
+#include <Geant4/globals.hh>
 
 class G4EicDircDetector;
 
 class PrtOpBoundaryProcess : public G4OpBoundaryProcess
 {
-public:
+ public:
   PrtOpBoundaryProcess();
-  ~PrtOpBoundaryProcess() override {};
+  ~PrtOpBoundaryProcess() override{};
 
-public:
+ public:
   G4VParticleChange* PostStepDoIt(const G4Track& aTrack, const G4Step& aStep) override;
 
   G4EicDircDetector* m_Detector;
 
-//private:
+  //private:
   //int fLensId;
-
 };
-
 
 #endif /*PrtOpBoundaryProcess_h*/

--- a/simulation/g4simulation/g4eicdst/Makefile.am
+++ b/simulation/g4simulation/g4eicdst/Makefile.am
@@ -5,18 +5,18 @@ AM_CPPFLAGS = \
   -I$(OFFLINE_MAIN)/include
 
 lib_LTLIBRARIES = \
-   libg4dst.la
+   libg4eicdst.la
 
-libg4dst_la_LDFLAGS = \
+libg4eicdst_la_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
   -lg4dst \
   -leicpidbase
 
-libg4dst_la_SOURCES = \
-   g4dst.cc
+libg4eicdst_la_SOURCES = \
+   g4eicdst.cc
 
-g4dst.cc:
+g4eicdst.cc:
 	echo "//*** this is a generated empty file. Do not commit, do not edit" > $@
 
 ################################################
@@ -26,13 +26,13 @@ noinst_PROGRAMS = testexternals
 
 BUILT_SOURCES = \
   testexternals.cc \
-  g4dst.cc
+  g4eicdst.cc
 
 testexternals_SOURCES = \
   testexternals.cc
 
 testexternals_LDADD = \
-  libg4dst.la
+  libg4eicdst.la
 
 testexternals.cc:
 	echo "//*** this is a generated file. Do not commit, do not edit" > $@

--- a/simulation/g4simulation/g4eicdst/Makefile.am
+++ b/simulation/g4simulation/g4eicdst/Makefile.am
@@ -1,0 +1,45 @@
+AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include
+
+lib_LTLIBRARIES = \
+   libg4dst.la
+
+libg4dst_la_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
+  -lg4dst \
+  -leicpidbase
+
+libg4dst_la_SOURCES = \
+   g4dst.cc
+
+g4dst.cc:
+	echo "//*** this is a generated empty file. Do not commit, do not edit" > $@
+
+################################################
+# linking tests
+
+noinst_PROGRAMS = testexternals
+
+BUILT_SOURCES = \
+  testexternals.cc \
+  g4dst.cc
+
+testexternals_SOURCES = \
+  testexternals.cc
+
+testexternals_LDADD = \
+  libg4dst.la
+
+testexternals.cc:
+	echo "//*** this is a generated file. Do not commit, do not edit" > $@
+	echo "int main()" >> $@
+	echo "{" >> $@
+	echo "  return 0;" >> $@
+	echo "}" >> $@
+
+clean-local:
+	rm -f *Dict* $(BUILT_SOURCES)

--- a/simulation/g4simulation/g4eicdst/README.md
+++ b/simulation/g4simulation/g4eicdst/README.md
@@ -1,0 +1,1 @@
+Convinient lib for reading DST from EIC production jobs

--- a/simulation/g4simulation/g4eicdst/autogen.sh
+++ b/simulation/g4simulation/g4eicdst/autogen.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(cd $srcdir; aclocal -I ${OFFLINE_MAIN}/share;\
+libtoolize --force; automake -a --add-missing; autoconf)
+
+$srcdir/configure  "$@"
+

--- a/simulation/g4simulation/g4eicdst/configure.ac
+++ b/simulation/g4simulation/g4eicdst/configure.ac
@@ -1,0 +1,22 @@
+AC_INIT(g4eicdst,[1.00])
+AC_CONFIG_SRCDIR([configure.ac])
+
+AM_INIT_AUTOMAKE
+
+AC_PROG_CXX(CC g++)
+LT_INIT([disable-static])
+
+dnl   no point in suppressing warnings people should 
+dnl   at least see them, so here we go for g++: -Wall
+if test $ac_cv_prog_gxx = yes; then
+   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+fi
+
+dnl test for root 6
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
+CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override "
+AC_SUBST(CINTDEFS)
+fi
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT


### PR DESCRIPTION
* `reconstruction/eicpidbase`: infrastructure for PID reconstruction, DST storage, and Log likelihood based analysis.
*  `simulation/g4simulation/g4eicdst` : a convenient lib for loading DST produced in EIC simulations
* ` simulation/g4simulation/g4eicdirc`: bring DIRC to be in shape that can run with main production, i.e. (1) using standard stepping action as the digitization stepping action is still in a flux, (2) introduce a non-default option to disable Cherenkov photon simulation
* `analysis/eicevaluator`: add high level PID log likelihood for the pion, kaon and proton hypnosis to the event eval output 