### PR TITLE
fixed projections and hits in EventEval and improved material budget of C/E/FTTL

### DIFF
--- a/analysis/eicevaluator/EventEvaluatorEIC.cc
+++ b/analysis/eicevaluator/EventEvaluatorEIC.cc
@@ -1153,6 +1153,9 @@ void EventEvaluatorEIC::fillOutputNtuples(PHCompositeNode* topNode)
           (GetProjectionNameFromIndex(iIndex).find("rpTruth2") != std::string::npos) || // needed for IP8
           (GetProjectionNameFromIndex(iIndex).find("offMomTruth") != std::string::npos) ||
           (GetProjectionNameFromIndex(iIndex).find("b0Truth") != std::string::npos) ||
+          (GetProjectionNameFromIndex(iIndex).find("EGEM") != std::string::npos) ||
+          (GetProjectionNameFromIndex(iIndex).find("FGEM") != std::string::npos) ||
+          (GetProjectionNameFromIndex(iIndex).find("RWELL") != std::string::npos) ||
           (((GetProjectionNameFromIndex(iIndex).find("BH_1") != std::string::npos) || (GetProjectionNameFromIndex(iIndex).find("BH_FORWARD_PLUS") != std::string::npos) || (GetProjectionNameFromIndex(iIndex).find("BH_FORWARD_NEG") != std::string::npos)) && _do_BLACKHOLE)
 	  ){
         string nodename = "G4HIT_" + GetProjectionNameFromIndex(iIndex);

--- a/analysis/eicevaluator/EventEvaluatorEIC.cc
+++ b/analysis/eicevaluator/EventEvaluatorEIC.cc
@@ -1139,14 +1139,14 @@ void EventEvaluatorEIC::fillOutputNtuples(PHCompositeNode* topNode)
     }
     _nHitsLayers = 0;
     PHG4TruthInfoContainer* truthinfocontainerHits = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
-    for (int iIndex = 0; iIndex < 100; ++iIndex)
+    for (int iIndex = 0; iIndex < 200; ++iIndex)
     {
       // you need to add your layer name here to be saved! This has to be done
       // as we do not want to save thousands of calorimeter hits!
       if (
 	  (GetProjectionNameFromIndex(iIndex).find("TTL") != std::string::npos) ||
           (GetProjectionNameFromIndex(iIndex).find("LBLVTX") != std::string::npos) ||
-          (GetProjectionNameFromIndex(iIndex).find("BARREL") != std::string::npos) ||
+          (GetProjectionNameFromIndex(iIndex).find("BARR") != std::string::npos) ||
           (GetProjectionNameFromIndex(iIndex).find("FST") != std::string::npos) ||
           (GetProjectionNameFromIndex(iIndex).find("ZDCsurrogate") != std::string::npos) ||
           (GetProjectionNameFromIndex(iIndex).find("rpTruth") != std::string::npos) ||

--- a/analysis/eicevaluator/EventEvaluatorEIC.cc
+++ b/analysis/eicevaluator/EventEvaluatorEIC.cc
@@ -3014,10 +3014,10 @@ void EventEvaluatorEIC::fillOutputNtuples(PHCompositeNode* topNode)
                 if (trackStateIndex > -1)
                 {
                   // save true projection info to given branch
-                  _track_TLP_true_x[_nProjections] = trkstates->second->get_pos(0);
-                  _track_TLP_true_y[_nProjections] = trkstates->second->get_pos(1);
-                  _track_TLP_true_z[_nProjections] = trkstates->second->get_pos(2);
-                  _track_TLP_true_t[_nProjections] = trkstates->first;
+                  _track_TLP_x[_nProjections] = trkstates->second->get_pos(0);
+                  _track_TLP_y[_nProjections] = trkstates->second->get_pos(1);
+                  _track_TLP_z[_nProjections] = trkstates->second->get_pos(2);
+                  _track_TLP_t[_nProjections] = trkstates->first;
                   _track_ProjLayer[_nProjections] = trackStateIndex;
                   _track_ProjTrackID[_nProjections] = _nTracks;
 
@@ -3043,10 +3043,10 @@ void EventEvaluatorEIC::fillOutputNtuples(PHCompositeNode* topNode)
                           cout << __PRETTY_FUNCTION__ << " found hit with id " << hit_iter->second->get_trkid() << endl;
                         }
                         // save reco projection info to given branch
-                        _track_TLP_x[_nProjections] = hit_iter->second->get_x(0);
-                        _track_TLP_y[_nProjections] = hit_iter->second->get_y(0);
-                        _track_TLP_z[_nProjections] = hit_iter->second->get_z(0);
-                        _track_TLP_t[_nProjections] = hit_iter->second->get_t(0);
+                        _track_TLP_true_x[_nProjections] = hit_iter->second->get_x(0);
+                        _track_TLP_true_y[_nProjections] = hit_iter->second->get_y(0);
+                        _track_TLP_true_z[_nProjections] = hit_iter->second->get_z(0);
+                        _track_TLP_true_t[_nProjections] = hit_iter->second->get_t(0);
                       }
                     }
                   }
@@ -3056,7 +3056,10 @@ void EventEvaluatorEIC::fillOutputNtuples(PHCompositeNode* topNode)
                     {
                       cout << __PRETTY_FUNCTION__ << " could not find " << nodename << endl;
                     }
-                    continue;
+                    _track_TLP_true_x[_nProjections] = -10000;
+                    _track_TLP_true_y[_nProjections] = -10000;
+                    _track_TLP_true_z[_nProjections] = -10000;
+                    _track_TLP_true_t[_nProjections] = -10000;
                   }
                   _nProjections++;
                 }

--- a/simulation/g4simulation/g4ttl/PHG4TTLDisplayAction.cc
+++ b/simulation/g4simulation/g4ttl/PHG4TTLDisplayAction.cc
@@ -136,7 +136,7 @@ void PHG4TTLDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
     }
     else if (it.second == "ModuleEnvelope")
     {
-      // visatt->SetVisibility(false);
+      visatt->SetVisibility(false);
       visatt->SetColour(G4Colour::Red());
       // visatt->SetForceSolid(true);
       visatt->SetForceWireframe(true);
@@ -155,7 +155,7 @@ void PHG4TTLDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
       visatt->SetForceSolid(true);
       // visatt->SetForceWireframe(true);
     }
-    else if (it.second == "Cooling_Support")
+    else if (it.second == "Cooling_Support" || it.second == "Carbon_Support")
     {
       // visatt->SetColour(G4Colour(21./255, 27./255, 31./255,0.5));
       visatt->SetColour(G4Colour(4 * 21. / 255, 4 * 27. / 255, 4 * 31. / 255));


### PR DESCRIPTION
This PR contains a full redesign of the TTL layers (barrel and disks) in terms of their support structure and cooling. The material budget is significantly reduced with this design (2mm of Al instead of ~8mm of Al).

In addition, the projections in the EventEvaluator are fixed (true and reconstructed information was switched) and hits are no longer required to save the reconstructed hit info (therefore the projections to e.g. the calorimeters are stored once again).