### PR TITLE
Use the built-in scintillation light production model for EEMCH

### DIFF
--- a/simulation/g4simulation/g4eiccalos/PHG4HybridHomogeneousCalorimeterSteppingAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4HybridHomogeneousCalorimeterSteppingAction.cc
@@ -201,7 +201,10 @@ bool PHG4HybridHomogeneousCalorimeterSteppingAction::UserSteppingAction(const G4
     if (whichactive > 0)
     {
       m_Hit->set_eion(m_Hit->get_eion() + eion);
-      m_Hit->set_light_yield(m_Hit->get_light_yield() + eion);
+
+      // using the G4 scintillation light production model
+      double light_yield = GetVisibleEnergyDeposition(aStep);
+      m_Hit->set_light_yield(m_Hit->get_light_yield() + light_yield);
     }
 
     if (geantino)


### PR DESCRIPTION
Enable the built-in scintillation light production model for EEMCH PbWO calorimeter, which should bring the e/h for the calorimeter simulation more closer to reality. And it is expected to improve pion rejection due to higher suppression of scintillation light production for hadronic showers. 

Under the hood it use Geant4 `G4EmSaturation` to calculate nonlinear scintillation light production based on Birk's formula. The Birk constant should be print out at the beginning of the run: 
```
   G4_PbWO4     0.0333333 mm/MeV     0.0276 g/cm^2/MeV  massFactor=  5.89329 effCharge= 2407.4
```

Please note this changes the energy scale of the EEMCH to about 0.96 of the previous energy scale based on ionization energy. 