### PR TITLE
Disable sim->offline geometry export for BCAL

### DIFF
--- a/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalDetector.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalDetector.cc
@@ -26,6 +26,9 @@
 #include <Geant4/G4SubtractionSolid.hh>
 #include <TSystem.h>
 
+#include <g4gdml/PHG4GDMLConfig.hh>
+#include <g4gdml/PHG4GDMLUtility.hh>
+
 #include <cmath>
 #include <cstdlib>
 #include <fstream>
@@ -49,6 +52,8 @@ PHG4BarrelEcalDetector::PHG4BarrelEcalDetector(PHG4Subsystem* subsys, PHComposit
   , m_TowerLogicNamePrefix("bcalTower")
   , m_SuperDetector("NONE")
 {
+  gdml_config = PHG4GDMLUtility::GetOrMakeConfigNode(Node);
+  assert(gdml_config);
 }
 //_______________________________________________________________________
 int PHG4BarrelEcalDetector::IsInBarrelEcal(G4VPhysicalVolume* volume) const
@@ -162,9 +167,11 @@ void PHG4BarrelEcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
   
   std::string name_envelope = m_TowerLogicNamePrefix + "_envelope";
 
-  new G4PVPlacement(0, G4ThreeVector(pos_x1, pos_y1, pos_z1), cylinder_logic, name_envelope,
+  G4PVPlacement * phys_envelope=
+      new G4PVPlacement(0, G4ThreeVector(pos_x1, pos_y1, pos_z1), cylinder_logic, name_envelope,
                                      logicWorld, false, 0, OverlapCheck());
 
+  gdml_config->exclude_physical_vol(phys_envelope);
   PlaceTower(cylinder_logic);
 
   return;

--- a/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalDetector.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalDetector.h
@@ -22,6 +22,7 @@ class PHCompositeNode;
 class PHG4BarrelEcalDisplayAction;
 class PHG4Subsystem;
 class PHParameters;
+class PHG4GDMLConfig;
 
 /**
  * \file ${file_name}
@@ -129,6 +130,9 @@ class PHG4BarrelEcalDetector : public PHG4Detector
   std::set<G4LogicalVolume *> m_AbsorberLogicalVolSet;
   std::set<G4LogicalVolume *> m_ScintiLogicalVolSet;
   std::set<G4LogicalVolume *> m_SupportLogicalVolSet;
+
+  //! registry for volumes that should not be exported, i.e. fibers
+  PHG4GDMLConfig* gdml_config = nullptr;
 };
 
 #endif


### PR DESCRIPTION
Disable the automatic sim->offline GDML geometry export for BCAL. 

Offline GDML geometry is used in Kalman filter currently and possible some other use in the future. But right now, BCal is not directly used in Kalman filter, while the tower export takes the majority of the GDML geometry size. Disabling the export drop the few-particle simulation memory usage from 4+GB to 2.5GB. 

