### PR TITLE
large geometry improvements for EEMCH, FEMC and LFHCAL

### DIFF
--- a/simulation/g4simulation/g4eiccalos/PHG4BackwardHcalDetector.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4BackwardHcalDetector.cc
@@ -192,21 +192,21 @@ PHG4BackwardHcalDetector::ConstructTower()
   m_AbsorberLogicalVolSet.insert(logic_absorber);
 
   G4LogicalVolume* logic_scint = new G4LogicalVolume(solid_scintillator,
-                                                      material_scintillator,
-                                                      "hHcal_scintillator_plate_logic",
-                                                      0, 0, 0);
+                                                     material_scintillator,
+                                                     "hHcal_scintillator_plate_logic",
+                                                     0, 0, 0);
   m_ScintiLogicalVolSet.insert(logic_scint);
 
   G4LogicalVolume* logic_wls = new G4LogicalVolume(solid_WLS_plate,
-                                                    material_wls,
-                                                    "hHcal_wls_plate_logic",
-                                                    0, 0, 0);
+                                                   material_wls,
+                                                   "hHcal_wls_plate_logic",
+                                                   0, 0, 0);
 
   m_AbsorberLogicalVolSet.insert(logic_wls);
   G4LogicalVolume* logic_support = new G4LogicalVolume(solid_support_plate,
-                                                        material_support,
-                                                        "hHcal_support_plate_logic",
-                                                        0, 0, 0);
+                                                       material_support,
+                                                       "hHcal_support_plate_logic",
+                                                       0, 0, 0);
 
   m_AbsorberLogicalVolSet.insert(logic_support);
   m_DisplayAction->AddVolume(logic_absorber, "Absorber");

--- a/simulation/g4simulation/g4eiccalos/PHG4BackwardHcalDisplayAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4BackwardHcalDisplayAction.cc
@@ -9,7 +9,7 @@
 #include <TSystem.h>
 
 #include <iostream>
-#include <utility>                     // for pair
+#include <utility>  // for pair
 
 using namespace std;
 
@@ -24,7 +24,6 @@ PHG4BackwardHcalDisplayAction::PHG4BackwardHcalDisplayAction(const std::string &
   showdetails = detailed;
   if (!detailed) std::cout << "PHG4BackwardHcalDisplayAction::disabled detailed view of towers" << std::endl;
 }
-
 
 PHG4BackwardHcalDisplayAction::~PHG4BackwardHcalDisplayAction()
 {
@@ -54,7 +53,7 @@ void PHG4BackwardHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvo
       visatt->SetColour(G4Colour::Red());
       if (showdetails)
         visatt->SetVisibility(true);
-      else 
+      else
         visatt->SetVisibility(false);
     }
     else if (it.second == "FHcalEnvelope")
@@ -66,16 +65,15 @@ void PHG4BackwardHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvo
       visatt->SetColour(G4Colour::White());
       if (showdetails)
         visatt->SetVisibility(true);
-      else 
+      else
         visatt->SetVisibility(false);
-
     }
     else if (it.second == "WLSplate")
     {
       visatt->SetColour(G4Colour::Yellow());
       if (showdetails)
         visatt->SetVisibility(true);
-      else 
+      else
         visatt->SetVisibility(false);
     }
     else if (it.second == "SupportPlate")
@@ -83,7 +81,7 @@ void PHG4BackwardHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvo
       visatt->SetColour(G4Colour::Gray());
       if (showdetails)
         visatt->SetVisibility(true);
-      else 
+      else
         visatt->SetVisibility(false);
     }
     else if (it.second == "SingleTower")
@@ -91,9 +89,8 @@ void PHG4BackwardHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvo
       visatt->SetColour(G4Colour::Red());
       if (showdetails)
         visatt->SetVisibility(false);
-      else 
+      else
         visatt->SetVisibility(true);
-
     }
     else
     {

--- a/simulation/g4simulation/g4eiccalos/PHG4BackwardHcalDisplayAction.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4BackwardHcalDisplayAction.h
@@ -18,7 +18,7 @@ class PHG4BackwardHcalDisplayAction : public PHG4DisplayAction
  public:
   PHG4BackwardHcalDisplayAction(const std::string &name);
   PHG4BackwardHcalDisplayAction(const std::string &name, bool detailed);
-  
+
   virtual ~PHG4BackwardHcalDisplayAction();
 
   void ApplyDisplayAction(G4VPhysicalVolume *physvol);

--- a/simulation/g4simulation/g4eiccalos/PHG4BackwardHcalSubsystem.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4BackwardHcalSubsystem.h
@@ -47,9 +47,8 @@ class PHG4BackwardHcalSubsystem : public PHG4DetectorSubsystem
 
   /** Set level of detail for display
   */
-  void SetDetailed(bool b){showdetailed = b;}
+  void SetDetailed(bool b) { showdetailed = b; }
 
-  
  private:
   void SetDefaultParameters();
 

--- a/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalDetector.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalDetector.cc
@@ -3,28 +3,27 @@
 
 #include <phparameter/PHParameters.h>
 
+#include <TSystem.h>
 #include <g4main/PHG4Detector.h>       // for PHG4Detector
 #include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4Subsystem.h>
 #include <phool/recoConsts.h>
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4Cons.hh>
-#include <Geant4/G4LogicalVolume.hh>
-#include <Geant4/G4Material.hh>
-#include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
-#include <Geant4/G4ThreeVector.hh>      // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>      // for G4Transform3D
-#include <Geant4/G4Types.hh>            // for G4double, G4int
-#include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
-#include <Geant4/G4DisplacedSolid.hh>
-#include <Geant4/G4Tubs.hh>
 #include <Geant4/G4CutTubs.hh>
+#include <Geant4/G4DisplacedSolid.hh>
+#include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4MaterialPropertiesTable.hh>  // for G4MaterialProperties...
 #include <Geant4/G4MaterialPropertyVector.hh>   // for G4MaterialPropertyVector
+#include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
 #include <Geant4/G4SubtractionSolid.hh>
-#include <TSystem.h>
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>  // for G4Transform3D
+#include <Geant4/G4Tubs.hh>
+#include <Geant4/G4Types.hh>            // for G4double, G4int
+#include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
 
 #include <g4gdml/PHG4GDMLConfig.hh>
 #include <g4gdml/PHG4GDMLUtility.hh>
@@ -102,74 +101,72 @@ void PHG4BarrelEcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
 
   ParseParametersFromTable();
 
-  G4double Radius        = m_Params->get_double_param("radius")*cm;
-  G4double tower_length  = m_Params->get_double_param("tower_length")*cm;
-  G4double becal_length  = m_Params->get_double_param("becal_length")*cm;
-  G4double CenterZ_Shift = m_Params->get_double_param("CenterZ_Shift")*cm;
-  G4double cone1_h  =  m_Params->get_double_param("cone1_h")*cm;
-  G4double cone1_dz =  m_Params->get_double_param("cone1_dz")*cm;
-  G4double cone2_h  =  m_Params->get_double_param("cone2_h")*cm;
-  G4double cone2_dz =  m_Params->get_double_param("cone2_dz")*cm;
+  G4double Radius = m_Params->get_double_param("radius") * cm;
+  G4double tower_length = m_Params->get_double_param("tower_length") * cm;
+  G4double becal_length = m_Params->get_double_param("becal_length") * cm;
+  G4double CenterZ_Shift = m_Params->get_double_param("CenterZ_Shift") * cm;
+  G4double cone1_h = m_Params->get_double_param("cone1_h") * cm;
+  G4double cone1_dz = m_Params->get_double_param("cone1_dz") * cm;
+  G4double cone2_h = m_Params->get_double_param("cone2_h") * cm;
+  G4double cone2_dz = m_Params->get_double_param("cone2_dz") * cm;
 
-  silicon_width_half = m_Params->get_double_param("silicon_width_half")*cm;
-  kapton_width_half = m_Params->get_double_param("kapton_width_half")*cm;
-  SIO2_width_half = m_Params->get_double_param("SIO2_width_half")*cm;
-  Carbon_width_half = m_Params->get_double_param("Carbon_width_half")*cm;
-  support_length = m_Params->get_double_param("support_length")*cm;
+  silicon_width_half = m_Params->get_double_param("silicon_width_half") * cm;
+  kapton_width_half = m_Params->get_double_param("kapton_width_half") * cm;
+  SIO2_width_half = m_Params->get_double_param("SIO2_width_half") * cm;
+  Carbon_width_half = m_Params->get_double_param("Carbon_width_half") * cm;
+  support_length = m_Params->get_double_param("support_length") * cm;
 
-  G4double max_radius    = Radius + tower_length + 2*silicon_width_half + 2*kapton_width_half + 2*SIO2_width_half + 2*Carbon_width_half + support_length + 8*overlap;
+  G4double max_radius = Radius + tower_length + 2 * silicon_width_half + 2 * kapton_width_half + 2 * SIO2_width_half + 2 * Carbon_width_half + support_length + 8 * overlap;
 
   //std::cout << Radius << "  " << max_radius << "====================================" << std::endl;
 
-  G4double pos_x1 = 0*cm;
-  G4double pos_y1 = 0*cm;
-  G4double pos_z1 = 0*cm;
+  G4double pos_x1 = 0 * cm;
+  G4double pos_y1 = 0 * cm;
+  G4double pos_z1 = 0 * cm;
 
-  G4Tubs *cylinder_solid1 = new G4Tubs("BCAL_SOLID1",
+  G4Tubs* cylinder_solid1 = new G4Tubs("BCAL_SOLID1",
                                        Radius, max_radius,
-                                       becal_length/2, 0, 2*M_PI);
+                                       becal_length / 2, 0, 2 * M_PI);
 
-
-  G4Tubs *cylinder_solid2 = new G4Tubs("BCAL_SOLID2",
+  G4Tubs* cylinder_solid2 = new G4Tubs("BCAL_SOLID2",
                                        Radius - 1, max_radius + 1,
-                                       abs(CenterZ_Shift), 0, 2*M_PI);
+                                       abs(CenterZ_Shift), 0, 2 * M_PI);
 
-  G4ThreeVector shift_cs2 = G4ThreeVector(0, 0, becal_length/2);
+  G4ThreeVector shift_cs2 = G4ThreeVector(0, 0, becal_length / 2);
 
   G4VSolid* cylinder_solid3 = new G4SubtractionSolid("BCAL_SOLID3", cylinder_solid1, cylinder_solid2, 0, shift_cs2);
 
-  
-  G4Cons *cone1 = new G4Cons("cone1", 
-                                      Radius - 1, Radius - 1,
-                                      Radius - 1, Radius + cone1_h, 
-                                      cone1_dz, 0, 2*M_PI);
+  G4Cons* cone1 = new G4Cons("cone1",
+                             Radius - 1, Radius - 1,
+                             Radius - 1, Radius + cone1_h,
+                             cone1_dz, 0, 2 * M_PI);
 
-  G4ThreeVector shift_cone1 = G4ThreeVector(0, 0, becal_length/2 - abs(CenterZ_Shift)- cone1_dz);
+  G4ThreeVector shift_cone1 = G4ThreeVector(0, 0, becal_length / 2 - abs(CenterZ_Shift) - cone1_dz);
 
   G4VSolid* cylinder_solid4 = new G4SubtractionSolid("BCAL_SOLID4", cylinder_solid3, cone1, 0, shift_cone1);
- 
-  G4Cons *cone2 = new G4Cons("cone2", 
-                                      Radius - 1, Radius + cone2_h, 
-                                      Radius - 1, Radius - 1,                                     
-                                      cone2_dz, 0, 2*M_PI);
 
-  G4ThreeVector shift_cone2 = G4ThreeVector(0, 0, -becal_length/2 + cone2_dz);
+  G4Cons* cone2 = new G4Cons("cone2",
+                             Radius - 1, Radius + cone2_h,
+                             Radius - 1, Radius - 1,
+                             cone2_dz, 0, 2 * M_PI);
+
+  G4ThreeVector shift_cone2 = G4ThreeVector(0, 0, -becal_length / 2 + cone2_dz);
 
   G4VSolid* cylinder_solid = new G4SubtractionSolid("BCAL_SOLID", cylinder_solid4, cone2, 0, shift_cone2);
 
-  G4Material *cylinder_mat = G4Material::GetMaterial("G4_AIR");
+  G4Material* cylinder_mat = G4Material::GetMaterial("G4_AIR");
   assert(cylinder_mat);
 
-  G4LogicalVolume *cylinder_logic = new G4LogicalVolume(cylinder_solid, cylinder_mat,
-                                       "BCAL_SOLID", 0, 0, 0);
+  G4LogicalVolume* cylinder_logic = new G4LogicalVolume(cylinder_solid, cylinder_mat,
+                                                        "BCAL_SOLID", 0, 0, 0);
 
   m_DisplayAction->AddVolume(cylinder_logic, "BCalCylinder");
-  
+
   std::string name_envelope = m_TowerLogicNamePrefix + "_envelope";
 
-  G4PVPlacement * phys_envelope=
+  G4PVPlacement* phys_envelope =
       new G4PVPlacement(0, G4ThreeVector(pos_x1, pos_y1, pos_z1), cylinder_logic, name_envelope,
-                                     logicWorld, false, 0, OverlapCheck());
+                        logicWorld, false, 0, OverlapCheck());
 
   gdml_config->exclude_physical_vol(phys_envelope);
   PlaceTower(cylinder_logic);
@@ -179,36 +176,36 @@ void PHG4BarrelEcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
 
 int PHG4BarrelEcalDetector::PlaceTower(G4LogicalVolume* sec)
 {
-
-  
   /* Loop over all tower positions in vector and place tower */
   for (std::map<std::string, towerposition>::iterator iterator = m_TowerPostionMap.begin(); iterator != m_TowerPostionMap.end(); ++iterator)
   {
-
     if (Verbosity() > 0)
     {
       std::cout << "PHG4BarrelEcalDetector: Place tower " << iterator->first
-                << " idx_j = " << iterator->second.idx_j << ", idx_k = " << iterator->second.idx_k<< std::endl;
+                << " idx_j = " << iterator->second.idx_j << ", idx_k = " << iterator->second.idx_k << std::endl;
     }
 
     int copyno = (iterator->second.idx_j << 16) + iterator->second.idx_k;
-  
-    G4LogicalVolume*  block_logic = ConstructTower(iterator);
+
+    G4LogicalVolume* block_logic = ConstructTower(iterator);
     m_DisplayAction->AddVolume(block_logic, iterator->first);
-    if(iterator->second.idx_k%2 == 0)  {
+    if (iterator->second.idx_k % 2 == 0)
+    {
       m_DisplayAction->AddVolume(block_logic, "Block1");
     }
-    else {
-       m_DisplayAction->AddVolume(block_logic, "Block2");
+    else
+    {
+      m_DisplayAction->AddVolume(block_logic, "Block2");
     }
 
-
-    G4LogicalVolume*  glass_logic = ConstructGlass(iterator);
-    if(iterator->second.idx_k%2 == 0)  {
+    G4LogicalVolume* glass_logic = ConstructGlass(iterator);
+    if (iterator->second.idx_k % 2 == 0)
+    {
       m_DisplayAction->AddVolume(glass_logic, "Block1");
     }
-    else {
-       m_DisplayAction->AddVolume(glass_logic, "Block2");
+    else
+    {
+      m_DisplayAction->AddVolume(glass_logic, "Block2");
     }
 
     G4RotationMatrix becal_rotm;
@@ -217,110 +214,108 @@ int PHG4BarrelEcalDetector::PlaceTower(G4LogicalVolume* sec)
     becal_rotm.rotateZ(iterator->second.rotz);
 
     new G4PVPlacement(G4Transform3D(becal_rotm, G4ThreeVector(iterator->second.centerx, iterator->second.centery, iterator->second.centerz)),
-                    block_logic,
-                    G4String(string(iterator->first) + string("_TT")),
-                    sec,
-                    0, copyno, OverlapCheck());
-  
-    G4double posx_glass =  iterator->second.centerx + th/2*abs(cos(iterator->second.roty - M_PI_2))*cos(iterator->second.rotz);
-    G4double posy_glass =  iterator->second.centery + th/2*abs(cos(iterator->second.roty - M_PI_2))*sin(iterator->second.rotz);
-    G4double posz_glass =  iterator->second.centerz + th*sin(iterator->second.roty - M_PI_2);
-   
-    new G4PVPlacement(G4Transform3D(becal_rotm, G4ThreeVector(posx_glass, posy_glass, posz_glass)),
-                    glass_logic,
-                    G4String(string(iterator->first) + string("_Glass")),
-                    sec,
-                    0, copyno, OverlapCheck());
+                      block_logic,
+                      G4String(string(iterator->first) + string("_TT")),
+                      sec,
+                      0, copyno, OverlapCheck());
 
-    //=================Silicon 
-    G4LogicalVolume*  block_silicon = ConstructSi(iterator);
+    G4double posx_glass = iterator->second.centerx + th / 2 * abs(cos(iterator->second.roty - M_PI_2)) * cos(iterator->second.rotz);
+    G4double posy_glass = iterator->second.centery + th / 2 * abs(cos(iterator->second.roty - M_PI_2)) * sin(iterator->second.rotz);
+    G4double posz_glass = iterator->second.centerz + th * sin(iterator->second.roty - M_PI_2);
+
+    new G4PVPlacement(G4Transform3D(becal_rotm, G4ThreeVector(posx_glass, posy_glass, posz_glass)),
+                      glass_logic,
+                      G4String(string(iterator->first) + string("_Glass")),
+                      sec,
+                      0, copyno, OverlapCheck());
+
+    //=================Silicon
+    G4LogicalVolume* block_silicon = ConstructSi(iterator);
     m_DisplayAction->AddVolume(block_silicon, "Si");
 
-    G4double pTheta   =  iterator->second.pTheta;   
-    G4double theta    =  iterator->second.roty - M_PI_2;
-    G4double len      = (tower_length/2) + silicon_width_half + overlap;
-    G4double sci_sr   =  len*tan(pTheta);
-    G4double sci_sz   = len;
-    G4double sci_mag  = sqrt(sci_sr*sci_sr + sci_sz*sci_sz);
-    
+    G4double pTheta = iterator->second.pTheta;
+    G4double theta = iterator->second.roty - M_PI_2;
+    G4double len = (tower_length / 2) + silicon_width_half + overlap;
+    G4double sci_sr = len * tan(pTheta);
+    G4double sci_sz = len;
+    G4double sci_mag = sqrt(sci_sr * sci_sr + sci_sz * sci_sz);
 
-    G4double posz_si  =  iterator->second.centerz - sci_mag*sin(theta + pTheta);
-    G4double posy_si  =  iterator->second.centery + sci_mag*cos(theta + pTheta)*sin(iterator->second.rotz); 
-    G4double posx_si  =  iterator->second.centerx + sci_mag*cos(theta + pTheta)*cos(iterator->second.rotz);
+    G4double posz_si = iterator->second.centerz - sci_mag * sin(theta + pTheta);
+    G4double posy_si = iterator->second.centery + sci_mag * cos(theta + pTheta) * sin(iterator->second.rotz);
+    G4double posx_si = iterator->second.centerx + sci_mag * cos(theta + pTheta) * cos(iterator->second.rotz);
     new G4PVPlacement(G4Transform3D(becal_rotm, G4ThreeVector(posx_si, posy_si, posz_si)),
-                    block_silicon,
-                    G4String(string(iterator->first) + string("_Si")),
-                    sec,
-                    0, copyno, OverlapCheck());
+                      block_silicon,
+                      G4String(string(iterator->first) + string("_Si")),
+                      sec,
+                      0, copyno, OverlapCheck());
 
     //=================Kapton
-    G4LogicalVolume*  block_kapton = ConstructKapton(iterator);
+    G4LogicalVolume* block_kapton = ConstructKapton(iterator);
     m_DisplayAction->AddVolume(block_kapton, "Kapton");
 
-    len               += kapton_width_half + overlap + silicon_width_half; 
+    len += kapton_width_half + overlap + silicon_width_half;
 
-    G4double kapton_sr    =  len*tan(pTheta);
-    G4double kapton_sz    =  len;
-    G4double kapton_mag   =  sqrt(kapton_sr*kapton_sr + kapton_sz*kapton_sz);
-   
-    G4double posz_kapton  =  iterator->second.centerz - kapton_mag*sin(theta + pTheta);
-    G4double posy_kapton  =  iterator->second.centery + kapton_mag*cos(theta + pTheta)*sin(iterator->second.rotz); 
-    G4double posx_kapton  =  iterator->second.centerx + kapton_mag*cos(theta + pTheta)*cos(iterator->second.rotz);
+    G4double kapton_sr = len * tan(pTheta);
+    G4double kapton_sz = len;
+    G4double kapton_mag = sqrt(kapton_sr * kapton_sr + kapton_sz * kapton_sz);
+
+    G4double posz_kapton = iterator->second.centerz - kapton_mag * sin(theta + pTheta);
+    G4double posy_kapton = iterator->second.centery + kapton_mag * cos(theta + pTheta) * sin(iterator->second.rotz);
+    G4double posx_kapton = iterator->second.centerx + kapton_mag * cos(theta + pTheta) * cos(iterator->second.rotz);
     new G4PVPlacement(G4Transform3D(becal_rotm, G4ThreeVector(posx_kapton, posy_kapton, posz_kapton)),
-                    block_kapton,
-                    G4String(string(iterator->first) + string("_Kapton")),
-                    sec,
-                    0, copyno, OverlapCheck());
+                      block_kapton,
+                      G4String(string(iterator->first) + string("_Kapton")),
+                      sec,
+                      0, copyno, OverlapCheck());
 
     //=================SIO2
-    G4LogicalVolume*  block_SIO2 = ConstructSIO2(iterator);
+    G4LogicalVolume* block_SIO2 = ConstructSIO2(iterator);
     m_DisplayAction->AddVolume(block_SIO2, "SIO2");
 
-    len              += SIO2_width_half + overlap + kapton_width_half; 
+    len += SIO2_width_half + overlap + kapton_width_half;
 
-    G4double SIO2_sr = len*tan(pTheta);
+    G4double SIO2_sr = len * tan(pTheta);
     G4double SIO2_sz = len;
-    G4double SIO2_mag = sqrt(SIO2_sr*SIO2_sr + SIO2_sz*SIO2_sz);
-   
-    G4double posz_SIO2  =  iterator->second.centerz - SIO2_mag*sin(theta + pTheta);
-    G4double posy_SIO2  =  iterator->second.centery + SIO2_mag*cos(theta + pTheta)*sin(iterator->second.rotz); 
-    G4double posx_SIO2  =  iterator->second.centerx + SIO2_mag*cos(theta + pTheta)*cos(iterator->second.rotz);
+    G4double SIO2_mag = sqrt(SIO2_sr * SIO2_sr + SIO2_sz * SIO2_sz);
+
+    G4double posz_SIO2 = iterator->second.centerz - SIO2_mag * sin(theta + pTheta);
+    G4double posy_SIO2 = iterator->second.centery + SIO2_mag * cos(theta + pTheta) * sin(iterator->second.rotz);
+    G4double posx_SIO2 = iterator->second.centerx + SIO2_mag * cos(theta + pTheta) * cos(iterator->second.rotz);
     new G4PVPlacement(G4Transform3D(becal_rotm, G4ThreeVector(posx_SIO2, posy_SIO2, posz_SIO2)),
-                    block_SIO2,
-                    G4String(string(iterator->first) + string("SIO2")),
-                    sec,
-                    0, copyno, OverlapCheck());
+                      block_SIO2,
+                      G4String(string(iterator->first) + string("SIO2")),
+                      sec,
+                      0, copyno, OverlapCheck());
 
     //=================Carbon
-    G4LogicalVolume*  block_Carbon = ConstructCarbon(iterator);
- 
-     if(iterator->second.idx_k%2 == 0)  {
+    G4LogicalVolume* block_Carbon = ConstructCarbon(iterator);
+
+    if (iterator->second.idx_k % 2 == 0)
+    {
       m_DisplayAction->AddVolume(block_Carbon, "Block1");
     }
-    else {
-       m_DisplayAction->AddVolume(block_Carbon, "Block2");
+    else
+    {
+      m_DisplayAction->AddVolume(block_Carbon, "Block2");
     }
 
+    len += Carbon_width_half + overlap + SIO2_width_half;
 
-    len              += Carbon_width_half + overlap + SIO2_width_half; 
-
-    G4double Carbon_sr = len*tan(pTheta);
+    G4double Carbon_sr = len * tan(pTheta);
     G4double Carbon_sz = len;
-    G4double Carbon_mag = sqrt(Carbon_sr*Carbon_sr + Carbon_sz*Carbon_sz);
-   
-    G4double posz_Carbon  =  iterator->second.centerz - Carbon_mag*sin(theta + pTheta);
-    G4double posy_Carbon  =  iterator->second.centery + Carbon_mag*cos(theta + pTheta)*sin(iterator->second.rotz); 
-    G4double posx_Carbon  =  iterator->second.centerx + Carbon_mag*cos(theta + pTheta)*cos(iterator->second.rotz);
-    new G4PVPlacement(G4Transform3D(becal_rotm, G4ThreeVector(posx_Carbon, posy_Carbon, posz_Carbon)),
-                    block_Carbon,
-                    G4String(string(iterator->first) + string("Carbon")),
-                    sec,
-                    0, copyno, OverlapCheck());
+    G4double Carbon_mag = sqrt(Carbon_sr * Carbon_sr + Carbon_sz * Carbon_sz);
 
+    G4double posz_Carbon = iterator->second.centerz - Carbon_mag * sin(theta + pTheta);
+    G4double posy_Carbon = iterator->second.centery + Carbon_mag * cos(theta + pTheta) * sin(iterator->second.rotz);
+    G4double posx_Carbon = iterator->second.centerx + Carbon_mag * cos(theta + pTheta) * cos(iterator->second.rotz);
+    new G4PVPlacement(G4Transform3D(becal_rotm, G4ThreeVector(posx_Carbon, posy_Carbon, posz_Carbon)),
+                      block_Carbon,
+                      G4String(string(iterator->first) + string("Carbon")),
+                      sec,
+                      0, copyno, OverlapCheck());
   }
   return 0;
 }
-
 
 int PHG4BarrelEcalDetector::ParseParametersFromTable()
 {
@@ -337,19 +332,17 @@ int PHG4BarrelEcalDetector::ParseParametersFromTable()
   std::string line_mapping;
   while (getline(istream_mapping, line_mapping))
   {
-
     std::istringstream iss(line_mapping);
 
     if (line_mapping.find("BECALtower ") != string::npos)
     {
-
       unsigned idphi_j, ideta_k;
       G4double cx, cy, cz;
       G4double rot_z, rot_y, rot_x;
       G4double size_z, size_y1, size_x1, size_y2, size_x2, p_Theta;
       std::string dummys;
- 
-      if (!(iss >> dummys >> ideta_k >> idphi_j >>  size_x1 >>  size_x2 >> size_y1 >> size_y2 >> size_z >> p_Theta >> cx >> cy >> cz >> rot_x >> rot_y >> rot_z))
+
+      if (!(iss >> dummys >> ideta_k >> idphi_j >> size_x1 >> size_x2 >> size_y1 >> size_y2 >> size_z >> p_Theta >> cx >> cy >> cz >> rot_x >> rot_y >> rot_z))
       {
         std::cout << "ERROR in PHG4BarrelEcalDetector: Failed to read line in mapping file " << m_Params->get_string_param("mapping_file") << std::endl;
         gSystem->Exit(1);
@@ -363,24 +356,23 @@ int PHG4BarrelEcalDetector::ParseParametersFromTable()
 
       /* insert tower into tower map */
       towerposition tower_new;
-      tower_new.sizex1  = size_x1*cm;
-      tower_new.sizex2  = size_x2*cm;
-      tower_new.sizey1  = size_y1*cm;
-      tower_new.sizey2  = size_y2*cm;
-      tower_new.sizez   = size_z*cm;
-      tower_new.pTheta  = p_Theta;
-      tower_new.centerx = cx*cm;
-      tower_new.centery = cy*cm;
-      tower_new.centerz = cz*cm;
-      tower_new.rotx    = rot_x;
-      tower_new.roty    = rot_y;
-      tower_new.rotz    = rot_z;
-      tower_new.idx_j   = idphi_j;
-      tower_new.idx_k   = ideta_k;
+      tower_new.sizex1 = size_x1 * cm;
+      tower_new.sizex2 = size_x2 * cm;
+      tower_new.sizey1 = size_y1 * cm;
+      tower_new.sizey2 = size_y2 * cm;
+      tower_new.sizez = size_z * cm;
+      tower_new.pTheta = p_Theta;
+      tower_new.centerx = cx * cm;
+      tower_new.centery = cy * cm;
+      tower_new.centerz = cz * cm;
+      tower_new.rotx = rot_x;
+      tower_new.roty = rot_y;
+      tower_new.rotz = rot_z;
+      tower_new.idx_j = idphi_j;
+      tower_new.idx_k = ideta_k;
       m_TowerPostionMap.insert(make_pair(towername.str(), tower_new));
-
-      
-    } else
+    }
+    else
     {
       /* If this line is not a comment and not a tower, save parameter as string / value. */
       string parname;
@@ -443,7 +435,7 @@ int PHG4BarrelEcalDetector::ParseParametersFromTable()
       {
         m_Params->set_double_param("thickness_wall", parit->second);  // in cm
       }
-       parit = m_GlobalParameterMap.find("silicon_width_half");
+      parit = m_GlobalParameterMap.find("silicon_width_half");
       if (parit != m_GlobalParameterMap.end())
       {
         m_Params->set_double_param("silicon_width_half", parit->second);  // in cm
@@ -474,20 +466,18 @@ int PHG4BarrelEcalDetector::ParseParametersFromTable()
   return 0;
 }
 
-
-
 G4LogicalVolume*
 PHG4BarrelEcalDetector::ConstructTower(std::map<std::string, towerposition>::iterator iterator)
 {
-  G4Trap *block_tower = GetTowerTrap(iterator);
-  G4Trap *block_glass = GetGlassTrapSubtract(iterator); 
-  G4ThreeVector shift = G4ThreeVector(-th*sin(iterator->second.roty - M_PI_2), 0, th/2*abs(cos(iterator->second.roty - M_PI_2)));
-  G4VSolid* block_solid = new G4SubtractionSolid(G4String(string(iterator->first)  + string("_Envelope")), block_tower, block_glass, 0, shift);
+  G4Trap* block_tower = GetTowerTrap(iterator);
+  G4Trap* block_glass = GetGlassTrapSubtract(iterator);
+  G4ThreeVector shift = G4ThreeVector(-th * sin(iterator->second.roty - M_PI_2), 0, th / 2 * abs(cos(iterator->second.roty - M_PI_2)));
+  G4VSolid* block_solid = new G4SubtractionSolid(G4String(string(iterator->first) + string("_Envelope")), block_tower, block_glass, 0, shift);
   G4Material* material_shell = GetCarbonFiber();
   assert(material_shell);
-    
+
   G4LogicalVolume* block_logic = new G4LogicalVolume(block_solid, material_shell,
-                                                     G4String(string(iterator->first)  + string("_Tower")), 0, 0,
+                                                     G4String(string(iterator->first) + string("_Tower")), 0, 0,
                                                      nullptr);
   m_AbsorberLogicalVolSet.insert(block_logic);
   return block_logic;
@@ -496,7 +486,7 @@ PHG4BarrelEcalDetector::ConstructTower(std::map<std::string, towerposition>::ite
 G4LogicalVolume*
 PHG4BarrelEcalDetector::ConstructGlass(std::map<std::string, towerposition>::iterator iterator)
 {
-  G4Trap *block_solid = GetGlassTrap(iterator);   
+  G4Trap* block_solid = GetGlassTrap(iterator);
   G4Material* material_glass = GetSciGlass();
   assert(material_glass);
   G4LogicalVolume* block_logic = new G4LogicalVolume(block_solid, material_glass,
@@ -505,8 +495,6 @@ PHG4BarrelEcalDetector::ConstructGlass(std::map<std::string, towerposition>::ite
   m_ScintiLogicalVolSet.insert(block_logic);
   return block_logic;
 }
-
-
 
 G4Material* PHG4BarrelEcalDetector::GetCarbonFiber()
 {
@@ -529,32 +517,31 @@ G4Material* PHG4BarrelEcalDetector::GetSciGlass()
   {
     G4double density;
     G4int ncomponents;
-    sciglass = new G4Material(matname, density = 4.22 * g / cm3, ncomponents = 4,  kStateSolid);
+    sciglass = new G4Material(matname, density = 4.22 * g / cm3, ncomponents = 4, kStateSolid);
     sciglass->AddElement(G4Element::GetElement("Ba"), 0.3875);
     sciglass->AddElement(G4Element::GetElement("Gd"), 0.2146);
     sciglass->AddElement(G4Element::GetElement("Si"), 0.1369);
-    sciglass->AddElement(G4Element::GetElement("O"),  0.2610);
+    sciglass->AddElement(G4Element::GetElement("O"), 0.2610);
   }
   return sciglass;
 }
 
 G4Trap* PHG4BarrelEcalDetector::GetGlassTrap(std::map<std::string, towerposition>::iterator iterator)
 {
+  G4double th = m_Params->get_double_param("thickness_wall") * cm;
+  G4double size_x1 = iterator->second.sizex1 / 2 - th;
+  G4double size_x2 = iterator->second.sizex2 / 2 - th;
+  G4double size_y1 = iterator->second.sizey1 / 2 - th;
+  G4double size_y2 = iterator->second.sizey2 / 2 - th;
+  G4double size_z = iterator->second.sizez / 2 - th;
 
-  G4double th =  m_Params->get_double_param("thickness_wall")*cm;
-  G4double size_x1 = iterator->second.sizex1/2 - th ;
-  G4double size_x2 = iterator->second.sizex2/2 - th; 
-  G4double size_y1 = iterator->second.sizey1/2 - th;
-  G4double size_y2 = iterator->second.sizey2/2 - th; 
-  G4double size_z  = iterator->second.sizez/2 - th; 
-
-  G4Trap* block_glass = new G4Trap( "solid_glass",
-      size_z,                                                                           // G4double pDz,
-      iterator->second.pTheta,  0,                                                              // G4double pTheta, G4double pPhi,
-      size_y1, size_x1, size_x1,      // G4double pDy1, G4double pDx1, G4double pDx2,
-      0,                                                                                        // G4double pAlp1,
-      size_y2, size_x2, size_x2,      // G4double pDy2, G4double pDx3, G4double pDx4,
-      0                                                                                         // G4double pAlp2 //
+  G4Trap* block_glass = new G4Trap("solid_glass",
+                                   size_z,                      // G4double pDz,
+                                   iterator->second.pTheta, 0,  // G4double pTheta, G4double pPhi,
+                                   size_y1, size_x1, size_x1,   // G4double pDy1, G4double pDx1, G4double pDx2,
+                                   0,                           // G4double pAlp1,
+                                   size_y2, size_x2, size_x2,   // G4double pDy2, G4double pDx3, G4double pDx4,
+                                   0                            // G4double pAlp2 //
   );
 
   return block_glass;
@@ -562,36 +549,34 @@ G4Trap* PHG4BarrelEcalDetector::GetGlassTrap(std::map<std::string, towerposition
 
 G4Trap* PHG4BarrelEcalDetector::GetTowerTrap(std::map<std::string, towerposition>::iterator iterator)
 {
-
-  G4Trap* block_tower = new G4Trap( "solid_tower",
-      iterator->second.sizez/2,                                                                           // G4double pDz,
-      iterator->second.pTheta,  0,                                                              // G4double pTheta, G4double pPhi,
-      iterator->second.sizey1/2, iterator->second.sizex1/2, iterator->second.sizex1/2.,      // G4double pDy1, G4double pDx1, G4double pDx2,
-      0,                                                                                        // G4double pAlp1,
-      iterator->second.sizey2/2, iterator->second.sizex2/2, iterator->second.sizex2/2.,      // G4double pDy2, G4double pDx3, G4double pDx4,
-      0                                                                                         // G4double pAlp2 //
+  G4Trap* block_tower = new G4Trap("solid_tower",
+                                   iterator->second.sizez / 2,                                                              // G4double pDz,
+                                   iterator->second.pTheta, 0,                                                              // G4double pTheta, G4double pPhi,
+                                   iterator->second.sizey1 / 2, iterator->second.sizex1 / 2, iterator->second.sizex1 / 2.,  // G4double pDy1, G4double pDx1, G4double pDx2,
+                                   0,                                                                                       // G4double pAlp1,
+                                   iterator->second.sizey2 / 2, iterator->second.sizex2 / 2, iterator->second.sizex2 / 2.,  // G4double pDy2, G4double pDx3, G4double pDx4,
+                                   0                                                                                        // G4double pAlp2 //
   );
 
   return block_tower;
 }
 
-
 G4Trap* PHG4BarrelEcalDetector::GetGlassTrapSubtract(std::map<std::string, towerposition>::iterator iterator)
 {
-  G4double th =  m_Params->get_double_param("thickness_wall")*cm;
-  G4double size_x1 = iterator->second.sizex1/2 - th + overlap;
-  G4double size_x2 = iterator->second.sizex2/2 - th + overlap; 
-  G4double size_y1 = iterator->second.sizey1/2 - th + overlap;
-  G4double size_y2 = iterator->second.sizey2/2 - th + overlap; 
-  G4double size_z  = iterator->second.sizez/2 - th/2  + overlap; 
+  G4double th = m_Params->get_double_param("thickness_wall") * cm;
+  G4double size_x1 = iterator->second.sizex1 / 2 - th + overlap;
+  G4double size_x2 = iterator->second.sizex2 / 2 - th + overlap;
+  G4double size_y1 = iterator->second.sizey1 / 2 - th + overlap;
+  G4double size_y2 = iterator->second.sizey2 / 2 - th + overlap;
+  G4double size_z = iterator->second.sizez / 2 - th / 2 + overlap;
 
-  G4Trap* block_glass = new G4Trap( "solid_glass",
-      size_z,                                                                           // G4double pDz,
-      iterator->second.pTheta,  0,                                                              // G4double pTheta, G4double pPhi,
-      size_y1, size_x1, size_x1,      // G4double pDy1, G4double pDx1, G4double pDx2,
-      0,                                                                                        // G4double pAlp1,
-      size_y2, size_x2, size_x2,      // G4double pDy2, G4double pDx3, G4double pDx4,
-      0                                                                                         // G4double pAlp2 //
+  G4Trap* block_glass = new G4Trap("solid_glass",
+                                   size_z,                      // G4double pDz,
+                                   iterator->second.pTheta, 0,  // G4double pTheta, G4double pPhi,
+                                   size_y1, size_x1, size_x1,   // G4double pDy1, G4double pDx1, G4double pDx2,
+                                   0,                           // G4double pAlp1,
+                                   size_y2, size_x2, size_x2,   // G4double pDy2, G4double pDx3, G4double pDx4,
+                                   0                            // G4double pAlp2 //
   );
 
   return block_glass;
@@ -599,20 +584,19 @@ G4Trap* PHG4BarrelEcalDetector::GetGlassTrapSubtract(std::map<std::string, tower
 
 G4Trap* PHG4BarrelEcalDetector::GetSiTrap(std::map<std::string, towerposition>::iterator iterator)
 {
+  G4double size_x1 = iterator->second.sizex2 / 2 - overlap;
+  G4double size_x2 = iterator->second.sizex2 / 2 - overlap;
+  G4double size_y1 = iterator->second.sizey2 / 2 - overlap;
+  G4double size_y2 = iterator->second.sizey2 / 2 - overlap;
+  G4double size_z = silicon_width_half;
 
-  G4double size_x1 = iterator->second.sizex2/2 - overlap;
-  G4double size_x2 = iterator->second.sizex2/2 - overlap; 
-  G4double size_y1 = iterator->second.sizey2/2 - overlap;
-  G4double size_y2 = iterator->second.sizey2/2 - overlap; 
-  G4double size_z  = silicon_width_half; 
-
-  G4Trap* block_si = new G4Trap( "Si",
-      size_z,                                                                           // G4double pDz,
-      iterator->second.pTheta,  0,                                                              // G4double pTheta, G4double pPhi,
-      size_y1, size_x1, size_x1,      // G4double pDy1, G4double pDx1, G4double pDx2,
-      0,                                                                                        // G4double pAlp1,
-      size_y2, size_x2, size_x2,      // G4double pDy2, G4double pDx3, G4double pDx4,
-      0                                                                                         // G4double pAlp2 //
+  G4Trap* block_si = new G4Trap("Si",
+                                size_z,                      // G4double pDz,
+                                iterator->second.pTheta, 0,  // G4double pTheta, G4double pPhi,
+                                size_y1, size_x1, size_x1,   // G4double pDy1, G4double pDx1, G4double pDx2,
+                                0,                           // G4double pAlp1,
+                                size_y2, size_x2, size_x2,   // G4double pDy2, G4double pDx3, G4double pDx4,
+                                0                            // G4double pAlp2 //
   );
 
   return block_si;
@@ -621,7 +605,7 @@ G4Trap* PHG4BarrelEcalDetector::GetSiTrap(std::map<std::string, towerposition>::
 G4LogicalVolume*
 PHG4BarrelEcalDetector::ConstructSi(std::map<std::string, towerposition>::iterator iterator)
 {
-  G4Trap *block_solid = GetSiTrap(iterator);   
+  G4Trap* block_solid = GetSiTrap(iterator);
   G4Material* material_si = G4Material::GetMaterial("G4_POLYSTYRENE");
   assert(material_si);
   G4LogicalVolume* block_logic = new G4LogicalVolume(block_solid, material_si,
@@ -632,18 +616,18 @@ PHG4BarrelEcalDetector::ConstructSi(std::map<std::string, towerposition>::iterat
 
 G4Trap* PHG4BarrelEcalDetector::GetKaptonTrap(std::map<std::string, towerposition>::iterator iterator)
 {
-  G4double size_x1 = iterator->second.sizex2/2 - overlap;
-  G4double size_x2 = iterator->second.sizex2/2 - overlap; 
-  G4double size_y1 = iterator->second.sizey2/2 - overlap;
-  G4double size_y2 = iterator->second.sizey2/2 - overlap; 
-  G4double size_z  = kapton_width_half; 
-  G4Trap* block_si = new G4Trap( "Kapton",
-      size_z,                                                                           // G4double pDz,
-      iterator->second.pTheta,  0,                                                              // G4double pTheta, G4double pPhi,
-      size_y1, size_x1, size_x1,      // G4double pDy1, G4double pDx1, G4double pDx2,
-      0,                                                                                        // G4double pAlp1,
-      size_y2, size_x2, size_x2,      // G4double pDy2, G4double pDx3, G4double pDx4,
-      0                                                                                         // G4double pAlp2 //
+  G4double size_x1 = iterator->second.sizex2 / 2 - overlap;
+  G4double size_x2 = iterator->second.sizex2 / 2 - overlap;
+  G4double size_y1 = iterator->second.sizey2 / 2 - overlap;
+  G4double size_y2 = iterator->second.sizey2 / 2 - overlap;
+  G4double size_z = kapton_width_half;
+  G4Trap* block_si = new G4Trap("Kapton",
+                                size_z,                      // G4double pDz,
+                                iterator->second.pTheta, 0,  // G4double pTheta, G4double pPhi,
+                                size_y1, size_x1, size_x1,   // G4double pDy1, G4double pDx1, G4double pDx2,
+                                0,                           // G4double pAlp1,
+                                size_y2, size_x2, size_x2,   // G4double pDy2, G4double pDx3, G4double pDx4,
+                                0                            // G4double pAlp2 //
   );
   return block_si;
 }
@@ -651,7 +635,7 @@ G4Trap* PHG4BarrelEcalDetector::GetKaptonTrap(std::map<std::string, towerpositio
 G4LogicalVolume*
 PHG4BarrelEcalDetector::ConstructKapton(std::map<std::string, towerposition>::iterator iterator)
 {
-  G4Trap *block_solid = GetKaptonTrap(iterator);   
+  G4Trap* block_solid = GetKaptonTrap(iterator);
   G4Material* material_kapton = G4Material::GetMaterial("G4_KAPTON");
   assert(material_kapton);
   G4LogicalVolume* block_logic = new G4LogicalVolume(block_solid, material_kapton,
@@ -662,20 +646,19 @@ PHG4BarrelEcalDetector::ConstructKapton(std::map<std::string, towerposition>::it
 
 G4Trap* PHG4BarrelEcalDetector::GetSIO2Trap(std::map<std::string, towerposition>::iterator iterator)
 {
+  G4double size_x1 = iterator->second.sizex2 / 2 - overlap;
+  G4double size_x2 = iterator->second.sizex2 / 2 - overlap;
+  G4double size_y1 = iterator->second.sizey2 / 2 - overlap;
+  G4double size_y2 = iterator->second.sizey2 / 2 - overlap;
+  G4double size_z = SIO2_width_half;
 
-  G4double size_x1 = iterator->second.sizex2/2 - overlap;
-  G4double size_x2 = iterator->second.sizex2/2 - overlap; 
-  G4double size_y1 = iterator->second.sizey2/2 - overlap;
-  G4double size_y2 = iterator->second.sizey2/2 - overlap; 
-  G4double size_z  = SIO2_width_half; 
-
-  G4Trap* block_SIO2 = new G4Trap( "SIO2",
-      size_z,                                                                           // G4double pDz,
-      iterator->second.pTheta,  0,                                                              // G4double pTheta, G4double pPhi,
-      size_y1, size_x1, size_x1,      // G4double pDy1, G4double pDx1, G4double pDx2,
-      0,                                                                                        // G4double pAlp1,
-      size_y2, size_x2, size_x2,      // G4double pDy2, G4double pDx3, G4double pDx4,
-      0                                                                                         // G4double pAlp2 //
+  G4Trap* block_SIO2 = new G4Trap("SIO2",
+                                  size_z,                      // G4double pDz,
+                                  iterator->second.pTheta, 0,  // G4double pTheta, G4double pPhi,
+                                  size_y1, size_x1, size_x1,   // G4double pDy1, G4double pDx1, G4double pDx2,
+                                  0,                           // G4double pAlp1,
+                                  size_y2, size_x2, size_x2,   // G4double pDy2, G4double pDx3, G4double pDx4,
+                                  0                            // G4double pAlp2 //
   );
   return block_SIO2;
 }
@@ -683,7 +666,7 @@ G4Trap* PHG4BarrelEcalDetector::GetSIO2Trap(std::map<std::string, towerposition>
 G4LogicalVolume*
 PHG4BarrelEcalDetector::ConstructSIO2(std::map<std::string, towerposition>::iterator iterator)
 {
-  G4Trap *block_solid = GetSIO2Trap(iterator);   
+  G4Trap* block_solid = GetSIO2Trap(iterator);
   G4Material* material_SIO2 = G4Material::GetMaterial("Quartz");
   assert(material_SIO2);
   G4LogicalVolume* block_logic = new G4LogicalVolume(block_solid, material_SIO2,
@@ -692,22 +675,21 @@ PHG4BarrelEcalDetector::ConstructSIO2(std::map<std::string, towerposition>::iter
   return block_logic;
 }
 
-
 G4Trap* PHG4BarrelEcalDetector::GetCarbonTrap(std::map<std::string, towerposition>::iterator iterator)
 {
-  G4double size_x1 = iterator->second.sizex2/2 - overlap;
-  G4double size_x2 = iterator->second.sizex2/2 - overlap; 
-  G4double size_y1 = iterator->second.sizey2/2 - overlap;
-  G4double size_y2 = iterator->second.sizey2/2 - overlap; 
-  G4double size_z  = Carbon_width_half; 
+  G4double size_x1 = iterator->second.sizex2 / 2 - overlap;
+  G4double size_x2 = iterator->second.sizex2 / 2 - overlap;
+  G4double size_y1 = iterator->second.sizey2 / 2 - overlap;
+  G4double size_y2 = iterator->second.sizey2 / 2 - overlap;
+  G4double size_z = Carbon_width_half;
 
-  G4Trap* block_SIO2 = new G4Trap( "C",
-      size_z,                                                                           // G4double pDz,
-      iterator->second.pTheta,  0,                                                              // G4double pTheta, G4double pPhi,
-      size_y1, size_x1, size_x1,      // G4double pDy1, G4double pDx1, G4double pDx2,
-      0,                                                                                        // G4double pAlp1,
-      size_y2, size_x2, size_x2,      // G4double pDy2, G4double pDx3, G4double pDx4,
-      0                                                                                         // G4double pAlp2 //
+  G4Trap* block_SIO2 = new G4Trap("C",
+                                  size_z,                      // G4double pDz,
+                                  iterator->second.pTheta, 0,  // G4double pTheta, G4double pPhi,
+                                  size_y1, size_x1, size_x1,   // G4double pDy1, G4double pDx1, G4double pDx2,
+                                  0,                           // G4double pAlp1,
+                                  size_y2, size_x2, size_x2,   // G4double pDy2, G4double pDx3, G4double pDx4,
+                                  0                            // G4double pAlp2 //
   );
 
   return block_SIO2;
@@ -716,7 +698,7 @@ G4Trap* PHG4BarrelEcalDetector::GetCarbonTrap(std::map<std::string, towerpositio
 G4LogicalVolume*
 PHG4BarrelEcalDetector::ConstructCarbon(std::map<std::string, towerposition>::iterator iterator)
 {
-  G4Trap *block_solid = GetCarbonTrap(iterator);   
+  G4Trap* block_solid = GetCarbonTrap(iterator);
   G4Material* material_Carbon = G4Material::GetMaterial("G4_C");
   assert(material_Carbon);
   G4LogicalVolume* block_logic = new G4LogicalVolume(block_solid, material_Carbon,

--- a/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalDetector.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalDetector.h
@@ -5,11 +5,11 @@
 
 #include <g4main/PHG4Detector.h>
 
-#include <Geant4/G4Types.hh>  // for G4double
-#include <Geant4/G4Transform3D.hh>
-#include <Geant4/G4Tubs.hh>
 #include <Geant4/G4SystemOfUnits.hh>
+#include <Geant4/G4Transform3D.hh>
 #include <Geant4/G4Trap.hh>
+#include <Geant4/G4Tubs.hh>
+#include <Geant4/G4Types.hh>  // for G4double
 
 #include <map>
 #include <set>
@@ -51,14 +51,13 @@ class PHG4BarrelEcalDetector : public PHG4Detector
   int get_Layer() const { return m_Layer; }
 
  private:
-
   //! BECAL parameters
 
-  G4double Radius = 85.*cm; //Inner radius of BECAL
-  G4double tower_length = 45.5*cm; // Length of the Tower
+  G4double Radius = 85. * cm;         //Inner radius of BECAL
+  G4double tower_length = 45.5 * cm;  // Length of the Tower
 
-  const int nTowers_layer = 128.; //Number of towers per phi tower
-  const double becal_length = 415*cm;  //support width
+  const int nTowers_layer = 128.;        //Number of towers per phi tower
+  const double becal_length = 415 * cm;  //support width
   const double th = 1.;
   const double overlap = 0.1;
 
@@ -67,15 +66,12 @@ class PHG4BarrelEcalDetector : public PHG4Detector
   G4double SIO2_width_half;
   G4double Carbon_width_half;
   G4double support_length;
-  
 
-  
   int PlaceTower(G4LogicalVolume *envelope);
   int ParseParametersFromTable();
 
   struct towerposition
   {
-
     G4double sizex1;
     G4double sizey1;
     G4double sizex2;
@@ -97,10 +93,10 @@ class PHG4BarrelEcalDetector : public PHG4Detector
 
   G4Trap *GetTowerTrap(std::map<std::string, towerposition>::iterator iterator);
   G4Trap *GetSiTrap(std::map<std::string, towerposition>::iterator iterator);
-  G4Trap* GetGlassTrap(std::map<std::string, towerposition>::iterator iterator);
-  G4Trap* GetKaptonTrap(std::map<std::string, towerposition>::iterator iterator);
-  G4Trap* GetSIO2Trap(std::map<std::string, towerposition>::iterator iterator);
-  G4Trap* GetCarbonTrap(std::map<std::string, towerposition>::iterator iterator);
+  G4Trap *GetGlassTrap(std::map<std::string, towerposition>::iterator iterator);
+  G4Trap *GetKaptonTrap(std::map<std::string, towerposition>::iterator iterator);
+  G4Trap *GetSIO2Trap(std::map<std::string, towerposition>::iterator iterator);
+  G4Trap *GetCarbonTrap(std::map<std::string, towerposition>::iterator iterator);
 
   G4LogicalVolume *GetTowerSci(std::map<std::string, towerposition>::iterator iterator);
   G4Trap *GetGlassTrapSubtract(std::map<std::string, towerposition>::iterator iterator);
@@ -108,8 +104,8 @@ class PHG4BarrelEcalDetector : public PHG4Detector
   G4LogicalVolume *ConstructGlass(std::map<std::string, towerposition>::iterator iterator);
   G4LogicalVolume *ConstructSi(std::map<std::string, towerposition>::iterator iterator);
   G4LogicalVolume *ConstructKapton(std::map<std::string, towerposition>::iterator iterator);
-  G4LogicalVolume *ConstructSIO2(std::map<std::string, towerposition>::iterator iterator);  
-  G4LogicalVolume *ConstructCarbon(std::map<std::string, towerposition>::iterator iterator);  
+  G4LogicalVolume *ConstructSIO2(std::map<std::string, towerposition>::iterator iterator);
+  G4LogicalVolume *ConstructCarbon(std::map<std::string, towerposition>::iterator iterator);
 
   PHG4BarrelEcalDisplayAction *m_DisplayAction = nullptr;
   PHParameters *m_Params = nullptr;
@@ -119,8 +115,7 @@ class PHG4BarrelEcalDetector : public PHG4Detector
   int m_SupportActiveFlag = 0;
   int m_Layer = 0;
 
- 
-  //G4LogicalVolume* singletower; 
+  //G4LogicalVolume* singletower;
   std::string m_TowerLogicNamePrefix;
   std::string m_SuperDetector;
 
@@ -132,7 +127,7 @@ class PHG4BarrelEcalDetector : public PHG4Detector
   std::set<G4LogicalVolume *> m_SupportLogicalVolSet;
 
   //! registry for volumes that should not be exported, i.e. fibers
-  PHG4GDMLConfig* gdml_config = nullptr;
+  PHG4GDMLConfig *gdml_config = nullptr;
 };
 
 #endif

--- a/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalDisplayAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalDisplayAction.cc
@@ -39,7 +39,7 @@ void PHG4BarrelEcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
     visatt->SetVisibility(true);
     visatt->SetForceSolid(true);
     m_VisAttVec.push_back(visatt);  // for later deletion
-    if (it.second == "BCalCylinder") 
+    if (it.second == "BCalCylinder")
     {
       visatt->SetColour(G4Colour::White());
       visatt->SetForceWireframe(true);
@@ -47,7 +47,7 @@ void PHG4BarrelEcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
     }
     else if (it.second == "Block1")
     {
-      visatt->SetColour(G4Colour(1.,0.5,0.));    
+      visatt->SetColour(G4Colour(1., 0.5, 0.));
     }
     else if (it.second == "Block2")
     {

--- a/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalDisplayAction.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalDisplayAction.h
@@ -1,4 +1,4 @@
- // Tell emacs that this is a C++ source
+// Tell emacs that this is a C++ source
 //  -*- C++ -*-.
 #ifndef G4DETECTORS_PHG4BARRELECALDISPLAYACTION_H
 #define G4DETECTORS_PHG4BARRELECALDISPLAYACTION_H

--- a/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalSteppingAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalSteppingAction.cc
@@ -77,7 +77,7 @@ bool PHG4BarrelEcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     return false;
   }
 
-   unsigned int icopy = touch->GetVolume(0)->GetCopyNo();
+  unsigned int icopy = touch->GetVolume(0)->GetCopyNo();
   int idx_k = icopy >> 16;
   int idx_j = icopy & 0xFFFF;
 
@@ -108,12 +108,11 @@ bool PHG4BarrelEcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     {
       geantino = true;
     }
-   
+
     /* Get Geant4 pre- and post-step points */
     G4StepPoint* prePoint = aStep->GetPreStepPoint();
     G4StepPoint* postPoint = aStep->GetPostStepPoint();
 
-   
     switch (prePoint->GetStepStatus())
     {
     case fGeomBoundary:
@@ -146,91 +145,91 @@ bool PHG4BarrelEcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
         /* Set hit location (tower index) */
         m_Hit->set_index_j(idx_j);
         m_Hit->set_index_k(idx_k);
-    }
-    else
-    {
-      m_SaveHitContainer = m_AbsorberHitContainer;
-    }
-
-    // here we set what is common for scintillator and absorber hits
-    if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
-    {
-      if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+      }
+      else
       {
-        m_Hit->set_trkid(pp->GetUserTrackId());
-        m_Hit->set_shower_id(pp->GetShower()->get_id());
-        m_SaveShower = pp->GetShower();
-       }
-    }
-    break;
+        m_SaveHitContainer = m_AbsorberHitContainer;
+      }
+
+      // here we set what is common for scintillator and absorber hits
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          m_Hit->set_trkid(pp->GetUserTrackId());
+          m_Hit->set_shower_id(pp->GetShower()->get_id());
+          m_SaveShower = pp->GetShower();
+        }
+      }
+      break;
     default:
-    break;
-  }
+      break;
+    }
 
-  /* Update exit values- will be overwritten with every step until
+    /* Update exit values- will be overwritten with every step until
    * we leave the volume or the particle ceases to exist */
-  m_Hit->set_x(1, postPoint->GetPosition().x() / cm);
-  m_Hit->set_y(1, postPoint->GetPosition().y() / cm);
-  m_Hit->set_z(1, postPoint->GetPosition().z() / cm);
+    m_Hit->set_x(1, postPoint->GetPosition().x() / cm);
+    m_Hit->set_y(1, postPoint->GetPosition().y() / cm);
+    m_Hit->set_z(1, postPoint->GetPosition().z() / cm);
 
-  m_Hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
+    m_Hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
 
-  /* sum up the energy to get total deposited */
-  m_Hit->set_edep(m_Hit->get_edep() + edep);
-  if (whichactive > 0)
-  {
-     m_Hit->set_eion(m_Hit->get_eion() + eion);
-    m_Hit->set_light_yield(m_Hit->get_light_yield() + eion);
-  }
-
-  if (geantino)
-  {
-    m_Hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+    /* sum up the energy to get total deposited */
+    m_Hit->set_edep(m_Hit->get_edep() + edep);
     if (whichactive > 0)
     {
-      m_Hit->set_eion(-1);
-      m_Hit->set_light_yield(-1);
+      m_Hit->set_eion(m_Hit->get_eion() + eion);
+      m_Hit->set_light_yield(m_Hit->get_light_yield() + eion);
     }
-  }
-  if (edep > 0)
-   {
-    if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+
+    if (geantino)
     {
-      if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+      m_Hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+      if (whichactive > 0)
       {
-        pp->SetKeep(1);  // we want to keep the track
+        m_Hit->set_eion(-1);
+        m_Hit->set_light_yield(-1);
       }
     }
-  }
-   // if any of these conditions is true this is the last step in
+    if (edep > 0)
+    {
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          pp->SetKeep(1);  // we want to keep the track
+        }
+      }
+    }
+    // if any of these conditions is true this is the last step in
     // this volume and we need to save the hit
     // postPoint->GetStepStatus() == fGeomBoundary: track leaves this volume
     // postPoint->GetStepStatus() == fWorldBoundary: track leaves this world
     // (not sure if this will ever be the case)
     // aTrack->GetTrackStatus() == fStopAndKill: track ends
-  if (postPoint->GetStepStatus() == fGeomBoundary ||
-      postPoint->GetStepStatus() == fWorldBoundary ||
-      postPoint->GetStepStatus() == fAtRestDoItProc ||
-      aTrack->GetTrackStatus() == fStopAndKill)
-  {
-    // save only hits with energy deposit (or -1 for geantino)
-    if (m_Hit->get_edep())
+    if (postPoint->GetStepStatus() == fGeomBoundary ||
+        postPoint->GetStepStatus() == fWorldBoundary ||
+        postPoint->GetStepStatus() == fAtRestDoItProc ||
+        aTrack->GetTrackStatus() == fStopAndKill)
     {
-      m_SaveHitContainer->AddHit(layer_id, m_Hit);
-      if (m_SaveShower)
+      // save only hits with energy deposit (or -1 for geantino)
+      if (m_Hit->get_edep())
       {
-        m_SaveShower->add_g4hit_id(m_HitContainer->GetID(), m_Hit->get_hit_id());
+        m_SaveHitContainer->AddHit(layer_id, m_Hit);
+        if (m_SaveShower)
+        {
+          m_SaveShower->add_g4hit_id(m_HitContainer->GetID(), m_Hit->get_hit_id());
+        }
+        // ownership has been transferred to container, set to null
+        // so we will create a new hit for the next track
+        m_Hit = nullptr;
       }
-      // ownership has been transferred to container, set to null
-      // so we will create a new hit for the next track
-      m_Hit = nullptr;
-    }
-     else
-    {
-      // if this hit has no energy deposit, just reset it for reuse
-      // this means we have to delete it in the dtor. If this was
-      // the last hit we processed the memory is still allocated
-      m_Hit->Reset();
+      else
+      {
+        // if this hit has no energy deposit, just reset it for reuse
+        // this means we have to delete it in the dtor. If this was
+        // the last hit we processed the memory is still allocated
+        m_Hit->Reset();
       }
     }
     return true;
@@ -240,7 +239,6 @@ bool PHG4BarrelEcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     return false;
   }
 }
-
 
 //____________________________________________________________________________..
 void PHG4BarrelEcalSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)

--- a/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalSteppingAction.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalSteppingAction.h
@@ -16,11 +16,12 @@ class PHParameters;
 
 class PHG4BarrelEcalSteppingAction : public PHG4SteppingAction
 {
+ using PHG4SteppingAction::SetHitNodeName;
  public:
   //! constructor
   PHG4BarrelEcalSteppingAction(PHG4BarrelEcalDetector*, const PHParameters* parameters);
 
-  //! destructor 
+  //! destructor
   virtual ~PHG4BarrelEcalSteppingAction();
 
   //! stepping action
@@ -56,4 +57,4 @@ class PHG4BarrelEcalSteppingAction : public PHG4SteppingAction
   std::string m_SupportNodeName;
 };
 
-#endif  
+#endif

--- a/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalSubsystem.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalSubsystem.cc
@@ -1,6 +1,5 @@
 #include "PHG4BarrelEcalSubsystem.h"
 #include "PHG4BarrelEcalDetector.h"
-#include "PHG4BarrelEcalDetector.h"
 #include "PHG4BarrelEcalDisplayAction.h"
 #include "PHG4BarrelEcalSteppingAction.h"
 
@@ -25,7 +24,7 @@
 #include <sstream>
 
 class PHG4Detector;
- 
+
 //_______________________________________________________________________
 PHG4BarrelEcalSubsystem::PHG4BarrelEcalSubsystem(const std::string& name, const int lyr)
   : PHG4DetectorSubsystem(name, lyr)
@@ -52,7 +51,7 @@ int PHG4BarrelEcalSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
   m_Detector->SuperDetector(SuperDetector());
   m_Detector->OverlapCheck(CheckOverlap());
   m_Detector->Verbosity(Verbosity());
-  
+
   std::set<std::string> nodes;
 
   if (GetParams()->get_int_param("active"))
@@ -142,16 +141,16 @@ void PHG4BarrelEcalSubsystem::SetDefaultParameters()
   set_default_double_param("max_radius", 138.);
   set_default_double_param("CenterZ_Shift", -41.);
   set_default_double_param("tower_length", 45.5);
-  set_default_double_param("cone1_h",30.);
-  set_default_double_param("cone1_dz",24.);
-  set_default_double_param("cone2_h",20.5);
-  set_default_double_param("cone2_dz",25.5);
-  set_default_double_param("thickness_wall",0.1);
-  set_default_double_param("silicon_width_half",0.05);
-  set_default_double_param("kapton_width_half",0.05);
-  set_default_double_param("SIO2_width_half",0.05);
-  set_default_double_param("Carbon_width_half",1.);
-  set_default_double_param("support_length",1.5);
+  set_default_double_param("cone1_h", 30.);
+  set_default_double_param("cone1_dz", 24.);
+  set_default_double_param("cone2_h", 20.5);
+  set_default_double_param("cone2_dz", 25.5);
+  set_default_double_param("thickness_wall", 0.1);
+  set_default_double_param("silicon_width_half", 0.05);
+  set_default_double_param("kapton_width_half", 0.05);
+  set_default_double_param("SIO2_width_half", 0.05);
+  set_default_double_param("Carbon_width_half", 1.);
+  set_default_double_param("support_length", 1.5);
 
   return;
 }
@@ -159,7 +158,6 @@ void PHG4BarrelEcalSubsystem::SetDefaultParameters()
 void PHG4BarrelEcalSubsystem::SetTowerMappingFile(const std::string& filename)
 {
   set_string_param("mapping_file", filename);
-  
 }
 
 void PHG4BarrelEcalSubsystem::Print(const std::string& what) const

--- a/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalSubsystem.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4BarrelEcalSubsystem.h
@@ -48,7 +48,7 @@ class PHG4BarrelEcalSubsystem : public PHG4DetectorSubsystem
    */
   void SetTowerMappingFile(const std::string &filename);
 
-  void SetUseFeTungstenAbsorber(int useTungsten) {set_int_param("absorber_FeTungsten", 1); };
+  void SetUseFeTungstenAbsorber(int useTungsten) { set_int_param("absorber_FeTungsten", 1); };
 
  private:
   void SetDefaultParameters() override;

--- a/simulation/g4simulation/g4eiccalos/PHG4CrystalCalorimeterDefs.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4CrystalCalorimeterDefs.h
@@ -3,11 +3,11 @@
 
 namespace PHG4CrystalCalorimeterDefs
 {
-  enum CaloType
-  {
-    nonprojective = 1,
-    projective = 2
-  };
+enum CaloType
+{
+  nonprojective = 1,
+  projective = 2
+};
 }
 
 #endif

--- a/simulation/g4simulation/g4eiccalos/PHG4CrystalCalorimeterSteppingAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4CrystalCalorimeterSteppingAction.cc
@@ -22,12 +22,12 @@
 #include <Geant4/G4StepStatus.hh>  // for fGeomBoundary, fAtRest...
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
+#include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
 #include <Geant4/G4Track.hh>                  // for G4Track
 #include <Geant4/G4TrackStatus.hh>            // for fStopAndKill
 #include <Geant4/G4Types.hh>                  // for G4double
 #include <Geant4/G4VPhysicalVolume.hh>        // for G4VPhysicalVolume
 #include <Geant4/G4VTouchable.hh>             // for G4VTouchable
-#include <Geant4/G4TouchableHandle.hh>                // for G4TouchableHandle
 #include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
 #include <TSystem.h>

--- a/simulation/g4simulation/g4eiccalos/PHG4EICForwardEcalDetector.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4EICForwardEcalDetector.cc
@@ -19,7 +19,7 @@
 
 #include <TSystem.h>
 
-#include <cmath>                          // for M_PI
+#include <cmath>  // for M_PI
 #include <fstream>
 #include <iostream>
 #include <sstream>

--- a/simulation/g4simulation/g4eiccalos/PHG4FCalDetector.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4FCalDetector.cc
@@ -2,7 +2,7 @@
 
 #include "PHG4FCalSteppingAction.h"
 
-#include <g4main/PHG4Detector.h>         // for PHG4Detector
+#include <g4main/PHG4Detector.h>  // for PHG4Detector
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4Colour.hh>
@@ -11,7 +11,7 @@
 #include <Geant4/G4NistManager.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4Region.hh>  // for G4Region
-#include <Geant4/G4String.hh>            // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
 #include <Geant4/G4Types.hh>

--- a/simulation/g4simulation/g4eiccalos/PHG4FCalDetector.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4FCalDetector.h
@@ -10,7 +10,7 @@
 #include <Geant4/G4Types.hh>
 
 #include <map>
-#include <string>                 // for string
+#include <string>  // for string
 
 class G4Material;
 class G4Box;

--- a/simulation/g4simulation/g4eiccalos/PHG4FCalSteppingAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4FCalSteppingAction.cc
@@ -2,15 +2,15 @@
 
 #include "PHG4FCalDetector.h"
 
-#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Shower.h>
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>
 
 #include <Geant4/G4Step.hh>
-#include <Geant4/G4StepPoint.hh>              // for G4StepPoint
+#include <Geant4/G4StepPoint.hh>  // for G4StepPoint
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
 #include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
@@ -19,55 +19,60 @@
 #include <Geant4/G4VTouchable.hh>             // for G4VTouchable
 #include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
-#include <iostream>                           // for operator<<, endl, basic...
-#include <map>                                // for _Rb_tree_iterator
-#include <utility>                            // for pair
+#include <iostream>  // for operator<<, endl, basic...
+#include <map>       // for _Rb_tree_iterator
+#include <utility>   // for pair
 
 class G4VPhysicalVolume;
 
 using namespace std;
 
-
-PHG4FCalSteppingAction::PHG4FCalSteppingAction( PHG4FCalDetector* detector ) :
-    detector_( detector ), hits_(nullptr), hit(nullptr)
+PHG4FCalSteppingAction::PHG4FCalSteppingAction(PHG4FCalDetector* detector)
+  : detector_(detector)
+  , hits_(nullptr)
+  , hit(nullptr)
 {
-  
 }
 
-
-void PHG4FCalSteppingAction::UserSteppingAction( const G4Step* aStep)
+void PHG4FCalSteppingAction::UserSteppingAction(const G4Step* aStep)
 {
   G4VPhysicalVolume* volume = aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume();
-  
+
   int layer_id = 0;
-  
-  if((detector_->isInScintillator(volume)) == false){return;}
-  
-  if((aStep->GetTotalEnergyDeposit()/GeV) == 0.){return;}
-  
+
+  if ((detector_->isInScintillator(volume)) == false)
+  {
+    return;
+  }
+
+  if ((aStep->GetTotalEnergyDeposit() / GeV) == 0.)
+  {
+    return;
+  }
+
   layer_id = detector_->getScintillatorLayer(volume);
   G4StepPoint* prePoint = aStep->GetPreStepPoint();
-//   G4StepPoint* postPoint = aStep->GetPostStepPoint();
+  //   G4StepPoint* postPoint = aStep->GetPostStepPoint();
   G4Track* aTrack = aStep->GetTrack();
-  
+
   G4double x_center, y_center, z_center;
-  
+
   unsigned int hit_index = detector_->computeIndex(layer_id, prePoint->GetPosition().x(), prePoint->GetPosition().y(), prePoint->GetPosition().z(), x_center, y_center, z_center);
 
   PHG4HitContainer::Iterator it = hits_->findOrAddHit(hit_index);
-  
+
   PHG4Hit* mhit = it->second;
   mhit->set_x(0, x_center);
   mhit->set_y(0, y_center);
   mhit->set_z(0, z_center);
-  mhit->set_edep((aStep->GetTotalEnergyDeposit()/GeV) + it->second->get_edep());
-  
+  mhit->set_edep((aStep->GetTotalEnergyDeposit() / GeV) + it->second->get_edep());
+
   // Also store the flag that we want to keep this track on output
   //
-  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+  if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
   {
     // Do nothing; was assume this flag has already been set
-    if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
+    if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
     {
       pp->SetWanted(true);
     }
@@ -86,40 +91,35 @@ void PHG4FCalSteppingAction::UserSteppingAction( const G4Step* aStep)
   //set the track ID
   {
     hit->set_trkid(aTrack->GetTrackID());
-    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+    if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+    {
+      if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
       {
-	if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-	  {
-	    mhit->set_trkid(pp->GetUserTrackId());
-	    mhit->set_shower_id(pp->GetShower()->get_id());
-	  }
+        mhit->set_trkid(pp->GetUserTrackId());
+        mhit->set_shower_id(pp->GetShower()->get_id());
       }
+    }
   }
 
   {
-    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
+    if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+    {
+      if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
       {
-	if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-	  {
-	    pp->GetShower()->add_g4hit_id(hits_->GetID(),mhit->get_hit_id());
-	  }
+        pp->GetShower()->add_g4hit_id(hits_->GetID(), mhit->get_hit_id());
       }
+    }
   }
-  
 }
 
-
-void PHG4FCalSteppingAction::SetInterfacePointers( PHCompositeNode* topNode )
+void PHG4FCalSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
 {
-  
   //now look for the map and grab a pointer to it.
-  hits_ =  findNode::getClass<PHG4HitContainer>( topNode , "G4HIT_FCAL" );
-  
+  hits_ = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_FCAL");
+
   // if we do not find the node we need to make it.
-  if ( ! hits_ )
-  { std::cout << "PHG4FCalSteppingAction::SetTopNode - unable to find G4HIT_FCAL" << std::endl; }
-  
+  if (!hits_)
+  {
+    std::cout << "PHG4FCalSteppingAction::SetTopNode - unable to find G4HIT_FCAL" << std::endl;
+  }
 }
-
-
-

--- a/simulation/g4simulation/g4eiccalos/PHG4FCalSteppingAction.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4FCalSteppingAction.h
@@ -13,21 +13,18 @@ class PHG4HitContainer;
 
 class PHG4FCalSteppingAction : public G4UserSteppingAction
 {
-  public:
-    PHG4FCalSteppingAction( PHG4FCalDetector* );
-    virtual ~PHG4FCalSteppingAction(){}
-    
-    virtual void UserSteppingAction(const G4Step*);
-    
-    virtual void SetInterfacePointers( PHCompositeNode* );
-    
-  private:
-    PHG4FCalDetector* detector_;
-    PHG4HitContainer* hits_;
-    PHG4Hit* hit;
+ public:
+  PHG4FCalSteppingAction(PHG4FCalDetector*);
+  virtual ~PHG4FCalSteppingAction() {}
+
+  virtual void UserSteppingAction(const G4Step*);
+
+  virtual void SetInterfacePointers(PHCompositeNode*);
+
+ private:
+  PHG4FCalDetector* detector_;
+  PHG4HitContainer* hits_;
+  PHG4Hit* hit;
 };
 
-
-
 #endif
-

--- a/simulation/g4simulation/g4eiccalos/PHG4FCalSubsystem.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4FCalSubsystem.cc
@@ -4,7 +4,7 @@
 #include "PHG4FCalSteppingAction.h"
 
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4Subsystem.h>          // for PHG4Subsystem
+#include <g4main/PHG4Subsystem.h>  // for PHG4Subsystem
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>    // for PHIODataNode

--- a/simulation/g4simulation/g4eiccalos/PHG4FCalSubsystem.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4FCalSubsystem.h
@@ -9,43 +9,39 @@ class PHCompositeNode;
 class PHG4Detector;
 class PHG4FCalDetector;
 
-class PHG4FCalSubsystem: public PHG4Subsystem
+class PHG4FCalSubsystem : public PHG4Subsystem
 {
-  
-  public:
-    
-    //! constructor
-    PHG4FCalSubsystem( const char* name = "FCAL" );
-    
-    //! destructor
-    virtual ~PHG4FCalSubsystem( void )
-    {}
-    
-    //! init
-    /*!
+ public:
+  //! constructor
+  PHG4FCalSubsystem(const char* name = "FCAL");
+
+  //! destructor
+  virtual ~PHG4FCalSubsystem(void)
+  {
+  }
+
+  //! init
+  /*!
     creates the detector_ object and place it on the node tree, under "DETECTORS" node (or whatever)
     reates the stepping action and place it on the node tree, under "ACTIONS" node
     creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
     */
-    int Init(PHCompositeNode *);
-    
-    //! event processing
-    /*!
+  int Init(PHCompositeNode*);
+
+  //! event processing
+  /*!
     get all relevant nodes from top nodes (namely hit list)
     and pass that to the stepping action
     */
-    int process_event(PHCompositeNode *);
-    
-    //! accessors (reimplemented)
-    virtual PHG4Detector* GetDetector( void ) const;
-    
-  private:
-    
-    //! detector geometry
-    /*! defives from PHG4Detector */
-    PHG4FCalDetector* detector_;
-    
-    
+  int process_event(PHCompositeNode*);
+
+  //! accessors (reimplemented)
+  virtual PHG4Detector* GetDetector(void) const;
+
+ private:
+  //! detector geometry
+  /*! defives from PHG4Detector */
+  PHG4FCalDetector* detector_;
 };
 
 #endif

--- a/simulation/g4simulation/g4eiccalos/PHG4FPbScDetector.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4FPbScDetector.cc
@@ -7,7 +7,7 @@
 #include <Geant4/G4NistManager.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4Region.hh>         // for G4Region
-#include <Geant4/G4String.hh>            // for G4String
+#include <Geant4/G4String.hh>         // for G4String
 #include <Geant4/G4SystemOfUnits.hh>  // for cm
 #include <Geant4/G4ThreeVector.hh>    // for G4ThreeVector
 #include <Geant4/G4Types.hh>

--- a/simulation/g4simulation/g4eiccalos/PHG4FPbScRegionSteppingAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4FPbScRegionSteppingAction.cc
@@ -2,8 +2,8 @@
 
 #include "PHG4FPbScDetector.h"
 
-#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
 #include <g4main/PHG4TrackUserInfoV1.h>
@@ -22,20 +22,22 @@
 #include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
 #include <iostream>
-#include <string>                             // for operator+, operator<<
+#include <string>  // for operator+, operator<<
 
 class G4VPhysicalVolume;
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4FPbScRegionSteppingAction::PHG4FPbScRegionSteppingAction( PHG4FPbScDetector* detector ):
-  detector_( detector ), hits_(nullptr), hit(nullptr)
-{}
+PHG4FPbScRegionSteppingAction::PHG4FPbScRegionSteppingAction(PHG4FPbScDetector* detector)
+  : detector_(detector)
+  , hits_(nullptr)
+  , hit(nullptr)
+{
+}
 
 //____________________________________________________________________________..
-void PHG4FPbScRegionSteppingAction::UserSteppingAction( const G4Step* aStep)
+void PHG4FPbScRegionSteppingAction::UserSteppingAction(const G4Step* aStep)
 {
-
   // get volume of the current step
   G4VPhysicalVolume* volume = aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume();
 
@@ -46,91 +48,89 @@ void PHG4FPbScRegionSteppingAction::UserSteppingAction( const G4Step* aStep)
   const G4Track* aTrack = aStep->GetTrack();
 
   // make sure we are in a volume
-  if ( detector_->isInScintillator(volume) )
+  if (detector_->isInScintillator(volume))
+  {
+    int layer_id = 0;
+    G4StepPoint* prePoint = aStep->GetPreStepPoint();
+    G4StepPoint* postPoint = aStep->GetPostStepPoint();
+    cout << "track id " << aTrack->GetTrackID() << endl;
+    cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
+    cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
+    switch (prePoint->GetStepStatus())
     {
-      int layer_id = 0;
-      G4StepPoint * prePoint = aStep->GetPreStepPoint();
-      G4StepPoint * postPoint = aStep->GetPostStepPoint();
-       cout << "track id " << aTrack->GetTrackID() << endl;
-       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
-       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
-      switch (prePoint->GetStepStatus())
+    case fGeomBoundary:
+    case fUndefined:
+      hit = new PHG4Hitv1();
+      //here we set the entrance values in cm
+      hit->set_x(0, prePoint->GetPosition().x() / cm);
+      hit->set_y(0, prePoint->GetPosition().y() / cm);
+      hit->set_z(0, prePoint->GetPosition().z() / cm);
+      // time in ns
+      hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
+      //set the track ID
+      {
+        hit->set_trkid(aTrack->GetTrackID());
+        if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
         {
-        case fGeomBoundary:
-        case fUndefined:
-          hit = new PHG4Hitv1();
-          //here we set the entrance values in cm
-          hit->set_x( 0, prePoint->GetPosition().x() / cm);
-          hit->set_y( 0, prePoint->GetPosition().y() / cm );
-          hit->set_z( 0, prePoint->GetPosition().z() / cm );
-	  // time in ns
-          hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
-  	  //set the track ID
-	  {
-	    hit->set_trkid(aTrack->GetTrackID());
-	    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	      {
-		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		  {
-		    hit->set_trkid(pp->GetUserTrackId());
-		    hit->set_shower_id(pp->GetShower()->get_id());
-		  }
-	      }
-	  }
-
-          //set the initial energy deposit
-          hit->set_edep(0);
-
-          // Now add the hit
-          hits_->AddHit(layer_id, hit);
-
-	  {
-	    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	      {
-		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		  {
-		    pp->GetShower()->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
-		  }
-	      }
-	  }
-	  
-          break;
-        default:
-          break;
+          if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+          {
+            hit->set_trkid(pp->GetUserTrackId());
+            hit->set_shower_id(pp->GetShower()->get_id());
+          }
         }
-      // here we just update the exit values, it will be overwritten
-      // for every step until we leave the volume or the particle
-      // ceases to exist
-      hit->set_x( 1, postPoint->GetPosition().x() / cm );
-      hit->set_y( 1, postPoint->GetPosition().y() / cm );
-      hit->set_z( 1, postPoint->GetPosition().z() / cm );
+      }
 
-      hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
-      //sum up the energy to get total deposited
-      hit->set_edep(hit->get_edep() + edep);
+      //set the initial energy deposit
+      hit->set_edep(0);
 
-      //    hit->identify();
-      // return true to indicate the hit was used
-      return;
+      // Now add the hit
+      hits_->AddHit(layer_id, hit);
 
+      {
+        if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+        {
+          if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+          {
+            pp->GetShower()->add_g4hit_id(hits_->GetID(), hit->get_hit_id());
+          }
+        }
+      }
+
+      break;
+    default:
+      break;
     }
+    // here we just update the exit values, it will be overwritten
+    // for every step until we leave the volume or the particle
+    // ceases to exist
+    hit->set_x(1, postPoint->GetPosition().x() / cm);
+    hit->set_y(1, postPoint->GetPosition().y() / cm);
+    hit->set_z(1, postPoint->GetPosition().z() / cm);
+
+    hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
+    //sum up the energy to get total deposited
+    hit->set_edep(hit->get_edep() + edep);
+
+    //    hit->identify();
+    // return true to indicate the hit was used
+    return;
+  }
   else
-    {
-      return;
-    }
+  {
+    return;
+  }
 }
 
 //____________________________________________________________________________..
-void PHG4FPbScRegionSteppingAction::SetInterfacePointers( PHCompositeNode* topNode )
+void PHG4FPbScRegionSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
 {
-
   string hitnodename = "G4HIT_" + detector_->GetName();
   //now look for the map and grab a pointer to it.
-  hits_ =  findNode::getClass<PHG4HitContainer>( topNode , hitnodename.c_str() );
+  hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
 
   // if we do not find the node we need to make it.
-  if ( ! hits_ )
-    { std::cout << "PHG4FPbScRegionSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
- }
-
+  if (!hits_)
+  {
+    std::cout << "PHG4FPbScRegionSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
+  }
 }

--- a/simulation/g4simulation/g4eiccalos/PHG4FPbScRegionSteppingAction.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4FPbScRegionSteppingAction.h
@@ -5,7 +5,6 @@
 
 #include <Geant4/G4UserSteppingAction.hh>
 
-
 class G4Step;
 class PHCompositeNode;
 class PHG4FPbScDetector;
@@ -14,31 +13,28 @@ class PHG4HitContainer;
 
 class PHG4FPbScRegionSteppingAction : public G4UserSteppingAction
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4FPbScRegionSteppingAction( PHG4FPbScDetector* );
+  PHG4FPbScRegionSteppingAction(PHG4FPbScDetector*);
 
   //! destroctor
   virtual ~PHG4FPbScRegionSteppingAction()
-  {}
+  {
+  }
 
   //! stepping action
   virtual void UserSteppingAction(const G4Step*);
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers( PHCompositeNode* );
+  virtual void SetInterfacePointers(PHCompositeNode*);
 
-  private:
-
+ private:
   //! pointer to the detector
   PHG4FPbScDetector* detector_;
 
   //! pointer to hit container
-  PHG4HitContainer * hits_;
-  PHG4Hit *hit;
+  PHG4HitContainer* hits_;
+  PHG4Hit* hit;
 };
 
-
-#endif //__G4PHPHYTHIAREADER_H__
+#endif  //__G4PHPHYTHIAREADER_H__

--- a/simulation/g4simulation/g4eiccalos/PHG4FPbScSteppingAction.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4FPbScSteppingAction.h
@@ -12,20 +12,17 @@ class PHG4HitContainer;
 
 class PHG4FPbScSteppingAction : public PHG4SteppingAction
 {
-  public:
-    PHG4FPbScSteppingAction( PHG4FPbScDetector* );
-    virtual ~PHG4FPbScSteppingAction(){}
-    
-    virtual bool UserSteppingAction(const G4Step*, bool);
-    
-    virtual void SetInterfacePointers( PHCompositeNode* );
-    
-  private:
-    PHG4FPbScDetector* detector_;
-    PHG4HitContainer* hits_;
+ public:
+  PHG4FPbScSteppingAction(PHG4FPbScDetector*);
+  virtual ~PHG4FPbScSteppingAction() {}
+
+  virtual bool UserSteppingAction(const G4Step*, bool);
+
+  virtual void SetInterfacePointers(PHCompositeNode*);
+
+ private:
+  PHG4FPbScDetector* detector_;
+  PHG4HitContainer* hits_;
 };
 
-
-
 #endif
-

--- a/simulation/g4simulation/g4eiccalos/PHG4FPbScSubsystem.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4FPbScSubsystem.h
@@ -5,7 +5,7 @@
 
 #include <g4main/PHG4Subsystem.h>
 
-#include <string>                  // for string
+#include <string>  // for string
 
 class PHCompositeNode;
 class PHG4Detector;
@@ -13,61 +13,58 @@ class PHG4FPbScDetector;
 class PHG4EventAction;
 class PHG4SteppingAction;
 
-class PHG4FPbScSubsystem: public PHG4Subsystem
+class PHG4FPbScSubsystem : public PHG4Subsystem
 {
-  
-  public:
-    
-    //! constructor
-  PHG4FPbScSubsystem( const std::string &name = "FPBSC" );
-    
-    //! destructor
-    virtual ~PHG4FPbScSubsystem( void )
-    {}
-    
-    //! init
-    /*!
+ public:
+  //! constructor
+  PHG4FPbScSubsystem(const std::string& name = "FPBSC");
+
+  //! destructor
+  virtual ~PHG4FPbScSubsystem(void)
+  {
+  }
+
+  //! init
+  /*!
     creates the detector_ object and place it on the node tree, under "DETECTORS" node (or whatever)
     reates the stepping action and place it on the node tree, under "ACTIONS" node
     creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
     */
-    int Init(PHCompositeNode *);
-    
-    //! event processing
-    /*!
+  int Init(PHCompositeNode*);
+
+  //! event processing
+  /*!
     get all relevant nodes from top nodes (namely hit list)
     and pass that to the stepping action
     */
-    int process_event(PHCompositeNode *);
-    
-    //! accessors (reimplemented)
-    virtual PHG4Detector* GetDetector( void ) const;
-    virtual PHG4SteppingAction* GetSteppingAction( void ) const;
+  int process_event(PHCompositeNode*);
 
-    PHG4EventAction* GetEventAction() const {return eventAction_;}
+  //! accessors (reimplemented)
+  virtual PHG4Detector* GetDetector(void) const;
+  virtual PHG4SteppingAction* GetSteppingAction(void) const;
 
-    void set_Place(double x, double y, double z)
-    {
-      x_position = x;
-      y_position = y;
-      z_position = z;
-    }
-   
-  private:
-    
-    //! detector geometry
-    /*! defives from PHG4Detector */
-    PHG4FPbScDetector* detector_;
+  PHG4EventAction* GetEventAction() const { return eventAction_; }
+
+  void set_Place(double x, double y, double z)
+  {
+    x_position = x;
+    y_position = y;
+    z_position = z;
+  }
+
+ private:
+  //! detector geometry
+  /*! defives from PHG4Detector */
+  PHG4FPbScDetector* detector_;
 
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingActions */
-    PHG4SteppingAction* steppingAction_;
-    PHG4EventAction *eventAction_;
-    
-    double x_position;
-    double y_position;
-    double z_position;
-    
+  PHG4SteppingAction* steppingAction_;
+  PHG4EventAction* eventAction_;
+
+  double x_position;
+  double y_position;
+  double z_position;
 };
 
 #endif

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardCalCellReco.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardCalCellReco.cc
@@ -1,39 +1,41 @@
 #include "PHG4ForwardCalCellReco.h"
 
-#include <g4detectors/PHG4CylinderCell.h>            // for PHG4CylinderCell
-#include <g4detectors/PHG4CylinderCellv3.h>
+#include <g4detectors/PHG4CylinderCell.h>  // for PHG4CylinderCell
 #include <g4detectors/PHG4CylinderCellContainer.h>
+#include <g4detectors/PHG4CylinderCellv3.h>
 
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>          // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHNode.h>                // for PHNode
+#include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
-#include <phool/PHObject.h>              // for PHObject
+#include <phool/PHObject.h>  // for PHObject
 #include <phool/getClass.h>
-#include <phool/phool.h>                 // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
 #include <cmath>
 #include <cstdlib>
-#include <cstring>                      // for memset
+#include <cstring>  // for memset
 #include <iostream>
 #include <sstream>
 
 using namespace std;
 
-PHG4ForwardCalCellReco::PHG4ForwardCalCellReco(const string &name) :
-  SubsysReco(name),
-  chkenergyconservation(0),
-  tmin_default(0.0),  // ns
-  tmax_default(60.0), // ns
+PHG4ForwardCalCellReco::PHG4ForwardCalCellReco(const string &name)
+  : SubsysReco(name)
+  , chkenergyconservation(0)
+  , tmin_default(0.0)
+  ,  // ns
+  tmax_default(60.0)
+  ,  // ns
   tmin_max()
 {
-  memset(nbins, 0, sizeof(nbins));  
+  memset(nbins, 0, sizeof(nbins));
 }
 
 int PHG4ForwardCalCellReco::InitRun(PHCompositeNode *topNode)
@@ -42,120 +44,111 @@ int PHG4ForwardCalCellReco::InitRun(PHCompositeNode *topNode)
 
   // Looking for the DST node
   PHCompositeNode *dstNode;
-  dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
   if (!dstNode)
-    {
-      std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
-      exit(1);
-    }
+  {
+    std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
+    exit(1);
+  }
   hitnodename = "G4HIT_" + detector;
   PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
   if (!g4hit)
-    {
-      cout << "Could not locate g4 hit node " << hitnodename << endl;
-      exit(1);
-    }
+  {
+    cout << "Could not locate g4 hit node " << hitnodename << endl;
+    exit(1);
+  }
   cellnodename = "G4CELL_" + detector;
-  PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode , cellnodename);
+  PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode, cellnodename);
   if (!cells)
+  {
+    PHNodeIterator dstiter(dstNode);
+    PHCompositeNode *DetNode =
+        dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode",
+                                                          detector));
+    if (!DetNode)
     {
-      PHNodeIterator dstiter(dstNode);
-      PHCompositeNode *DetNode =
-          dynamic_cast<PHCompositeNode*>(dstiter.findFirst("PHCompositeNode",
-              detector));
-      if (!DetNode)
-        {
-          DetNode = new PHCompositeNode(detector);
-          dstNode->addNode(DetNode);
-        }
-      cells = new PHG4CylinderCellContainer();
-      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(cells, cellnodename.c_str() , "PHObject");
-      DetNode->addNode(newNode);
+      DetNode = new PHCompositeNode(detector);
+      dstNode->addNode(DetNode);
     }
-  
+    cells = new PHG4CylinderCellContainer();
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(cells, cellnodename.c_str(), "PHObject");
+    DetNode->addNode(newNode);
+  }
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-
-int
-PHG4ForwardCalCellReco::process_event(PHCompositeNode *topNode)
+int PHG4ForwardCalCellReco::process_event(PHCompositeNode *topNode)
 {
   PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
   if (!g4hit)
-    {
-      cout << "Could not locate g4 hit node " << hitnodename << endl;
-      exit(1);
-    }
+  {
+    cout << "Could not locate g4 hit node " << hitnodename << endl;
+    exit(1);
+  }
   PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode, cellnodename);
-  if (! cells)
-    {
-      cout << "could not locate cell node " << cellnodename << endl;
-      exit(1);
-    }
+  if (!cells)
+  {
+    cout << "could not locate cell node " << cellnodename << endl;
+    exit(1);
+  }
 
   PHG4HitContainer::LayerIter layer;
   pair<PHG4HitContainer::LayerIter, PHG4HitContainer::LayerIter> layer_begin_end = g4hit->getLayers();
   for (layer = layer_begin_end.first; layer != layer_begin_end.second; ++layer)
+  {
+    PHG4HitContainer::ConstIterator hiter;
+    PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits(*layer);
+    for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
     {
-      PHG4HitContainer::ConstIterator hiter;
-      PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits(*layer);
-      for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
-	{
-	  // checking ADC timing integration window cut
-	  if (hiter->second->get_t(0)>tmax_default) continue;
-	  if (hiter->second->get_t(1)<tmin_default) continue;
+      // checking ADC timing integration window cut
+      if (hiter->second->get_t(0) > tmax_default) continue;
+      if (hiter->second->get_t(1) < tmin_default) continue;
 
-          // only hits that deposited energy (or geantinos)
-          if (hiter->second->get_edep()<=0)
-            continue;
+      // only hits that deposited energy (or geantinos)
+      if (hiter->second->get_edep() <= 0)
+        continue;
 
-	  unsigned int key = (hiter->second->get_index_j()<<16) + hiter->second->get_index_k();
-	  if (celllist.find(key) == celllist.end())
-	    {
-	      celllist[key] = new PHG4CylinderCellv3();
-	      celllist[key]->set_layer(*layer);
-	      celllist[key]->set_j_index(hiter->second->get_index_j());
-	      celllist[key]->set_k_index(hiter->second->get_index_k());
-	      celllist[key]->set_l_index(hiter->second->get_index_l());
-	    }
+      unsigned int key = (hiter->second->get_index_j() << 16) + hiter->second->get_index_k();
+      if (celllist.find(key) == celllist.end())
+      {
+        celllist[key] = new PHG4CylinderCellv3();
+        celllist[key]->set_layer(*layer);
+        celllist[key]->set_j_index(hiter->second->get_index_j());
+        celllist[key]->set_k_index(hiter->second->get_index_k());
+        celllist[key]->set_l_index(hiter->second->get_index_l());
+      }
 
-	  celllist[key]->add_edep(hiter->first, hiter->second->get_edep(), hiter->second->get_light_yield());
-	  celllist[key]->add_shower_edep(hiter->second->get_shower_id(), hiter->second->get_edep());
-
-	}
-
-      int numcells = 0;
-      for (map<unsigned int, PHG4CylinderCell *>::const_iterator mapiter = celllist.begin();mapiter != celllist.end() ; ++mapiter)
-	{
-	  cells->AddCylinderCellSpecifyKey(mapiter->first, mapiter->second);
-	  numcells++;
-	}
-      celllist.clear();
-      if (Verbosity() > 0)
-	{
-	  cout << Name() << ": found " << numcells << " eta/slat cells with energy deposition" << endl;
-	}
- 
-
+      celllist[key]->add_edep(hiter->first, hiter->second->get_edep(), hiter->second->get_light_yield());
+      celllist[key]->add_shower_edep(hiter->second->get_shower_id(), hiter->second->get_edep());
     }
+
+    int numcells = 0;
+    for (map<unsigned int, PHG4CylinderCell *>::const_iterator mapiter = celllist.begin(); mapiter != celllist.end(); ++mapiter)
+    {
+      cells->AddCylinderCellSpecifyKey(mapiter->first, mapiter->second);
+      numcells++;
+    }
+    celllist.clear();
+    if (Verbosity() > 0)
+    {
+      cout << Name() << ": found " << numcells << " eta/slat cells with energy deposition" << endl;
+    }
+  }
 
   if (chkenergyconservation)
-    {
-      CheckEnergy(topNode);
-    }
+  {
+    CheckEnergy(topNode);
+  }
   return Fun4AllReturnCodes::EVENT_OK;
-
 }
 
-int
-PHG4ForwardCalCellReco::End(PHCompositeNode *topNode)
+int PHG4ForwardCalCellReco::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-
-int
-PHG4ForwardCalCellReco::CheckEnergy(PHCompositeNode *topNode)
+int PHG4ForwardCalCellReco::CheckEnergy(PHCompositeNode *topNode)
 {
   PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
   PHG4CylinderCellContainer *cells = findNode::getClass<PHG4CylinderCellContainer>(topNode, cellnodename);
@@ -164,33 +157,30 @@ PHG4ForwardCalCellReco::CheckEnergy(PHCompositeNode *topNode)
   PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits();
   PHG4HitContainer::ConstIterator hiter;
   for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
-    {
-      sum_energy_g4hit += hiter->second->get_edep();
-    }
+  {
+    sum_energy_g4hit += hiter->second->get_edep();
+  }
   PHG4CylinderCellContainer::ConstRange cell_begin_end = cells->getCylinderCells();
   PHG4CylinderCellContainer::ConstIterator citer;
   for (citer = cell_begin_end.first; citer != cell_begin_end.second; ++citer)
-    {
-      sum_energy_cells += citer->second->get_edep();
-
-    }
+  {
+    sum_energy_cells += citer->second->get_edep();
+  }
   // the fractional eloss for particles traversing eta bins leads to minute rounding errors
   if (fabs(sum_energy_cells - sum_energy_g4hit) / sum_energy_g4hit > 1e-6)
-    {
-      cout << "energy mismatch between cells: " << sum_energy_cells
-	   << " and hits: " << sum_energy_g4hit
-	   << " diff sum(cells) - sum(hits): " << sum_energy_cells - sum_energy_g4hit
-	   << endl;
-      return -1;
-    }
+  {
+    cout << "energy mismatch between cells: " << sum_energy_cells
+         << " and hits: " << sum_energy_g4hit
+         << " diff sum(cells) - sum(hits): " << sum_energy_cells - sum_energy_g4hit
+         << endl;
+    return -1;
+  }
   else
+  {
+    if (Verbosity() > 0)
     {
-      if (Verbosity() > 0)
-	{
-	  cout << Name() << ": total energy for this event: " << sum_energy_g4hit << " GeV" << endl;
-	}
+      cout << Name() << ": total energy for this event: " << sum_energy_g4hit << " GeV" << endl;
     }
+  }
   return 0;
 }
-
-

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardCalCellReco.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardCalCellReco.h
@@ -5,9 +5,9 @@
 
 #include <fun4all/SubsysReco.h>
 
-#include <string>
 #include <map>
-#include <utility>               // for pair
+#include <string>
+#include <utility>  // for pair
 
 class PHCompositeNode;
 class PHG4CylinderCell;
@@ -15,30 +15,33 @@ class PHG4CylinderCell;
 class PHG4ForwardCalCellReco : public SubsysReco
 {
  public:
-
   PHG4ForwardCalCellReco(const std::string &name = "FWDCALCELLRECO");
 
-  virtual ~PHG4ForwardCalCellReco(){}
-  
+  virtual ~PHG4ForwardCalCellReco() {}
+
   //! module initialization
   int InitRun(PHCompositeNode *topNode);
-  
-    //! event processing
+
+  //! event processing
   int process_event(PHCompositeNode *topNode);
-  
+
   //! end of process
   int End(PHCompositeNode *topNode);
-  
-  void Detector(const std::string &d) {detector = d;}
-  void checkenergy(const int i=1) {chkenergyconservation = i;}
 
-  double get_timing_window_min(const int i) {return tmin_default;}
-  double get_timing_window_max(const int i) {return tmax_default;}
-  void   set_timing_window(const int i, const double tmin, const double tmax) {
-    tmin_default = tmin; tmax_default = tmax;
+  void Detector(const std::string &d) { detector = d; }
+  void checkenergy(const int i = 1) { chkenergyconservation = i; }
+
+  double get_timing_window_min(const int i) { return tmin_default; }
+  double get_timing_window_max(const int i) { return tmax_default; }
+  void set_timing_window(const int i, const double tmin, const double tmax)
+  {
+    tmin_default = tmin;
+    tmax_default = tmax;
   }
-  void   set_timing_window_defaults(const double tmin, const double tmax) {
-    tmin_default = tmin; tmax_default = tmax;
+  void set_timing_window_defaults(const double tmin, const double tmax)
+  {
+    tmin_default = tmin;
+    tmax_default = tmax;
   }
 
  protected:
@@ -53,7 +56,7 @@ class PHG4ForwardCalCellReco : public SubsysReco
   //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
   double tmin_default;
   double tmax_default;
-  std::map<int, std::pair<double,double> > tmin_max;
+  std::map<int, std::pair<double, double> > tmin_max;
 };
 
 #endif

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalDetector.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalDetector.cc
@@ -15,18 +15,18 @@
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4Cons.hh>
-#include <Geant4/G4SubtractionSolid.hh>
+#include <Geant4/G4LogicalSkinSurface.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
+#include <Geant4/G4MaterialPropertiesTable.hh>
+#include <Geant4/G4OpticalSurface.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4PVReplica.hh>
 #include <Geant4/G4PhysicalConstants.hh>
-#include <Geant4/G4MaterialPropertiesTable.hh>
-#include <Geant4/G4OpticalSurface.hh>
 #include <Geant4/G4Polyhedra.hh>
-#include <Geant4/G4LogicalSkinSurface.hh>
 #include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
 #include <Geant4/G4String.hh>          // for G4String
+#include <Geant4/G4SubtractionSolid.hh>
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
 #include <Geant4/G4Transform3D.hh>  // for G4Transform3D
@@ -114,20 +114,19 @@ void PHG4ForwardEcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
   recoConsts* rc = recoConsts::instance();
   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
 
-  G4double tower_readout_dz = m_Params->get_double_param("tower_readout_dz")*cm;
+  G4double tower_readout_dz = m_Params->get_double_param("tower_readout_dz") * cm;
 
-  G4VSolid *beampipe_cutout = new G4Cons("FEMC_beampipe_cutout",
+  G4VSolid* beampipe_cutout = new G4Cons("FEMC_beampipe_cutout",
                                          0, m_RMin[0],
                                          0, m_RMin[1],
                                          (m_dZ + tower_readout_dz),
                                          0, 2 * M_PI);
-  G4VSolid *ecal_envelope_solid = new G4Cons("FEMC_envelope_solid_cutout",
-                                            0, m_RMax[0],
-                                            0, m_RMax[1],
-                                            (m_dZ + tower_readout_dz) / 2.0,
-                                            0, 2 * M_PI);
+  G4VSolid* ecal_envelope_solid = new G4Cons("FEMC_envelope_solid_cutout",
+                                             0, m_RMax[0],
+                                             0, m_RMax[1],
+                                             (m_dZ + tower_readout_dz) / 2.0,
+                                             0, 2 * M_PI);
   ecal_envelope_solid = new G4SubtractionSolid(G4String("hFEMC_envelope_solid"), ecal_envelope_solid, beampipe_cutout, 0, G4ThreeVector(m_Params->get_double_param("xoffset") * cm, m_Params->get_double_param("yoffset") * cm, 0.));
-
 
   G4LogicalVolume* ecal_envelope_log = new G4LogicalVolume(ecal_envelope_solid, WorldMaterial, "hFEMC_envelope", 0, 0, 0);
 
@@ -143,7 +142,7 @@ void PHG4ForwardEcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
   /* Place envelope cone in simulation */
   std::string name_envelope = m_TowerLogicNamePrefix + "_envelope";
 
-  new G4PVPlacement(G4Transform3D(ecal_rotm, G4ThreeVector(m_PlaceX, m_PlaceY, m_PlaceZ - tower_readout_dz/2)),
+  new G4PVPlacement(G4Transform3D(ecal_rotm, G4ThreeVector(m_PlaceX, m_PlaceY, m_PlaceZ - tower_readout_dz / 2)),
                     ecal_envelope_log, name_envelope, logicWorld, 0, false, OverlapCheck());
 
   /* Construct single calorimeter towers */
@@ -182,38 +181,36 @@ PHG4ForwardEcalDetector::ConstructTower(int type)
   recoConsts* rc = recoConsts::instance();
   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
 
-
-
   /* create geometry volumes for scintillator and absorber plates to place inside single_tower */
   // PHENIX EMCal JGL 3/27/2016
-  G4int nlayers                   = 66;
-  G4double thickness_layer        = m_TowerDz[2] / (float) nlayers;
+  G4int nlayers = 66;
+  G4double thickness_layer = m_TowerDz[2] / (float) nlayers;
   // update layer thickness with https://doi.org/10.1016/S0168-9002(02)01954-X
   G4double thickness_cell = 5.6 * mm;
-  G4double thickness_absorber     = 1.55 * mm;      // 1.55mm absorber
+  G4double thickness_absorber = 1.55 * mm;     // 1.55mm absorber
   G4double thickness_scintillator = 4.0 * mm;  // 4mm scintillator
   // notched in TiO2 coating in scintillator plate
   G4double width_coating = m_Params->get_double_param("width_coating") * cm;  // 4mm scintillator
-  G4Material* material_scintillator = GetScintillatorMaterial();//G4Material::GetMaterial("G4_POLYSTYRENE");
-  G4Material* material_absorber     = G4Material::GetMaterial("G4_Pb");
+  G4Material* material_scintillator = GetScintillatorMaterial();              //G4Material::GetMaterial("G4_POLYSTYRENE");
+  G4Material* material_absorber = G4Material::GetMaterial("G4_Pb");
   G4int nFibers = m_Params->get_int_param("nFibers");
   G4double fiber_diam = m_Params->get_double_param("fiber_diam") * cm;  // 4mm scintillator
   G4double fiber_extra_length = 0.0;
   // additional fiber length at end of calorimeter
-  if(fiber_diam>0) fiber_extra_length = 0.5 * cm;
+  if (fiber_diam > 0) fiber_extra_length = 0.5 * cm;
   // width of plate in front of FEMC for clamping all layers
-  G4double clamp_plate_width = m_Params->get_double_param("clamp_plate_width")*cm;
+  G4double clamp_plate_width = m_Params->get_double_param("clamp_plate_width") * cm;
   // depth of readout (4cm)
-  G4double tower_readout_dz = m_Params->get_double_param("tower_readout_dz")*cm;
+  G4double tower_readout_dz = m_Params->get_double_param("tower_readout_dz") * cm;
 
   G4VSolid* single_tower_solid = new G4Box("single_tower_solid2",
                                            m_TowerDx[2] / 2.0,
                                            m_TowerDy[2] / 2.0,
                                            (m_TowerDz[2] + tower_readout_dz) / 2.0);
   G4VSolid* single_tower_solid_replica = new G4Box("single_tower_solid_replica",
-                                           m_TowerDx[2] / 2.0,
-                                           m_TowerDy[2] / 2.0,
-                                           m_TowerDz[2] / 2.0);
+                                                   m_TowerDx[2] / 2.0,
+                                                   m_TowerDy[2] / 2.0,
+                                                   m_TowerDz[2] / 2.0);
 
   G4LogicalVolume* single_tower_logic = new G4LogicalVolume(single_tower_solid,
                                                             WorldMaterial,
@@ -224,35 +221,34 @@ PHG4ForwardEcalDetector::ConstructTower(int type)
 
   if (Verbosity())
   {
-    std::cout <<" m_TowerDz[2] = "<< m_TowerDz[2]<< " thickness_layer = "<<thickness_layer<<" thickness_cell = "<<thickness_cell<<std::endl;
+    std::cout << " m_TowerDz[2] = " << m_TowerDz[2] << " thickness_layer = " << thickness_layer << " thickness_cell = " << thickness_cell << std::endl;
   }
 
-  if (thickness_layer<=thickness_cell)
+  if (thickness_layer <= thickness_cell)
   {
-    std::cout<<__PRETTY_FUNCTION__
-        <<"Tower size z (m_TowerDz[2) from database is too thin. "
-        <<"It does not fit the layer structure as described in https://doi.org/10.1016/S0168-9002(02)01954-X !"<<std::endl
-        <<"Abort"<<std::endl;
-    std::cout <<" m_TowerDz[2] = "<< m_TowerDz[2]<<" i.e. nlayers "<<nlayers<< " * thickness_layer "<<thickness_layer<<" <= thickness_cell "<<thickness_cell<<std::endl;
+    std::cout << __PRETTY_FUNCTION__
+              << "Tower size z (m_TowerDz[2) from database is too thin. "
+              << "It does not fit the layer structure as described in https://doi.org/10.1016/S0168-9002(02)01954-X !" << std::endl
+              << "Abort" << std::endl;
+    std::cout << " m_TowerDz[2] = " << m_TowerDz[2] << " i.e. nlayers " << nlayers << " * thickness_layer " << thickness_layer << " <= thickness_cell " << thickness_cell << std::endl;
     exit(1);
   }
-  
-  
+
   //**********************************************************************************************
   /* create logical and geometry volumes for minitower read-out unit */
   //**********************************************************************************************
-  G4VSolid* miniblock_solid         = new G4Box("miniblock_solid",
-                                                m_TowerDx[2] / 2.0,
-                                                m_TowerDy[2] / 2.0,
-                                                thickness_cell / 2.0);
-  G4LogicalVolume* miniblock_logic  = new G4LogicalVolume(miniblock_solid,
-                                                          WorldMaterial,
-                                                          "miniblock_logic",
-                                                          0, 0, 0);
+  G4VSolid* miniblock_solid = new G4Box("miniblock_solid",
+                                        m_TowerDx[2] / 2.0,
+                                        m_TowerDy[2] / 2.0,
+                                        thickness_cell / 2.0);
+  G4LogicalVolume* miniblock_logic = new G4LogicalVolume(miniblock_solid,
+                                                         WorldMaterial,
+                                                         "miniblock_logic",
+                                                         0, 0, 0);
   GetDisplayAction()->AddVolume(miniblock_logic, "miniblock");
   //**********************************************************************************************
   /* create logical & geometry volumes for scintillator and absorber plates to place inside mini read-out unit */
-  //**********************************************************************************************  
+  //**********************************************************************************************
   G4VSolid* solid_absorber = new G4Box("single_plate_absorber_solid2",
                                        m_TowerDx[2] / 2.0,
                                        m_TowerDy[2] / 2.0,
@@ -261,19 +257,20 @@ PHG4ForwardEcalDetector::ConstructTower(int type)
   G4VSolid* solid_scintillator = new G4Box("single_plate_scintillator2",
                                            (m_TowerDx[2]) / 2.0,
                                            (m_TowerDy[2]) / 2.0,
-                                          //  (m_TowerDx[2] - 2*width_coating) / 2.0,
-                                          //  (m_TowerDy[2] - 2*width_coating) / 2.0,
+                                           //  (m_TowerDx[2] - 2*width_coating) / 2.0,
+                                           //  (m_TowerDy[2] - 2*width_coating) / 2.0,
                                            thickness_scintillator / 2.0);
-  
-  if(clamp_plate_width>0){
+
+  if (clamp_plate_width > 0)
+  {
     G4VSolid* solid_clamp1 = new G4Box("single_plate_clamp_solid1",
-                                        m_TowerDx[2] / 2.0,
-                                        m_TowerDy[2] / 2.0,
-                                        clamp_plate_width / 2.0);
+                                       m_TowerDx[2] / 2.0,
+                                       m_TowerDy[2] / 2.0,
+                                       clamp_plate_width / 2.0);
     G4LogicalVolume* logic_clampplate = new G4LogicalVolume(solid_clamp1,
-                                                          G4Material::GetMaterial("G4_Fe"),
-                                                          "logic_clampplate",
-                                                          0, 0, 0);
+                                                            G4Material::GetMaterial("G4_Fe"),
+                                                            "logic_clampplate",
+                                                            0, 0, 0);
     m_AbsorberLogicalVolSet.insert(logic_clampplate);
     GetDisplayAction()->AddVolume(logic_clampplate, "Clamp");
     std::string name_clamp = m_TowerLogicNamePrefix + "_single_plate_clamp";
@@ -284,80 +281,82 @@ PHG4ForwardEcalDetector::ConstructTower(int type)
                       single_tower_logic,
                       0, 0, OverlapCheck());
   }
-  if(nFibers>0 && nFibers==5 && fiber_diam>0){
+  if (nFibers > 0 && nFibers == 5 && fiber_diam > 0)
+  {
     G4VSolid* cutoutfiber_solid = new G4Tubs("cutoutfiber_solid",
-                                                    0.0, 1.01*fiber_diam / 2.0, m_TowerDz[2], 0.0, 2 * M_PI);
+                                             0.0, 1.01 * fiber_diam / 2.0, m_TowerDz[2], 0.0, 2 * M_PI);
 
-    single_tower_solid_replica = new G4SubtractionSolid(G4String("single_tower_solid_replica_cu1"), single_tower_solid_replica, cutoutfiber_solid, 0 ,G4ThreeVector( 0 , 0 ,0.));
-    single_tower_solid_replica = new G4SubtractionSolid(G4String("single_tower_solid_replica_cu2"), single_tower_solid_replica, cutoutfiber_solid, 0 ,G4ThreeVector( -m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0 ,0.));
-    single_tower_solid_replica = new G4SubtractionSolid(G4String("single_tower_solid_replica_cu3"), single_tower_solid_replica, cutoutfiber_solid, 0 ,G4ThreeVector( m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0 ,0.));
-    single_tower_solid_replica = new G4SubtractionSolid(G4String("single_tower_solid_replica_cu4"), single_tower_solid_replica, cutoutfiber_solid, 0 ,G4ThreeVector( m_TowerDx[2] / 4.0 , -m_TowerDy[2] / 4.0 ,0.));
-    single_tower_solid_replica = new G4SubtractionSolid(G4String("single_tower_solid_replica_cu5"), single_tower_solid_replica, cutoutfiber_solid, 0 ,G4ThreeVector( -m_TowerDx[2] / 4.0 , -m_TowerDy[2] / 4.0 ,0.));
+    single_tower_solid_replica = new G4SubtractionSolid(G4String("single_tower_solid_replica_cu1"), single_tower_solid_replica, cutoutfiber_solid, 0, G4ThreeVector(0, 0, 0.));
+    single_tower_solid_replica = new G4SubtractionSolid(G4String("single_tower_solid_replica_cu2"), single_tower_solid_replica, cutoutfiber_solid, 0, G4ThreeVector(-m_TowerDx[2] / 4.0, m_TowerDy[2] / 4.0, 0.));
+    single_tower_solid_replica = new G4SubtractionSolid(G4String("single_tower_solid_replica_cu3"), single_tower_solid_replica, cutoutfiber_solid, 0, G4ThreeVector(m_TowerDx[2] / 4.0, m_TowerDy[2] / 4.0, 0.));
+    single_tower_solid_replica = new G4SubtractionSolid(G4String("single_tower_solid_replica_cu4"), single_tower_solid_replica, cutoutfiber_solid, 0, G4ThreeVector(m_TowerDx[2] / 4.0, -m_TowerDy[2] / 4.0, 0.));
+    single_tower_solid_replica = new G4SubtractionSolid(G4String("single_tower_solid_replica_cu5"), single_tower_solid_replica, cutoutfiber_solid, 0, G4ThreeVector(-m_TowerDx[2] / 4.0, -m_TowerDy[2] / 4.0, 0.));
 
-    solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_cu1"), solid_absorber, cutoutfiber_solid, 0 ,G4ThreeVector( 0 , 0 ,0.));
-    solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_cu2"), solid_absorber, cutoutfiber_solid, 0 ,G4ThreeVector( -m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0 ,0.));
-    solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_cu3"), solid_absorber, cutoutfiber_solid, 0 ,G4ThreeVector( m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0 ,0.));
-    solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_cu4"), solid_absorber, cutoutfiber_solid, 0 ,G4ThreeVector( m_TowerDx[2] / 4.0 , -m_TowerDy[2] / 4.0 ,0.));
-    solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_cu5"), solid_absorber, cutoutfiber_solid, 0 ,G4ThreeVector( -m_TowerDx[2] / 4.0 , -m_TowerDy[2] / 4.0 ,0.));
+    solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_cu1"), solid_absorber, cutoutfiber_solid, 0, G4ThreeVector(0, 0, 0.));
+    solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_cu2"), solid_absorber, cutoutfiber_solid, 0, G4ThreeVector(-m_TowerDx[2] / 4.0, m_TowerDy[2] / 4.0, 0.));
+    solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_cu3"), solid_absorber, cutoutfiber_solid, 0, G4ThreeVector(m_TowerDx[2] / 4.0, m_TowerDy[2] / 4.0, 0.));
+    solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_cu4"), solid_absorber, cutoutfiber_solid, 0, G4ThreeVector(m_TowerDx[2] / 4.0, -m_TowerDy[2] / 4.0, 0.));
+    solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_cu5"), solid_absorber, cutoutfiber_solid, 0, G4ThreeVector(-m_TowerDx[2] / 4.0, -m_TowerDy[2] / 4.0, 0.));
 
-    solid_scintillator = new G4SubtractionSolid(G4String("solid_scintillator_cu1"), solid_scintillator, cutoutfiber_solid, 0 ,G4ThreeVector( 0 , 0 ,0.));
-    solid_scintillator = new G4SubtractionSolid(G4String("solid_scintillator_cu2"), solid_scintillator, cutoutfiber_solid, 0 ,G4ThreeVector( -m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0 ,0.));
-    solid_scintillator = new G4SubtractionSolid(G4String("solid_scintillator_cu3"), solid_scintillator, cutoutfiber_solid, 0 ,G4ThreeVector( m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0 ,0.));
-    solid_scintillator = new G4SubtractionSolid(G4String("solid_scintillator_cu4"), solid_scintillator, cutoutfiber_solid, 0 ,G4ThreeVector( m_TowerDx[2] / 4.0 , -m_TowerDy[2] / 4.0 ,0.));
-    solid_scintillator = new G4SubtractionSolid(G4String("solid_scintillator_cu5"), solid_scintillator, cutoutfiber_solid, 0 ,G4ThreeVector( -m_TowerDx[2] / 4.0 , -m_TowerDy[2] / 4.0 ,0.));
+    solid_scintillator = new G4SubtractionSolid(G4String("solid_scintillator_cu1"), solid_scintillator, cutoutfiber_solid, 0, G4ThreeVector(0, 0, 0.));
+    solid_scintillator = new G4SubtractionSolid(G4String("solid_scintillator_cu2"), solid_scintillator, cutoutfiber_solid, 0, G4ThreeVector(-m_TowerDx[2] / 4.0, m_TowerDy[2] / 4.0, 0.));
+    solid_scintillator = new G4SubtractionSolid(G4String("solid_scintillator_cu3"), solid_scintillator, cutoutfiber_solid, 0, G4ThreeVector(m_TowerDx[2] / 4.0, m_TowerDy[2] / 4.0, 0.));
+    solid_scintillator = new G4SubtractionSolid(G4String("solid_scintillator_cu4"), solid_scintillator, cutoutfiber_solid, 0, G4ThreeVector(m_TowerDx[2] / 4.0, -m_TowerDy[2] / 4.0, 0.));
+    solid_scintillator = new G4SubtractionSolid(G4String("solid_scintillator_cu5"), solid_scintillator, cutoutfiber_solid, 0, G4ThreeVector(-m_TowerDx[2] / 4.0, -m_TowerDy[2] / 4.0, 0.));
 
-    if(clamp_plate_width>0){
+    if (clamp_plate_width > 0)
+    {
       G4VSolid* solid_clamp2 = new G4Box("single_plate_clamp_solid2",
-                                          m_TowerDx[2] / 2.0,
-                                          m_TowerDy[2] / 2.0,
-                                          clamp_plate_width / 2.0);
-      solid_clamp2 = new G4SubtractionSolid(G4String("solid_clamp2_cu1"), solid_clamp2, cutoutfiber_solid, 0 ,G4ThreeVector( 0 , 0 ,0.));
-      solid_clamp2 = new G4SubtractionSolid(G4String("solid_clamp2_cu2"), solid_clamp2, cutoutfiber_solid, 0 ,G4ThreeVector( -m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0 ,0.));
-      solid_clamp2 = new G4SubtractionSolid(G4String("solid_clamp2_cu3"), solid_clamp2, cutoutfiber_solid, 0 ,G4ThreeVector( m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0 ,0.));
-      solid_clamp2 = new G4SubtractionSolid(G4String("solid_clamp2_cu4"), solid_clamp2, cutoutfiber_solid, 0 ,G4ThreeVector( m_TowerDx[2] / 4.0 , -m_TowerDy[2] / 4.0 ,0.));
-      solid_clamp2 = new G4SubtractionSolid(G4String("solid_clamp2_cu5"), solid_clamp2, cutoutfiber_solid, 0 ,G4ThreeVector( -m_TowerDx[2] / 4.0 , -m_TowerDy[2] / 4.0 ,0.));
+                                         m_TowerDx[2] / 2.0,
+                                         m_TowerDy[2] / 2.0,
+                                         clamp_plate_width / 2.0);
+      solid_clamp2 = new G4SubtractionSolid(G4String("solid_clamp2_cu1"), solid_clamp2, cutoutfiber_solid, 0, G4ThreeVector(0, 0, 0.));
+      solid_clamp2 = new G4SubtractionSolid(G4String("solid_clamp2_cu2"), solid_clamp2, cutoutfiber_solid, 0, G4ThreeVector(-m_TowerDx[2] / 4.0, m_TowerDy[2] / 4.0, 0.));
+      solid_clamp2 = new G4SubtractionSolid(G4String("solid_clamp2_cu3"), solid_clamp2, cutoutfiber_solid, 0, G4ThreeVector(m_TowerDx[2] / 4.0, m_TowerDy[2] / 4.0, 0.));
+      solid_clamp2 = new G4SubtractionSolid(G4String("solid_clamp2_cu4"), solid_clamp2, cutoutfiber_solid, 0, G4ThreeVector(m_TowerDx[2] / 4.0, -m_TowerDy[2] / 4.0, 0.));
+      solid_clamp2 = new G4SubtractionSolid(G4String("solid_clamp2_cu5"), solid_clamp2, cutoutfiber_solid, 0, G4ThreeVector(-m_TowerDx[2] / 4.0, -m_TowerDy[2] / 4.0, 0.));
       G4LogicalVolume* logic_clampplate2 = new G4LogicalVolume(solid_clamp2,
-                                                            G4Material::GetMaterial("G4_Fe"),
-                                                            "logic_clampplate2",
-                                                            0, 0, 0);
+                                                               G4Material::GetMaterial("G4_Fe"),
+                                                               "logic_clampplate2",
+                                                               0, 0, 0);
       m_AbsorberLogicalVolSet.insert(logic_clampplate2);
       GetDisplayAction()->AddVolume(logic_clampplate2, "Clamp");
       std::string name_clamp = m_TowerLogicNamePrefix + "_single_plate_clamp2";
 
-      new G4PVPlacement(0, G4ThreeVector(0, 0, (tower_readout_dz) / 2.0-clamp_plate_width -m_TowerDz[2] / 2.0 - clamp_plate_width / 2.0),
+      new G4PVPlacement(0, G4ThreeVector(0, 0, (tower_readout_dz) / 2.0 - clamp_plate_width - m_TowerDz[2] / 2.0 - clamp_plate_width / 2.0),
                         logic_clampplate2,
                         name_clamp,
                         single_tower_logic,
                         0, 0, OverlapCheck());
-
-      }
+    }
   }
 
-  if(width_coating>0){
-    G4double depthCoating = 0.93*thickness_scintillator;
-    G4double zPlaneCoating[2] = {0,depthCoating};
-    G4double rInnerCoating[2] = {(m_TowerDx[2]-2*width_coating) / 2,(m_TowerDx[2]-2*width_coating) / 2.0};
+  if (width_coating > 0)
+  {
+    G4double depthCoating = 0.93 * thickness_scintillator;
+    G4double zPlaneCoating[2] = {0, depthCoating};
+    G4double rInnerCoating[2] = {(m_TowerDx[2] - 2 * width_coating) / 2, (m_TowerDx[2] - 2 * width_coating) / 2.0};
     G4double rOuterCoating[2] = {m_TowerDx[2] / 2.0, m_TowerDx[2] / 2.0};
     G4VSolid* solid_coating = new G4Polyhedra("solid_coating",
-                                            0, 2*M_PI,
-                                            4,2,
-                                            zPlaneCoating, rInnerCoating, rOuterCoating);
+                                              0, 2 * M_PI,
+                                              4, 2,
+                                              zPlaneCoating, rInnerCoating, rOuterCoating);
     G4LogicalVolume* logic_coating = new G4LogicalVolume(solid_coating,
-                                                          GetCoatingMaterial(),
-                                                          "logic_coating",
-                                                          0, 0, 0);
+                                                         GetCoatingMaterial(),
+                                                         "logic_coating",
+                                                         0, 0, 0);
     m_AbsorberLogicalVolSet.insert(logic_coating);
     GetDisplayAction()->AddVolume(logic_coating, "Coating");
     std::string name_coating = m_TowerLogicNamePrefix + "_single_plate_coating";
 
-    G4RotationMatrix *rotCoating = new G4RotationMatrix();
+    G4RotationMatrix* rotCoating = new G4RotationMatrix();
     rotCoating->rotateZ(M_PI / 4);
-    new G4PVPlacement(rotCoating, G4ThreeVector(0, 0, thickness_cell/2.0 - depthCoating),
+    new G4PVPlacement(rotCoating, G4ThreeVector(0, 0, thickness_cell / 2.0 - depthCoating),
                       logic_coating,
                       name_coating,
                       miniblock_logic,
                       0, 0, OverlapCheck());
-    solid_scintillator = new G4SubtractionSolid(G4String("solid_scintillator_cuCoating"), solid_scintillator, solid_coating,rotCoating ,G4ThreeVector( 0 , 0 ,thickness_scintillator / 2.0-depthCoating));
+    solid_scintillator = new G4SubtractionSolid(G4String("solid_scintillator_cuCoating"), solid_scintillator, solid_coating, rotCoating, G4ThreeVector(0, 0, thickness_scintillator / 2.0 - depthCoating));
   }
   G4LogicalVolume* logic_absorber = new G4LogicalVolume(solid_absorber,
                                                         material_absorber,
@@ -369,98 +368,95 @@ PHG4ForwardEcalDetector::ConstructTower(int type)
                                                      "hEcal_scintillator_plate_logic2",
                                                      0, 0, 0);
   m_ScintiLogicalVolSet.insert(logic_scint);
-  if(m_doLightProp){
+  if (m_doLightProp)
+  {
     SurfaceTable(logic_scint);
   }
-  
+
   GetDisplayAction()->AddVolume(logic_absorber, "Absorber");
   GetDisplayAction()->AddVolume(logic_scint, "Scintillator");
 
   std::string name_absorber = m_TowerLogicNamePrefix + "_single_plate_absorber2";
   std::string name_scintillator = m_TowerLogicNamePrefix + "_single_plate_scintillator2";
 
-  new G4PVPlacement(0, G4ThreeVector(0, 0, -thickness_cell/2.0 + thickness_absorber/2.0),
+  new G4PVPlacement(0, G4ThreeVector(0, 0, -thickness_cell / 2.0 + thickness_absorber / 2.0),
                     logic_absorber,
                     name_absorber,
                     miniblock_logic,
                     0, 0, OverlapCheck());
 
-
-  new G4PVPlacement(0, G4ThreeVector(0, 0, thickness_cell/2.0 - thickness_scintillator/2.0),
+  new G4PVPlacement(0, G4ThreeVector(0, 0, thickness_cell / 2.0 - thickness_scintillator / 2.0),
                     logic_scint,
                     name_scintillator,
                     miniblock_logic,
                     0, 0, OverlapCheck());
 
-
-
   G4LogicalVolume* single_tower_replica_logic = new G4LogicalVolume(single_tower_solid_replica,
-                                                            WorldMaterial,
-                                                            "single_tower_replica_logic",
-                                                            0, 0, 0);
+                                                                    WorldMaterial,
+                                                                    "single_tower_replica_logic",
+                                                                    0, 0, 0);
   /* create replica within tower */
   std::string name_tower = m_TowerLogicNamePrefix;
-  new G4PVReplica(name_tower,miniblock_logic,single_tower_replica_logic,
-                      kZAxis,nlayers, thickness_layer,0);
+  new G4PVReplica(name_tower, miniblock_logic, single_tower_replica_logic,
+                  kZAxis, nlayers, thickness_layer, 0);
 
   GetDisplayAction()->AddVolume(single_tower_replica_logic, "SingleTower");
 
-  new G4PVPlacement(0, G4ThreeVector(0, 0, (tower_readout_dz) / 2.0-clamp_plate_width),
+  new G4PVPlacement(0, G4ThreeVector(0, 0, (tower_readout_dz) / 2.0 - clamp_plate_width),
                     single_tower_replica_logic,
                     "replicated_layers_placed",
                     single_tower_logic,
                     0, 0, OverlapCheck());
 
   // place array of fibers inside absorber
-  if(nFibers>0 && nFibers==5 && fiber_diam>0){
-
+  if (nFibers > 0 && nFibers == 5 && fiber_diam > 0)
+  {
     std::string fiberName = "single_fiber_scintillator_solid" + std::to_string(type);
     G4VSolid* single_scintillator_solid = new G4Tubs(fiberName,
-                                                    0.0, fiber_diam / 2.0, (m_TowerDz[2]+fiber_extra_length)/2 , 0.0, 2 * M_PI);
+                                                     0.0, fiber_diam / 2.0, (m_TowerDz[2] + fiber_extra_length) / 2, 0.0, 2 * M_PI);
 
     /* create logical volumes for scintillator and absorber plates to place inside single_tower */
     G4Material* material_WLSFiber = GetWLSFiberFEMCMaterial();
 
     std::string fiberLogicName = "hEcal_scintillator_fiber_logic" + std::to_string(type);
     G4LogicalVolume* single_scintillator_logic = new G4LogicalVolume(single_scintillator_solid,
-                                                                    material_WLSFiber,
-                                                                    fiberLogicName,
-                                                                    0, 0, 0);
+                                                                     material_WLSFiber,
+                                                                     fiberLogicName,
+                                                                     0, 0, 0);
     m_ScintiLogicalVolSet.insert(single_scintillator_logic);
     GetDisplayAction()->AddVolume(single_scintillator_logic, "Fiber");
 
     std::string name_scintillator = m_TowerLogicNamePrefix + "_single_fiber_scintillator" + std::to_string(type);
 
-    new G4PVPlacement(0, G4ThreeVector(0, 0, -fiber_extra_length/2+tower_readout_dz/2-clamp_plate_width),
+    new G4PVPlacement(0, G4ThreeVector(0, 0, -fiber_extra_length / 2 + tower_readout_dz / 2 - clamp_plate_width),
                       single_scintillator_logic,
                       name_scintillator + "_center",
                       single_tower_logic,
                       0, 0, OverlapCheck());
 
-    new G4PVPlacement(0, G4ThreeVector(-m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0, -fiber_extra_length/2+tower_readout_dz/2-clamp_plate_width),
+    new G4PVPlacement(0, G4ThreeVector(-m_TowerDx[2] / 4.0, m_TowerDy[2] / 4.0, -fiber_extra_length / 2 + tower_readout_dz / 2 - clamp_plate_width),
                       single_scintillator_logic,
                       name_scintillator + "_tl",
                       single_tower_logic,
                       0, 0, OverlapCheck());
 
-    new G4PVPlacement(0, G4ThreeVector(m_TowerDx[2] / 4.0 , -m_TowerDy[2] / 4.0, -fiber_extra_length/2+tower_readout_dz/2-clamp_plate_width),
+    new G4PVPlacement(0, G4ThreeVector(m_TowerDx[2] / 4.0, -m_TowerDy[2] / 4.0, -fiber_extra_length / 2 + tower_readout_dz / 2 - clamp_plate_width),
                       single_scintillator_logic,
                       name_scintillator + "_bl",
                       single_tower_logic,
                       0, 0, OverlapCheck());
 
-    new G4PVPlacement(0, G4ThreeVector(m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0, -fiber_extra_length/2+tower_readout_dz/2-clamp_plate_width),
+    new G4PVPlacement(0, G4ThreeVector(m_TowerDx[2] / 4.0, m_TowerDy[2] / 4.0, -fiber_extra_length / 2 + tower_readout_dz / 2 - clamp_plate_width),
                       single_scintillator_logic,
                       name_scintillator + "_tr",
                       single_tower_logic,
                       0, 0, OverlapCheck());
 
-    new G4PVPlacement(0, G4ThreeVector(-m_TowerDx[2] / 4.0 ,- m_TowerDy[2] / 4.0, -fiber_extra_length/2+tower_readout_dz/2-clamp_plate_width),
+    new G4PVPlacement(0, G4ThreeVector(-m_TowerDx[2] / 4.0, -m_TowerDy[2] / 4.0, -fiber_extra_length / 2 + tower_readout_dz / 2 - clamp_plate_width),
                       single_scintillator_logic,
                       name_scintillator + "_br",
                       single_tower_logic,
                       0, 0, OverlapCheck());
-
   }
 
   if (Verbosity() > 0)
@@ -487,7 +483,6 @@ int PHG4ForwardEcalDetector::PlaceTower(G4LogicalVolume* ecalenvelope, G4Logical
     G4LogicalVolume* singletower = singletowerIn[iterator->second.type];
     int copyno = (iterator->second.idx_j << 16) + iterator->second.idx_k;
 
-
     G4PVPlacement* tower_placement =
         new G4PVPlacement(0, G4ThreeVector(iterator->second.x, iterator->second.y, iterator->second.z),
                           singletower,
@@ -501,30 +496,29 @@ int PHG4ForwardEcalDetector::PlaceTower(G4LogicalVolume* ecalenvelope, G4Logical
   return 0;
 }
 
-
 //_______________________________________________________________________
 G4Material* PHG4ForwardEcalDetector::GetScintillatorMaterial()
 {
-
-	G4double density;
-	G4int ncomponents;
-  G4Material* material_ScintFEMC = new G4Material("PolystyreneFEMC", density = 1.03 * g / cm3, ncomponents=2);
+  G4double density;
+  G4int ncomponents;
+  G4Material* material_ScintFEMC = new G4Material("PolystyreneFEMC", density = 1.03 * g / cm3, ncomponents = 2);
   material_ScintFEMC->AddElement(G4Element::GetElement("C"), 8);
   material_ScintFEMC->AddElement(G4Element::GetElement("H"), 8);
 
-  if(m_doLightProp){
+  if (m_doLightProp)
+  {
     const G4int ntab = 4;
 
-    G4double wls_Energy[] = { 2.00 * eV, 2.87 * eV, 2.90 * eV,
-                                        3.47 * eV };
+    G4double wls_Energy[] = {2.00 * eV, 2.87 * eV, 2.90 * eV,
+                             3.47 * eV};
 
-    G4double rIndexPstyrene[] = { 1.5, 1.5, 1.5, 1.5 };
-    G4double absorption1[]    = { 2. * cm, 2. * cm, 2. * cm, 2. * cm };
-    G4double scintilFast[]    = { 0.0, 0.0, 1.0, 1.0 };
+    G4double rIndexPstyrene[] = {1.5, 1.5, 1.5, 1.5};
+    G4double absorption1[] = {2. * cm, 2. * cm, 2. * cm, 2. * cm};
+    G4double scintilFast[] = {0.0, 0.0, 1.0, 1.0};
     G4MaterialPropertiesTable* fMPTPStyrene = new G4MaterialPropertiesTable();
-    fMPTPStyrene->AddProperty("RINDEX", wls_Energy, rIndexPstyrene,ntab);
-    fMPTPStyrene->AddProperty("ABSLENGTH", wls_Energy, absorption1,ntab);
-    fMPTPStyrene->AddProperty("SCINTILLATIONCOMPONENT1", wls_Energy, scintilFast,ntab);
+    fMPTPStyrene->AddProperty("RINDEX", wls_Energy, rIndexPstyrene, ntab);
+    fMPTPStyrene->AddProperty("ABSLENGTH", wls_Energy, absorption1, ntab);
+    fMPTPStyrene->AddProperty("SCINTILLATIONCOMPONENT1", wls_Energy, scintilFast, ntab);
     fMPTPStyrene->AddConstProperty("SCINTILLATIONYIELD", 10. / keV);
     fMPTPStyrene->AddConstProperty("RESOLUTIONSCALE", 1.0);
     fMPTPStyrene->AddConstProperty("SCINTILLATIONTIMECONSTANT", 10. * ns);
@@ -540,13 +534,12 @@ G4Material* PHG4ForwardEcalDetector::GetScintillatorMaterial()
 //_______________________________________________________________________
 G4Material* PHG4ForwardEcalDetector::GetCoatingMaterial()
 {
-
   //--------------------------------------------------
   // TiO2
   //--------------------------------------------------
-	G4double density,fractionmass;
-	G4int ncomponents;
-  G4Material* material_TiO2 = new G4Material("TiO2_FEMC", density = 1.52 * g / cm3, ncomponents=2);
+  G4double density, fractionmass;
+  G4int ncomponents;
+  G4Material* material_TiO2 = new G4Material("TiO2_FEMC", density = 1.52 * g / cm3, ncomponents = 2);
   material_TiO2->AddElement(G4Element::GetElement("Ti"), 1);
   material_TiO2->AddElement(G4Element::GetElement("O"), 2);
 
@@ -555,7 +548,7 @@ G4Material* PHG4ForwardEcalDetector::GetCoatingMaterial()
   //--------------------------------------------------
   //Coating_FEMC (Glass + Epoxy)
   density = 1.86 * g / cm3;
-  G4Material *Coating_FEMC = new G4Material("Coating_FEMC", density, ncomponents = 2);
+  G4Material* Coating_FEMC = new G4Material("Coating_FEMC", density, ncomponents = 2);
   Coating_FEMC->AddMaterial(G4Material::GetMaterial("Epoxy"), fractionmass = 0.80);
   Coating_FEMC->AddMaterial(material_TiO2, fractionmass = 0.20);
 
@@ -563,9 +556,9 @@ G4Material* PHG4ForwardEcalDetector::GetCoatingMaterial()
 }
 
 //_____________________________________________________________________________
-void PHG4ForwardEcalDetector::SurfaceTable(G4LogicalVolume *vol) {
-
-  G4OpticalSurface *surface = new G4OpticalSurface("ScintWrapB1");
+void PHG4ForwardEcalDetector::SurfaceTable(G4LogicalVolume* vol)
+{
+  G4OpticalSurface* surface = new G4OpticalSurface("ScintWrapB1");
 
   new G4LogicalSkinSurface("CrystalSurfaceL", vol, surface);
 
@@ -580,13 +573,13 @@ void PHG4ForwardEcalDetector::SurfaceTable(G4LogicalVolume *vol) {
   // G4double opt_en[] = {1.551*eV, 3.545*eV}; // 350 - 800 nm
   // G4double reflectivity[] = {0.8, 0.8};
   // G4double efficiency[] = {0.9, 0.9};
-  G4MaterialPropertiesTable *surfmat = new G4MaterialPropertiesTable();
+  G4MaterialPropertiesTable* surfmat = new G4MaterialPropertiesTable();
   // surfmat->AddProperty("REFLECTIVITY", opt_en, reflectivity, ntab);
   // surfmat->AddProperty("EFFICIENCY", opt_en, efficiency, ntab);
   surface->SetMaterialPropertiesTable(surfmat);
   //csurf->DumpInfo();
 
-}//SurfaceTable
+}  //SurfaceTable
 //_______________________________________________________________________
 G4Material* PHG4ForwardEcalDetector::GetWLSFiberFEMCMaterial()
 {
@@ -595,26 +588,27 @@ G4Material* PHG4ForwardEcalDetector::GetWLSFiberFEMCMaterial()
     std::cout << "PHG4ForwardEcalDetector: Making WLSFiberFEMC material..." << std::endl;
   }
 
-	G4double density;
-	G4int ncomponents;
+  G4double density;
+  G4int ncomponents;
 
   G4Material* material_WLSFiberFEMC = new G4Material("WLSFiberFEMC", density = 1.18 * g / cm3, ncomponents = 3);
   material_WLSFiberFEMC->AddElement(G4Element::GetElement("C"), 5);
   material_WLSFiberFEMC->AddElement(G4Element::GetElement("H"), 8);
   material_WLSFiberFEMC->AddElement(G4Element::GetElement("O"), 2);
-  if(m_doLightProp){
+  if (m_doLightProp)
+  {
     const G4int ntab = 4;
-    G4double wls_Energy[] = { 2.00 * eV, 2.87 * eV, 2.90 * eV,
-                                        3.47 * eV };
+    G4double wls_Energy[] = {2.00 * eV, 2.87 * eV, 2.90 * eV,
+                             3.47 * eV};
 
-    G4double RefractiveIndexFiber[] = { 1.6, 1.6, 1.6, 1.6 };
-    G4double AbsFiber[]    = { 9.0 * m, 9.0 * m, 0.1 * mm, 0.1 * mm };
-    G4double EmissionFib[] = { 1.0, 1.0, 0.0, 0.0 };
+    G4double RefractiveIndexFiber[] = {1.6, 1.6, 1.6, 1.6};
+    G4double AbsFiber[] = {9.0 * m, 9.0 * m, 0.1 * mm, 0.1 * mm};
+    G4double EmissionFib[] = {1.0, 1.0, 0.0, 0.0};
     // Add entries into properties table
     G4MaterialPropertiesTable* mptWLSfiber = new G4MaterialPropertiesTable();
-    mptWLSfiber->AddProperty("RINDEX", wls_Energy, RefractiveIndexFiber,ntab);
-    mptWLSfiber->AddProperty("WLSABSLENGTH", wls_Energy, AbsFiber,ntab);
-    mptWLSfiber->AddProperty("WLSCOMPONENT", wls_Energy, EmissionFib,ntab);
+    mptWLSfiber->AddProperty("RINDEX", wls_Energy, RefractiveIndexFiber, ntab);
+    mptWLSfiber->AddProperty("WLSABSLENGTH", wls_Energy, AbsFiber, ntab);
+    mptWLSfiber->AddProperty("WLSCOMPONENT", wls_Energy, EmissionFib, ntab);
     mptWLSfiber->AddConstProperty("WLSTIMECONSTANT", 0.5 * ns);
     material_WLSFiberFEMC->SetMaterialPropertiesTable(mptWLSfiber);
   }
@@ -782,32 +776,31 @@ int PHG4ForwardEcalDetector::ParseParametersFromTable()
   {
     m_TowerType = parit->second;
   }
-  
+
   parit = m_GlobalParameterMap.find("xoffset");
   if (parit != m_GlobalParameterMap.end())
-    m_Params->set_double_param("xoffset", parit->second);  
+    m_Params->set_double_param("xoffset", parit->second);
 
   parit = m_GlobalParameterMap.find("yoffset");
   if (parit != m_GlobalParameterMap.end())
-    m_Params->set_double_param("yoffset", parit->second);  
+    m_Params->set_double_param("yoffset", parit->second);
 
   parit = m_GlobalParameterMap.find("width_coating");
   if (parit != m_GlobalParameterMap.end())
-    m_Params->set_double_param("width_coating", parit->second);  
+    m_Params->set_double_param("width_coating", parit->second);
 
   parit = m_GlobalParameterMap.find("clamp_plate_width");
   if (parit != m_GlobalParameterMap.end())
-    m_Params->set_double_param("clamp_plate_width", parit->second);  
+    m_Params->set_double_param("clamp_plate_width", parit->second);
 
   parit = m_GlobalParameterMap.find("fiber_diam");
   if (parit != m_GlobalParameterMap.end())
-    m_Params->set_double_param("fiber_diam", parit->second);  
+    m_Params->set_double_param("fiber_diam", parit->second);
 
   parit = m_GlobalParameterMap.find("nFibers");
   if (parit != m_GlobalParameterMap.end())
-    m_Params->set_int_param("nFibers", parit->second);  
+    m_Params->set_int_param("nFibers", parit->second);
 
-  
   return 0;
 }
 

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalDetector.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalDetector.cc
@@ -21,6 +21,10 @@
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4PVReplica.hh>
 #include <Geant4/G4PhysicalConstants.hh>
+#include <Geant4/G4MaterialPropertiesTable.hh>
+#include <Geant4/G4OpticalSurface.hh>
+#include <Geant4/G4Polyhedra.hh>
+#include <Geant4/G4LogicalSkinSurface.hh>
 #include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
 #include <Geant4/G4String.hh>          // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
@@ -50,6 +54,7 @@ PHG4ForwardEcalDetector::PHG4ForwardEcalDetector(PHG4Subsystem* subsys, PHCompos
   , m_GdmlConfig(PHG4GDMLUtility::GetOrMakeConfigNode(Node))
   , m_ActiveFlag(m_Params->get_int_param("active"))
   , m_AbsorberActiveFlag(m_Params->get_int_param("absorberactive"))
+  , m_doLightProp(false)
 {
   for (int i = 0; i < 3; i++)
   {
@@ -109,16 +114,17 @@ void PHG4ForwardEcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
   recoConsts* rc = recoConsts::instance();
   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
 
-  
+  G4double tower_readout_dz = m_Params->get_double_param("tower_readout_dz")*cm;
+
   G4VSolid *beampipe_cutout = new G4Cons("FEMC_beampipe_cutout",
                                          0, m_RMin[0],
                                          0, m_RMin[1],
-                                         m_dZ / 2.0,
+                                         (m_dZ + tower_readout_dz),
                                          0, 2 * M_PI);
   G4VSolid *ecal_envelope_solid = new G4Cons("FEMC_envelope_solid_cutout",
                                             0, m_RMax[0],
                                             0, m_RMax[1],
-                                            m_dZ / 2.0,
+                                            (m_dZ + tower_readout_dz) / 2.0,
                                             0, 2 * M_PI);
   ecal_envelope_solid = new G4SubtractionSolid(G4String("hFEMC_envelope_solid"), ecal_envelope_solid, beampipe_cutout, 0, G4ThreeVector(m_Params->get_double_param("xoffset") * cm, m_Params->get_double_param("yoffset") * cm, 0.));
 
@@ -137,7 +143,7 @@ void PHG4ForwardEcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
   /* Place envelope cone in simulation */
   std::string name_envelope = m_TowerLogicNamePrefix + "_envelope";
 
-  new G4PVPlacement(G4Transform3D(ecal_rotm, G4ThreeVector(m_PlaceX, m_PlaceY, m_PlaceZ)),
+  new G4PVPlacement(G4Transform3D(ecal_rotm, G4ThreeVector(m_PlaceX, m_PlaceY, m_PlaceZ - tower_readout_dz/2)),
                     ecal_envelope_log, name_envelope, logicWorld, 0, false, OverlapCheck());
 
   /* Construct single calorimeter towers */
@@ -172,101 +178,39 @@ PHG4ForwardEcalDetector::ConstructTower(int type)
   {
     std::cout << "PHG4ForwardEcalDetector: Build logical volume for single tower, type = " << type << std::endl;
   }
-  assert(type >= 0 && type <= 6);
-  // This method allows construction of Type 0,1 tower (PbGl or PbW04).
-  // Call a separate routine to generate Type 2 towers (PbSc)
-  // Call a separate routine to generate Type 3-6 towers (E864 Pb-Scifi)
-
-  if (type == 2) 
-    return ConstructTowerType2();
-  if ((type == 3) || (type == 4) || (type == 5) || (type == 6)) 
-    return ConstructTowerType3_4_5_6(type);
-
   /* create logical volume for single tower */
   recoConsts* rc = recoConsts::instance();
   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
 
-  G4Material* material_scintillator;
-  double tower_dx = m_TowerDx[type];
-  double tower_dy = m_TowerDy[type];
-  double tower_dz = m_TowerDz[type];
-  std::cout << "building type " << type << " towers" << std::endl;
-  if (type == 0)
-  {
-    material_scintillator = G4Material::GetMaterial("G4_LEAD_OXIDE");
-  }
-  else if (type == 1)
-  {
-    material_scintillator = G4Material::GetMaterial("G4_PbWO4");
-  }
-  else
-  {
-    std::cout << "PHG4ForwardEcalDetector::ConstructTower invalid type = " << type << std::endl;
-    material_scintillator = nullptr;
-  }
 
-  std::string single_tower_solid_name = m_TowerLogicNamePrefix + "_single_scintillator_type" + std::to_string(type);
 
-  G4VSolid* single_tower_solid = new G4Box(single_tower_solid_name,
-                                           tower_dx / 2.0,
-                                           tower_dy / 2.0,
-                                           tower_dz / 2.0);
-
-  std::string single_tower_logic_name = "single_tower_logic_type" + std::to_string(type);
-
-  G4LogicalVolume* single_tower_logic = new G4LogicalVolume(single_tower_solid,
-                                                            WorldMaterial,
-                                                            single_tower_logic_name,
-                                                            0, 0, 0);
-
-  std::string single_scintillator_name = "single_scintillator_type" + std::to_string(type);
-
-  G4VSolid* solid_scintillator = new G4Box(single_scintillator_name,
-                                           tower_dx / 2.0,
-                                           tower_dy / 2.0,
-                                           tower_dz / 2.0);
-
-  std::string hEcal_scintillator_plate_logic_name = "hFEMC_scintillator_plate_logic_type" + std::to_string(type);
-
-  G4LogicalVolume* logic_scint = new G4LogicalVolume(solid_scintillator,
-                                                     material_scintillator,
-                                                     hEcal_scintillator_plate_logic_name,
-                                                     0, 0, 0);
-
-  GetDisplayAction()->AddVolume(logic_scint, "Scintillator");
-
-  /* place physical volumes for scintillator */
-
-  std::string name_scintillator = m_TowerLogicNamePrefix + "_single_plate_scintillator";
-
-  new G4PVPlacement(0, G4ThreeVector(0.0, 0.0, 0.0),
-                    logic_scint,
-                    name_scintillator,
-                    single_tower_logic,
-                    0, 0, OverlapCheck());
-
-  GetDisplayAction()->AddVolume(single_tower_logic, "SingleTower");
-
-  if (Verbosity() > 0)
-  {
-    std::cout << "PHG4ForwardEcalDetector: Building logical volume for single tower done, type = " << type << std::endl;
-  }
-
-  return single_tower_logic;
-}
-
-G4LogicalVolume*
-PHG4ForwardEcalDetector::ConstructTowerType2()
-{
-  if (Verbosity() > 0)
-  {
-    std::cout << "PHG4ForwardEcalDetector: Build logical volume for single tower type 2..." << std::endl;
-  }
-  /* create logical volume for single tower */
-  recoConsts* rc = recoConsts::instance();
-  G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
+  /* create geometry volumes for scintillator and absorber plates to place inside single_tower */
+  // PHENIX EMCal JGL 3/27/2016
+  G4int nlayers                   = 66;
+  G4double thickness_layer        = m_TowerDz[2] / (float) nlayers;
+  // update layer thickness with https://doi.org/10.1016/S0168-9002(02)01954-X
+  G4double thickness_cell = 5.6 * mm;
+  G4double thickness_absorber     = 1.55 * mm;      // 1.55mm absorber
+  G4double thickness_scintillator = 4.0 * mm;  // 4mm scintillator
+  // notched in TiO2 coating in scintillator plate
+  G4double width_coating = m_Params->get_double_param("width_coating") * cm;  // 4mm scintillator
+  G4Material* material_scintillator = GetScintillatorMaterial();//G4Material::GetMaterial("G4_POLYSTYRENE");
+  G4Material* material_absorber     = G4Material::GetMaterial("G4_Pb");
+  G4int nFibers = m_Params->get_int_param("nFibers");
+  G4double fiber_diam = m_Params->get_double_param("fiber_diam") * cm;  // 4mm scintillator
+  G4double fiber_extra_length = 0.0;
+  // additional fiber length at end of calorimeter
+  if(fiber_diam>0) fiber_extra_length = 0.5 * cm;
+  // width of plate in front of FEMC for clamping all layers
+  G4double clamp_plate_width = m_Params->get_double_param("clamp_plate_width")*cm;
+  // depth of readout (4cm)
+  G4double tower_readout_dz = m_Params->get_double_param("tower_readout_dz")*cm;
 
   G4VSolid* single_tower_solid = new G4Box("single_tower_solid2",
+                                           m_TowerDx[2] / 2.0,
+                                           m_TowerDy[2] / 2.0,
+                                           (m_TowerDz[2] + tower_readout_dz) / 2.0);
+  G4VSolid* single_tower_solid_replica = new G4Box("single_tower_solid_replica",
                                            m_TowerDx[2] / 2.0,
                                            m_TowerDy[2] / 2.0,
                                            m_TowerDz[2] / 2.0);
@@ -276,16 +220,7 @@ PHG4ForwardEcalDetector::ConstructTowerType2()
                                                             "single_tower_logic2",
                                                             0, 0, 0);
 
-  /* create geometry volumes for scintillator and absorber plates to place inside single_tower */
-  // PHENIX EMCal JGL 3/27/2016
-  G4int nlayers                   = 66;
-  G4double thickness_layer        = m_TowerDz[2] / (float) nlayers;
-  // update layer thickness with https://doi.org/10.1016/S0168-9002(02)01954-X
-  G4double thickness_cell = 5.6 * mm;
-  G4double thickness_absorber     = 1.5 * mm;      // 1.5mm absorber
-  G4double thickness_scintillator = 4.0 * mm;  // 4mm scintillator
-  G4Material* material_scintillator = G4Material::GetMaterial("G4_POLYSTYRENE");
-  G4Material* material_absorber     = G4Material::GetMaterial("G4_Pb");
+  GetDisplayAction()->AddVolume(single_tower_logic, "SingleTower");
 
   if (Verbosity())
   {
@@ -324,10 +259,106 @@ PHG4ForwardEcalDetector::ConstructTowerType2()
                                        thickness_absorber / 2.0);
 
   G4VSolid* solid_scintillator = new G4Box("single_plate_scintillator2",
-                                           m_TowerDx[2] / 2.0,
-                                           m_TowerDy[2] / 2.0,
+                                           (m_TowerDx[2]) / 2.0,
+                                           (m_TowerDy[2]) / 2.0,
+                                          //  (m_TowerDx[2] - 2*width_coating) / 2.0,
+                                          //  (m_TowerDy[2] - 2*width_coating) / 2.0,
                                            thickness_scintillator / 2.0);
+  
+  if(clamp_plate_width>0){
+    G4VSolid* solid_clamp1 = new G4Box("single_plate_clamp_solid1",
+                                        m_TowerDx[2] / 2.0,
+                                        m_TowerDy[2] / 2.0,
+                                        clamp_plate_width / 2.0);
+    G4LogicalVolume* logic_clampplate = new G4LogicalVolume(solid_clamp1,
+                                                          G4Material::GetMaterial("G4_Fe"),
+                                                          "logic_clampplate",
+                                                          0, 0, 0);
+    m_AbsorberLogicalVolSet.insert(logic_clampplate);
+    GetDisplayAction()->AddVolume(logic_clampplate, "Clamp");
+    std::string name_clamp = m_TowerLogicNamePrefix + "_single_plate_clamp";
 
+    new G4PVPlacement(0, G4ThreeVector(0, 0, (m_dZ + tower_readout_dz) / 2.0 - clamp_plate_width / 2.0),
+                      logic_clampplate,
+                      name_clamp,
+                      single_tower_logic,
+                      0, 0, OverlapCheck());
+  }
+  if(nFibers>0 && nFibers==5 && fiber_diam>0){
+    G4VSolid* cutoutfiber_solid = new G4Tubs("cutoutfiber_solid",
+                                                    0.0, 1.01*fiber_diam / 2.0, m_TowerDz[2], 0.0, 2 * M_PI);
+
+    single_tower_solid_replica = new G4SubtractionSolid(G4String("single_tower_solid_replica_cu1"), single_tower_solid_replica, cutoutfiber_solid, 0 ,G4ThreeVector( 0 , 0 ,0.));
+    single_tower_solid_replica = new G4SubtractionSolid(G4String("single_tower_solid_replica_cu2"), single_tower_solid_replica, cutoutfiber_solid, 0 ,G4ThreeVector( -m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0 ,0.));
+    single_tower_solid_replica = new G4SubtractionSolid(G4String("single_tower_solid_replica_cu3"), single_tower_solid_replica, cutoutfiber_solid, 0 ,G4ThreeVector( m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0 ,0.));
+    single_tower_solid_replica = new G4SubtractionSolid(G4String("single_tower_solid_replica_cu4"), single_tower_solid_replica, cutoutfiber_solid, 0 ,G4ThreeVector( m_TowerDx[2] / 4.0 , -m_TowerDy[2] / 4.0 ,0.));
+    single_tower_solid_replica = new G4SubtractionSolid(G4String("single_tower_solid_replica_cu5"), single_tower_solid_replica, cutoutfiber_solid, 0 ,G4ThreeVector( -m_TowerDx[2] / 4.0 , -m_TowerDy[2] / 4.0 ,0.));
+
+    solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_cu1"), solid_absorber, cutoutfiber_solid, 0 ,G4ThreeVector( 0 , 0 ,0.));
+    solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_cu2"), solid_absorber, cutoutfiber_solid, 0 ,G4ThreeVector( -m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0 ,0.));
+    solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_cu3"), solid_absorber, cutoutfiber_solid, 0 ,G4ThreeVector( m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0 ,0.));
+    solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_cu4"), solid_absorber, cutoutfiber_solid, 0 ,G4ThreeVector( m_TowerDx[2] / 4.0 , -m_TowerDy[2] / 4.0 ,0.));
+    solid_absorber = new G4SubtractionSolid(G4String("solid_absorber_cu5"), solid_absorber, cutoutfiber_solid, 0 ,G4ThreeVector( -m_TowerDx[2] / 4.0 , -m_TowerDy[2] / 4.0 ,0.));
+
+    solid_scintillator = new G4SubtractionSolid(G4String("solid_scintillator_cu1"), solid_scintillator, cutoutfiber_solid, 0 ,G4ThreeVector( 0 , 0 ,0.));
+    solid_scintillator = new G4SubtractionSolid(G4String("solid_scintillator_cu2"), solid_scintillator, cutoutfiber_solid, 0 ,G4ThreeVector( -m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0 ,0.));
+    solid_scintillator = new G4SubtractionSolid(G4String("solid_scintillator_cu3"), solid_scintillator, cutoutfiber_solid, 0 ,G4ThreeVector( m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0 ,0.));
+    solid_scintillator = new G4SubtractionSolid(G4String("solid_scintillator_cu4"), solid_scintillator, cutoutfiber_solid, 0 ,G4ThreeVector( m_TowerDx[2] / 4.0 , -m_TowerDy[2] / 4.0 ,0.));
+    solid_scintillator = new G4SubtractionSolid(G4String("solid_scintillator_cu5"), solid_scintillator, cutoutfiber_solid, 0 ,G4ThreeVector( -m_TowerDx[2] / 4.0 , -m_TowerDy[2] / 4.0 ,0.));
+
+    if(clamp_plate_width>0){
+      G4VSolid* solid_clamp2 = new G4Box("single_plate_clamp_solid2",
+                                          m_TowerDx[2] / 2.0,
+                                          m_TowerDy[2] / 2.0,
+                                          clamp_plate_width / 2.0);
+      solid_clamp2 = new G4SubtractionSolid(G4String("solid_clamp2_cu1"), solid_clamp2, cutoutfiber_solid, 0 ,G4ThreeVector( 0 , 0 ,0.));
+      solid_clamp2 = new G4SubtractionSolid(G4String("solid_clamp2_cu2"), solid_clamp2, cutoutfiber_solid, 0 ,G4ThreeVector( -m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0 ,0.));
+      solid_clamp2 = new G4SubtractionSolid(G4String("solid_clamp2_cu3"), solid_clamp2, cutoutfiber_solid, 0 ,G4ThreeVector( m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0 ,0.));
+      solid_clamp2 = new G4SubtractionSolid(G4String("solid_clamp2_cu4"), solid_clamp2, cutoutfiber_solid, 0 ,G4ThreeVector( m_TowerDx[2] / 4.0 , -m_TowerDy[2] / 4.0 ,0.));
+      solid_clamp2 = new G4SubtractionSolid(G4String("solid_clamp2_cu5"), solid_clamp2, cutoutfiber_solid, 0 ,G4ThreeVector( -m_TowerDx[2] / 4.0 , -m_TowerDy[2] / 4.0 ,0.));
+      G4LogicalVolume* logic_clampplate2 = new G4LogicalVolume(solid_clamp2,
+                                                            G4Material::GetMaterial("G4_Fe"),
+                                                            "logic_clampplate2",
+                                                            0, 0, 0);
+      m_AbsorberLogicalVolSet.insert(logic_clampplate2);
+      GetDisplayAction()->AddVolume(logic_clampplate2, "Clamp");
+      std::string name_clamp = m_TowerLogicNamePrefix + "_single_plate_clamp2";
+
+      new G4PVPlacement(0, G4ThreeVector(0, 0, (tower_readout_dz) / 2.0-clamp_plate_width -m_TowerDz[2] / 2.0 - clamp_plate_width / 2.0),
+                        logic_clampplate2,
+                        name_clamp,
+                        single_tower_logic,
+                        0, 0, OverlapCheck());
+
+      }
+  }
+
+  if(width_coating>0){
+    G4double depthCoating = 0.93*thickness_scintillator;
+    G4double zPlaneCoating[2] = {0,depthCoating};
+    G4double rInnerCoating[2] = {(m_TowerDx[2]-2*width_coating) / 2,(m_TowerDx[2]-2*width_coating) / 2.0};
+    G4double rOuterCoating[2] = {m_TowerDx[2] / 2.0, m_TowerDx[2] / 2.0};
+    G4VSolid* solid_coating = new G4Polyhedra("solid_coating",
+                                            0, 2*M_PI,
+                                            4,2,
+                                            zPlaneCoating, rInnerCoating, rOuterCoating);
+    G4LogicalVolume* logic_coating = new G4LogicalVolume(solid_coating,
+                                                          GetCoatingMaterial(),
+                                                          "logic_coating",
+                                                          0, 0, 0);
+    m_AbsorberLogicalVolSet.insert(logic_coating);
+    GetDisplayAction()->AddVolume(logic_coating, "Coating");
+    std::string name_coating = m_TowerLogicNamePrefix + "_single_plate_coating";
+
+    G4RotationMatrix *rotCoating = new G4RotationMatrix();
+    rotCoating->rotateZ(M_PI / 4);
+    new G4PVPlacement(rotCoating, G4ThreeVector(0, 0, thickness_cell/2.0 - depthCoating),
+                      logic_coating,
+                      name_coating,
+                      miniblock_logic,
+                      0, 0, OverlapCheck());
+    solid_scintillator = new G4SubtractionSolid(G4String("solid_scintillator_cuCoating"), solid_scintillator, solid_coating,rotCoating ,G4ThreeVector( 0 , 0 ,thickness_scintillator / 2.0-depthCoating));
+  }
   G4LogicalVolume* logic_absorber = new G4LogicalVolume(solid_absorber,
                                                         material_absorber,
                                                         "single_plate_absorber_logic2",
@@ -338,6 +369,9 @@ PHG4ForwardEcalDetector::ConstructTowerType2()
                                                      "hEcal_scintillator_plate_logic2",
                                                      0, 0, 0);
   m_ScintiLogicalVolSet.insert(logic_scint);
+  if(m_doLightProp){
+    SurfaceTable(logic_scint);
+  }
   
   GetDisplayAction()->AddVolume(logic_absorber, "Absorber");
   GetDisplayAction()->AddVolume(logic_scint, "Scintillator");
@@ -345,155 +379,89 @@ PHG4ForwardEcalDetector::ConstructTowerType2()
   std::string name_absorber = m_TowerLogicNamePrefix + "_single_plate_absorber2";
   std::string name_scintillator = m_TowerLogicNamePrefix + "_single_plate_scintillator2";
 
-  new G4PVPlacement(0, G4ThreeVector(0, 0, -thickness_scintillator/2),
+  new G4PVPlacement(0, G4ThreeVector(0, 0, -thickness_cell/2.0 + thickness_absorber/2.0),
                     logic_absorber,
                     name_absorber,
                     miniblock_logic,
                     0, 0, OverlapCheck());
 
-  new G4PVPlacement(0, G4ThreeVector(0, 0, (thickness_absorber)/ 2.),
+
+  new G4PVPlacement(0, G4ThreeVector(0, 0, thickness_cell/2.0 - thickness_scintillator/2.0),
                     logic_scint,
                     name_scintillator,
                     miniblock_logic,
                     0, 0, OverlapCheck());
 
+
+
+  G4LogicalVolume* single_tower_replica_logic = new G4LogicalVolume(single_tower_solid_replica,
+                                                            WorldMaterial,
+                                                            "single_tower_replica_logic",
+                                                            0, 0, 0);
   /* create replica within tower */
   std::string name_tower = m_TowerLogicNamePrefix;
-  new G4PVReplica(name_tower,miniblock_logic,single_tower_logic,
+  new G4PVReplica(name_tower,miniblock_logic,single_tower_replica_logic,
                       kZAxis,nlayers, thickness_layer,0);
 
-  GetDisplayAction()->AddVolume(single_tower_logic, "SingleTower");
+  GetDisplayAction()->AddVolume(single_tower_replica_logic, "SingleTower");
 
-  if (Verbosity() > 0)
-  {
-    std::cout << "PHG4ForwardEcalDetector: Building logical volume for single tower done." << std::endl;
-  }
-
-  return single_tower_logic;
-}
-
-G4LogicalVolume*
-PHG4ForwardEcalDetector::ConstructTowerType3_4_5_6(int type)
-{
-  if (Verbosity() > 0)
-  {
-    std::cout << "PHG4ForwardEcalDetector: Build logical volume for single tower type ..." << type << std::endl;
-  }
-
-  double tower_dx, tower_dy, tower_dz;
-  int num_fibers_x, num_fibers_y;
-  tower_dx = m_TowerDx[type];
-  tower_dy = m_TowerDy[type];
-  tower_dz = m_TowerDz[type];
-  switch (type)
-  {
-  case 3:
-    num_fibers_x = 10;
-    num_fibers_y = 10;
-    break;
-  case 4:
-    num_fibers_x = 9;
-    num_fibers_y = 10;
-    break;
-  case 5:
-    num_fibers_x = 10;
-    num_fibers_y = 9;
-    break;
-  case 6:
-    num_fibers_x = 9;
-    num_fibers_y = 9;
-    break;
-  default:
-    std::cout << "PHG4ForwardEcalDetector: Invalid tower type in ConstructTowerType3_4_5_6, stopping..." << std::endl;
-    return nullptr;
-  }
-
-  /* create logical volume for single tower */
-  recoConsts* rc = recoConsts::instance();
-  G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
-
-  std::string solidName = "single_tower_solid" + std::to_string(type);
-  G4VSolid* single_tower_solid = new G4Box(solidName,
-                                           tower_dx / 2.0,
-                                           tower_dy / 2.0,
-                                           tower_dz / 2.0);
-
-  std::string name_single_tower_logic = "single_tower_logic" + std::to_string(type);
-
-  G4LogicalVolume* single_tower_logic = new G4LogicalVolume(single_tower_solid,
-                                                            WorldMaterial,
-                                                            name_single_tower_logic,
-                                                            0, 0, 0);
-
-  // Now the absorber and then the fibers:
-
-  std::string absorberName = "single_absorber_solid" + std::to_string(type);
-  G4VSolid* single_absorber_solid = new G4Box(absorberName,
-                                              tower_dx / 2.0,
-                                              tower_dy / 2.0,
-                                              tower_dz / 2.0);
-
-  std::string absorberLogicName = "single_absorber_logic" + std::to_string(type);
-  ;
-  // E864 Pb-Scifi calorimeter
-  // E864 Calorimeter is 99% Pb, 1% Antimony
-  G4LogicalVolume* single_absorber_logic = new G4LogicalVolume(single_absorber_solid,
-                                                               G4Material::GetMaterial("E864_Absorber"),
-
-                                                               absorberLogicName,
-                                                               0, 0, 0);
-
-  /* create geometry volumes for scintillator and place inside single_tower */
-  // 1.1mm fibers
-
-  std::string fiberName = "single_fiber_scintillator_solid" + std::to_string(type);
-  G4VSolid* single_scintillator_solid = new G4Tubs(fiberName,
-                                                   0.0, 0.055 * cm, (tower_dz / 2.0), 0.0, CLHEP::twopi);
-
-  /* create logical volumes for scintillator and absorber plates to place inside single_tower */
-  G4Material* material_scintillator = G4Material::GetMaterial("G4_POLYSTYRENE");
-
-  std::string fiberLogicName = "hEcal_scintillator_fiber_logic" + std::to_string(type);
-  G4LogicalVolume* single_scintillator_logic = new G4LogicalVolume(single_scintillator_solid,
-                                                                   material_scintillator,
-                                                                   fiberLogicName,
-                                                                   0, 0, 0);
-  m_AbsorberLogicalVolSet.insert(single_absorber_logic);
-  m_ScintiLogicalVolSet.insert(single_scintillator_logic);
-  GetDisplayAction()->AddVolume(single_absorber_logic, "Absorber");
-  GetDisplayAction()->AddVolume(single_scintillator_logic, "Fiber");
-
-  // place array of fibers inside absorber
-
-  double fiber_unit_cell = 10.0 * cm / 47.0;
-  double xpos_i = -(tower_dx / 2.0) + (fiber_unit_cell / 2.0);
-  double ypos_i = -(tower_dy / 2.0) + (fiber_unit_cell / 2.0);
-  double zpos_i = 0.0;
-
-  std::string name_scintillator = m_TowerLogicNamePrefix + "_single_fiber_scintillator" + std::to_string(type);
-
-  for (int i = 0; i < num_fibers_x; i++)
-  {
-    for (int j = 0; j < num_fibers_y; j++)
-    {
-      new G4PVPlacement(0, G4ThreeVector(xpos_i + i * fiber_unit_cell, ypos_i + j * fiber_unit_cell, zpos_i),
-                        single_scintillator_logic,
-                        name_scintillator,
-                        single_absorber_logic,
-                        0, 0, OverlapCheck());
-    }
-  }
-
-  // Place the absorber inside the envelope
-
-  std::string name_absorber = m_TowerLogicNamePrefix + "_single_absorber" + std::to_string(type);
-
-  new G4PVPlacement(0, G4ThreeVector(0.0, 0.0, 0.0),
-                    single_absorber_logic,
-                    name_absorber,
+  new G4PVPlacement(0, G4ThreeVector(0, 0, (tower_readout_dz) / 2.0-clamp_plate_width),
+                    single_tower_replica_logic,
+                    "replicated_layers_placed",
                     single_tower_logic,
                     0, 0, OverlapCheck());
-  GetDisplayAction()->AddVolume(single_tower_logic, "SingleTower");
+
+  // place array of fibers inside absorber
+  if(nFibers>0 && nFibers==5 && fiber_diam>0){
+
+    std::string fiberName = "single_fiber_scintillator_solid" + std::to_string(type);
+    G4VSolid* single_scintillator_solid = new G4Tubs(fiberName,
+                                                    0.0, fiber_diam / 2.0, (m_TowerDz[2]+fiber_extra_length)/2 , 0.0, 2 * M_PI);
+
+    /* create logical volumes for scintillator and absorber plates to place inside single_tower */
+    G4Material* material_WLSFiber = GetWLSFiberFEMCMaterial();
+
+    std::string fiberLogicName = "hEcal_scintillator_fiber_logic" + std::to_string(type);
+    G4LogicalVolume* single_scintillator_logic = new G4LogicalVolume(single_scintillator_solid,
+                                                                    material_WLSFiber,
+                                                                    fiberLogicName,
+                                                                    0, 0, 0);
+    m_ScintiLogicalVolSet.insert(single_scintillator_logic);
+    GetDisplayAction()->AddVolume(single_scintillator_logic, "Fiber");
+
+    std::string name_scintillator = m_TowerLogicNamePrefix + "_single_fiber_scintillator" + std::to_string(type);
+
+    new G4PVPlacement(0, G4ThreeVector(0, 0, -fiber_extra_length/2+tower_readout_dz/2-clamp_plate_width),
+                      single_scintillator_logic,
+                      name_scintillator + "_center",
+                      single_tower_logic,
+                      0, 0, OverlapCheck());
+
+    new G4PVPlacement(0, G4ThreeVector(-m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0, -fiber_extra_length/2+tower_readout_dz/2-clamp_plate_width),
+                      single_scintillator_logic,
+                      name_scintillator + "_tl",
+                      single_tower_logic,
+                      0, 0, OverlapCheck());
+
+    new G4PVPlacement(0, G4ThreeVector(m_TowerDx[2] / 4.0 , -m_TowerDy[2] / 4.0, -fiber_extra_length/2+tower_readout_dz/2-clamp_plate_width),
+                      single_scintillator_logic,
+                      name_scintillator + "_bl",
+                      single_tower_logic,
+                      0, 0, OverlapCheck());
+
+    new G4PVPlacement(0, G4ThreeVector(m_TowerDx[2] / 4.0 , m_TowerDy[2] / 4.0, -fiber_extra_length/2+tower_readout_dz/2-clamp_plate_width),
+                      single_scintillator_logic,
+                      name_scintillator + "_tr",
+                      single_tower_logic,
+                      0, 0, OverlapCheck());
+
+    new G4PVPlacement(0, G4ThreeVector(-m_TowerDx[2] / 4.0 ,- m_TowerDy[2] / 4.0, -fiber_extra_length/2+tower_readout_dz/2-clamp_plate_width),
+                      single_scintillator_logic,
+                      name_scintillator + "_br",
+                      single_tower_logic,
+                      0, 0, OverlapCheck());
+
+  }
 
   if (Verbosity() > 0)
   {
@@ -519,6 +487,7 @@ int PHG4ForwardEcalDetector::PlaceTower(G4LogicalVolume* ecalenvelope, G4Logical
     G4LogicalVolume* singletower = singletowerIn[iterator->second.type];
     int copyno = (iterator->second.idx_j << 16) + iterator->second.idx_k;
 
+
     G4PVPlacement* tower_placement =
         new G4PVPlacement(0, G4ThreeVector(iterator->second.x, iterator->second.y, iterator->second.z),
                           singletower,
@@ -530,6 +499,131 @@ int PHG4ForwardEcalDetector::PlaceTower(G4LogicalVolume* ecalenvelope, G4Logical
   }
 
   return 0;
+}
+
+
+//_______________________________________________________________________
+G4Material* PHG4ForwardEcalDetector::GetScintillatorMaterial()
+{
+
+	G4double density;
+	G4int ncomponents;
+  G4Material* material_ScintFEMC = new G4Material("PolystyreneFEMC", density = 1.03 * g / cm3, ncomponents=2);
+  material_ScintFEMC->AddElement(G4Element::GetElement("C"), 8);
+  material_ScintFEMC->AddElement(G4Element::GetElement("H"), 8);
+
+  if(m_doLightProp){
+    const G4int ntab = 4;
+
+    G4double wls_Energy[] = { 2.00 * eV, 2.87 * eV, 2.90 * eV,
+                                        3.47 * eV };
+
+    G4double rIndexPstyrene[] = { 1.5, 1.5, 1.5, 1.5 };
+    G4double absorption1[]    = { 2. * cm, 2. * cm, 2. * cm, 2. * cm };
+    G4double scintilFast[]    = { 0.0, 0.0, 1.0, 1.0 };
+    G4MaterialPropertiesTable* fMPTPStyrene = new G4MaterialPropertiesTable();
+    fMPTPStyrene->AddProperty("RINDEX", wls_Energy, rIndexPstyrene,ntab);
+    fMPTPStyrene->AddProperty("ABSLENGTH", wls_Energy, absorption1,ntab);
+    fMPTPStyrene->AddProperty("SCINTILLATIONCOMPONENT1", wls_Energy, scintilFast,ntab);
+    fMPTPStyrene->AddConstProperty("SCINTILLATIONYIELD", 10. / keV);
+    fMPTPStyrene->AddConstProperty("RESOLUTIONSCALE", 1.0);
+    fMPTPStyrene->AddConstProperty("SCINTILLATIONTIMECONSTANT", 10. * ns);
+
+    material_ScintFEMC->SetMaterialPropertiesTable(fMPTPStyrene);
+  }
+  // Set the Birks Constant for the Polystyrene scintillator
+  material_ScintFEMC->GetIonisation()->SetBirksConstant(0.126 * mm / MeV);
+
+  return material_ScintFEMC;
+}
+
+//_______________________________________________________________________
+G4Material* PHG4ForwardEcalDetector::GetCoatingMaterial()
+{
+
+  //--------------------------------------------------
+  // TiO2
+  //--------------------------------------------------
+	G4double density,fractionmass;
+	G4int ncomponents;
+  G4Material* material_TiO2 = new G4Material("TiO2_FEMC", density = 1.52 * g / cm3, ncomponents=2);
+  material_TiO2->AddElement(G4Element::GetElement("Ti"), 1);
+  material_TiO2->AddElement(G4Element::GetElement("O"), 2);
+
+  //--------------------------------------------------
+  // Scintillator Coating - 15% TiO2 and 85% polystyrene by weight.
+  //--------------------------------------------------
+  //Coating_FEMC (Glass + Epoxy)
+  density = 1.86 * g / cm3;
+  G4Material *Coating_FEMC = new G4Material("Coating_FEMC", density, ncomponents = 2);
+  Coating_FEMC->AddMaterial(G4Material::GetMaterial("Epoxy"), fractionmass = 0.80);
+  Coating_FEMC->AddMaterial(material_TiO2, fractionmass = 0.20);
+
+  return Coating_FEMC;
+}
+
+//_____________________________________________________________________________
+void PHG4ForwardEcalDetector::SurfaceTable(G4LogicalVolume *vol) {
+
+  G4OpticalSurface *surface = new G4OpticalSurface("ScintWrapB1");
+
+  new G4LogicalSkinSurface("CrystalSurfaceL", vol, surface);
+
+  surface->SetType(dielectric_metal);
+  surface->SetFinish(polished);
+  surface->SetModel(glisur);
+
+  //crystal optical surface
+
+  //surface material
+  // const G4int ntab = 2;
+  // G4double opt_en[] = {1.551*eV, 3.545*eV}; // 350 - 800 nm
+  // G4double reflectivity[] = {0.8, 0.8};
+  // G4double efficiency[] = {0.9, 0.9};
+  G4MaterialPropertiesTable *surfmat = new G4MaterialPropertiesTable();
+  // surfmat->AddProperty("REFLECTIVITY", opt_en, reflectivity, ntab);
+  // surfmat->AddProperty("EFFICIENCY", opt_en, efficiency, ntab);
+  surface->SetMaterialPropertiesTable(surfmat);
+  //csurf->DumpInfo();
+
+}//SurfaceTable
+//_______________________________________________________________________
+G4Material* PHG4ForwardEcalDetector::GetWLSFiberFEMCMaterial()
+{
+  if (Verbosity() > 0)
+  {
+    std::cout << "PHG4ForwardEcalDetector: Making WLSFiberFEMC material..." << std::endl;
+  }
+
+	G4double density;
+	G4int ncomponents;
+
+  G4Material* material_WLSFiberFEMC = new G4Material("WLSFiberFEMC", density = 1.18 * g / cm3, ncomponents = 3);
+  material_WLSFiberFEMC->AddElement(G4Element::GetElement("C"), 5);
+  material_WLSFiberFEMC->AddElement(G4Element::GetElement("H"), 8);
+  material_WLSFiberFEMC->AddElement(G4Element::GetElement("O"), 2);
+  if(m_doLightProp){
+    const G4int ntab = 4;
+    G4double wls_Energy[] = { 2.00 * eV, 2.87 * eV, 2.90 * eV,
+                                        3.47 * eV };
+
+    G4double RefractiveIndexFiber[] = { 1.6, 1.6, 1.6, 1.6 };
+    G4double AbsFiber[]    = { 9.0 * m, 9.0 * m, 0.1 * mm, 0.1 * mm };
+    G4double EmissionFib[] = { 1.0, 1.0, 0.0, 0.0 };
+    // Add entries into properties table
+    G4MaterialPropertiesTable* mptWLSfiber = new G4MaterialPropertiesTable();
+    mptWLSfiber->AddProperty("RINDEX", wls_Energy, RefractiveIndexFiber,ntab);
+    mptWLSfiber->AddProperty("WLSABSLENGTH", wls_Energy, AbsFiber,ntab);
+    mptWLSfiber->AddProperty("WLSCOMPONENT", wls_Energy, EmissionFib,ntab);
+    mptWLSfiber->AddConstProperty("WLSTIMECONSTANT", 0.5 * ns);
+    material_WLSFiberFEMC->SetMaterialPropertiesTable(mptWLSfiber);
+  }
+  if (Verbosity() > 0)
+  {
+    std::cout << "PHG4ForwardEcalDetector:  Making WLSFiberFEMC material done." << std::endl;
+  }
+
+  return material_WLSFiberFEMC;
 }
 
 int PHG4ForwardEcalDetector::ParseParametersFromTable()
@@ -696,6 +790,22 @@ int PHG4ForwardEcalDetector::ParseParametersFromTable()
   parit = m_GlobalParameterMap.find("yoffset");
   if (parit != m_GlobalParameterMap.end())
     m_Params->set_double_param("yoffset", parit->second);  
+
+  parit = m_GlobalParameterMap.find("width_coating");
+  if (parit != m_GlobalParameterMap.end())
+    m_Params->set_double_param("width_coating", parit->second);  
+
+  parit = m_GlobalParameterMap.find("clamp_plate_width");
+  if (parit != m_GlobalParameterMap.end())
+    m_Params->set_double_param("clamp_plate_width", parit->second);  
+
+  parit = m_GlobalParameterMap.find("fiber_diam");
+  if (parit != m_GlobalParameterMap.end())
+    m_Params->set_double_param("fiber_diam", parit->second);  
+
+  parit = m_GlobalParameterMap.find("nFibers");
+  if (parit != m_GlobalParameterMap.end())
+    m_Params->set_int_param("nFibers", parit->second);  
 
   
   return 0;

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalDetector.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalDetector.h
@@ -5,8 +5,8 @@
 
 #include <g4main/PHG4Detector.h>
 
-#include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4Material.hh>
+#include <Geant4/G4SystemOfUnits.hh>
 
 #include <cassert>
 #include <map>
@@ -100,7 +100,7 @@ class PHG4ForwardEcalDetector : public PHG4Detector
 
   int get_Layer() const { return m_Layer; }
   int get_TowerType() const { return m_TowerType; }
-  
+
   PHG4ForwardEcalDisplayAction *GetDisplayAction() { return m_DisplayAction; }
 
  private:
@@ -109,9 +109,9 @@ class PHG4ForwardEcalDetector : public PHG4Detector
   G4LogicalVolume *ConstructTowerType3_4_5_6(int type);
   int PlaceTower(G4LogicalVolume *envelope, G4LogicalVolume *tower[6]);
   int ParseParametersFromTable();
-  G4Material* GetWLSFiberFEMCMaterial();
-  G4Material* GetScintillatorMaterial();
-  G4Material* GetCoatingMaterial();
+  G4Material *GetWLSFiberFEMCMaterial();
+  G4Material *GetScintillatorMaterial();
+  G4Material *GetCoatingMaterial();
   void SurfaceTable(G4LogicalVolume *vol);
   struct towerposition
   {
@@ -150,7 +150,7 @@ class PHG4ForwardEcalDetector : public PHG4Detector
   int m_AbsorberActiveFlag = 0;
   int m_Layer = 0;
   int m_TowerType = 0;
-  
+
   std::string m_SuperDetector = "NONE";
   std::string m_TowerLogicNamePrefix = "hEcalTower";
 

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalDetector.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalDetector.h
@@ -6,6 +6,7 @@
 #include <g4main/PHG4Detector.h>
 
 #include <Geant4/G4SystemOfUnits.hh>
+#include <Geant4/G4Material.hh>
 
 #include <cassert>
 #include <map>
@@ -43,6 +44,8 @@ class PHG4ForwardEcalDetector : public PHG4Detector
   int IsInForwardEcal(G4VPhysicalVolume *) const;
 
   void SetTowerDimensions(double dx, double dy, double dz, int type);
+
+  void DoFullLightProp(bool doProp) { m_doLightProp = doProp; }
 
   void SetPlace(double place_in_x, double place_in_y, double place_in_z)
   {
@@ -106,7 +109,10 @@ class PHG4ForwardEcalDetector : public PHG4Detector
   G4LogicalVolume *ConstructTowerType3_4_5_6(int type);
   int PlaceTower(G4LogicalVolume *envelope, G4LogicalVolume *tower[6]);
   int ParseParametersFromTable();
-
+  G4Material* GetWLSFiberFEMCMaterial();
+  G4Material* GetScintillatorMaterial();
+  G4Material* GetCoatingMaterial();
+  void SurfaceTable(G4LogicalVolume *vol);
   struct towerposition
   {
     double x;
@@ -168,6 +174,8 @@ class PHG4ForwardEcalDetector : public PHG4Detector
   std::map<std::string, double>::const_iterator FindIter(const std::string &name) { return m_GlobalParameterMap.find(name); }
   std::map<std::string, double>::const_iterator EndIter() { return m_GlobalParameterMap.end(); }
   void InsertParam(const std::string &parname, double parval) { m_GlobalParameterMap.insert(make_pair(parname, parval)); }
+
+  bool m_doLightProp;
 };
 
 #endif

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalDisplayAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalDisplayAction.cc
@@ -23,7 +23,6 @@ PHG4ForwardEcalDisplayAction::PHG4ForwardEcalDisplayAction(const std::string &na
   if (!detailed) std::cout << "PHG4ForwardEcalDisplayAction::disabled detailed view of towers" << std::endl;
 }
 
-
 PHG4ForwardEcalDisplayAction::~PHG4ForwardEcalDisplayAction()
 {
   for (auto &it : m_VisAttVec)
@@ -52,7 +51,7 @@ void PHG4ForwardEcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol
       visatt->SetColour(G4Colour::Gray());
       if (showdetails)
         visatt->SetVisibility(true);
-      else 
+      else
         visatt->SetVisibility(false);
     }
     else if (it.second == "Coating")
@@ -60,7 +59,7 @@ void PHG4ForwardEcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol
       visatt->SetColour(G4Colour::Black());
       if (showdetails)
         visatt->SetVisibility(true);
-      else 
+      else
         visatt->SetVisibility(false);
     }
     else if (it.second == "Clamp")
@@ -69,7 +68,7 @@ void PHG4ForwardEcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol
       // visatt->SetForceWireframe(true);
       if (showdetails)
         visatt->SetVisibility(true);
-      else 
+      else
         visatt->SetVisibility(false);
     }
     else if (it.second == "Envelope")
@@ -81,20 +80,20 @@ void PHG4ForwardEcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol
     else if (it.second == "Fiber")
     {
       // visatt->SetColour(G4Colour::Cyan());
-      visatt->SetColour(152./ 255,251./ 255,152./ 255, 0.4);
+      visatt->SetColour(152. / 255, 251. / 255, 152. / 255, 0.4);
       if (showdetails)
         visatt->SetVisibility(true);
-      else 
+      else
         visatt->SetVisibility(false);
     }
     else if (it.second == "Scintillator")
     {
       // visatt->SetColour(G4Colour::White());
       // visatt->SetColour(G4Colour::Cyan());
-      visatt->SetColour(127./ 255,255./ 255,212./ 255, 0.2);
+      visatt->SetColour(127. / 255, 255. / 255, 212. / 255, 0.2);
       if (showdetails)
         visatt->SetVisibility(true);
-      else 
+      else
         visatt->SetVisibility(false);
     }
     else if (it.second == "SingleTower")
@@ -104,7 +103,7 @@ void PHG4ForwardEcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol
       // visatt->SetForceWireframe(true);
       if (showdetails)
         visatt->SetVisibility(false);
-      else 
+      else
         visatt->SetVisibility(true);
     }
     else if (it.second == "miniblock")

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalDisplayAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalDisplayAction.cc
@@ -49,7 +49,24 @@ void PHG4ForwardEcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol
     m_VisAttVec.push_back(visatt);  // for later deletion
     if (it.second == "Absorber")
     {
-      visatt->SetColour(G4Colour::Cyan());
+      visatt->SetColour(G4Colour::Gray());
+      if (showdetails)
+        visatt->SetVisibility(true);
+      else 
+        visatt->SetVisibility(false);
+    }
+    else if (it.second == "Coating")
+    {
+      visatt->SetColour(G4Colour::Black());
+      if (showdetails)
+        visatt->SetVisibility(true);
+      else 
+        visatt->SetVisibility(false);
+    }
+    else if (it.second == "Clamp")
+    {
+      visatt->SetColour(4 * 21. / 255, 4 * 27. / 255, 4 * 31. / 255);
+      // visatt->SetForceWireframe(true);
       if (showdetails)
         visatt->SetVisibility(true);
       else 
@@ -59,11 +76,12 @@ void PHG4ForwardEcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol
     {
       visatt->SetColour(G4Colour::Magenta());
       visatt->SetVisibility(false);
-      visatt->SetForceSolid(false);
+      visatt->SetForceWireframe(true);
     }
     else if (it.second == "Fiber")
     {
-      visatt->SetColour(G4Colour::Cyan());
+      // visatt->SetColour(G4Colour::Cyan());
+      visatt->SetColour(152./ 255,251./ 255,152./ 255, 0.4);
       if (showdetails)
         visatt->SetVisibility(true);
       else 
@@ -71,7 +89,9 @@ void PHG4ForwardEcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol
     }
     else if (it.second == "Scintillator")
     {
-      visatt->SetColour(G4Colour::White());
+      // visatt->SetColour(G4Colour::White());
+      // visatt->SetColour(G4Colour::Cyan());
+      visatt->SetColour(127./ 255,255./ 255,212./ 255, 0.2);
       if (showdetails)
         visatt->SetVisibility(true);
       else 
@@ -79,7 +99,9 @@ void PHG4ForwardEcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol
     }
     else if (it.second == "SingleTower")
     {
-      visatt->SetColour(G4Colour::Cyan());
+      // visatt->SetColour(G4Colour::Cyan());
+      visatt->SetColour(4 * 21. / 255, 4 * 27. / 255, 4 * 31. / 255);
+      // visatt->SetForceWireframe(true);
       if (showdetails)
         visatt->SetVisibility(false);
       else 

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalSteppingAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalSteppingAction.cc
@@ -86,9 +86,8 @@ bool PHG4ForwardEcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool
   int idx_k = icopy & 0xFFFF;
 
   if (Verbosity() > 2)
-    std::cout << "\t" << icopy << "\t idx_j =" << idx_j << ", idx_k =" << idx_k <<"\t id:" << icopy << "\t type: " << towertype <<  std::endl;
+    std::cout << "\t" << icopy << "\t idx_j =" << idx_j << ", idx_k =" << idx_k << "\t id:" << icopy << "\t type: " << towertype << std::endl;
 
-  
   /* Get energy deposited by this step */
   double edep = aStep->GetTotalEnergyDeposit() / GeV;
   double eion = (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) / GeV;

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalSteppingAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalSteppingAction.cc
@@ -79,7 +79,7 @@ bool PHG4ForwardEcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool
 
   int layer_id = m_Detector->get_Layer();
   int towertype = m_Detector->get_TowerType();
-  unsigned int icopy = touch->GetVolume(2)->GetCopyNo();
+  unsigned int icopy = touch->GetVolume(3)->GetCopyNo();
   if (towertype != 2)
     icopy = touch->GetVolume(1)->GetCopyNo();
   int idx_j = icopy >> 16;

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalSubsystem.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalSubsystem.cc
@@ -56,6 +56,7 @@ int PHG4ForwardEcalSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
   {
     m_Detector = new PHG4ForwardEcalDetector(this, topNode, GetParams(), Name());
   }
+  m_Detector->DoFullLightProp(_do_lightpropagation);
 
   m_Detector->SuperDetector(SuperDetector());
   m_Detector->OverlapCheck(CheckOverlap());
@@ -130,6 +131,21 @@ PHG4Detector* PHG4ForwardEcalSubsystem::GetDetector(void) const
 
 void PHG4ForwardEcalSubsystem::SetDefaultParameters()
 {
+  set_default_int_param("nFibers", 0);
+  set_default_double_param("fiber_diam", 0.);
+  set_default_double_param("width_coating", 0.);
+  set_default_double_param("tower_readout_dz", 4.0);
+  set_default_double_param("clamp_plate_width", 0.0);
+  set_default_double_param("place_x", 0.);
+  set_default_double_param("place_y", 0.);
+  set_default_double_param("place_z", -108.);
+  set_default_double_param("rMin1", 2.2);
+  set_default_double_param("rMax1", 65.6);
+  set_default_double_param("rMin2", 2.6);
+  set_default_double_param("rMax2", 77.5);
+  set_default_double_param("rot_x", 0.);
+  set_default_double_param("rot_y", 180.);
+  set_default_double_param("rot_z", 0.);
   std::ostringstream mappingfilename;
   const char* calibroot = getenv("CALIBRATIONROOT");
   if (calibroot)

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalSubsystem.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalSubsystem.cc
@@ -46,7 +46,7 @@ int PHG4ForwardEcalSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
   PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create display settings before detector
-  m_DisplayAction = new PHG4ForwardEcalDisplayAction(Name(),showdetailed);
+  m_DisplayAction = new PHG4ForwardEcalDisplayAction(Name(), showdetailed);
   // create detector
   if (m_EICDetectorFlag)
   {

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalSubsystem.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalSubsystem.h
@@ -20,7 +20,7 @@ class PHG4ForwardEcalSubsystem : public PHG4DetectorSubsystem
    */
   PHG4ForwardEcalSubsystem(const std::string& name = "FORWARD_ECAL_DEFAULT", const int layer = 0);
 
-  void DoFullLightPropagation(bool doProp) {_do_lightpropagation = doProp;};
+  void DoFullLightPropagation(bool doProp) { _do_lightpropagation = doProp; };
 
   /** Destructor
    */
@@ -50,9 +50,8 @@ class PHG4ForwardEcalSubsystem : public PHG4DetectorSubsystem
 
   /** Set level of detail for display
    */
-  void SetDetailed(bool b){showdetailed = b;}
+  void SetDetailed(bool b) { showdetailed = b; }
 
-  
  private:
   void SetDefaultParameters();
 

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalSubsystem.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardEcalSubsystem.h
@@ -20,6 +20,8 @@ class PHG4ForwardEcalSubsystem : public PHG4DetectorSubsystem
    */
   PHG4ForwardEcalSubsystem(const std::string& name = "FORWARD_ECAL_DEFAULT", const int layer = 0);
 
+  void DoFullLightPropagation(bool doProp) {_do_lightpropagation = doProp;};
+
   /** Destructor
    */
   virtual ~PHG4ForwardEcalSubsystem();
@@ -68,6 +70,7 @@ class PHG4ForwardEcalSubsystem : public PHG4DetectorSubsystem
 
   int m_EICDetectorFlag = 0;
   bool showdetailed = false;
+  bool _do_lightpropagation = false;
 };
 
 #endif

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalDetector.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalDetector.cc
@@ -14,8 +14,8 @@
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4SubtractionSolid.hh>
 #include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
+#include <Geant4/G4SubtractionSolid.hh>
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4ThreeVector.hh>      // for G4ThreeVector
 #include <Geant4/G4Transform3D.hh>      // for G4Transform3D
@@ -98,18 +98,18 @@ void PHG4ForwardHcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
   recoConsts* rc = recoConsts::instance();
   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
 
-  G4VSolid *beampipe_cutout = new G4Cons("FHCAL_beampipe_cutout",
+  G4VSolid* beampipe_cutout = new G4Cons("FHCAL_beampipe_cutout",
                                          0, m_Params->get_double_param("rMin1") * cm,
                                          0, m_Params->get_double_param("rMin2") * cm,
                                          m_Params->get_double_param("dz") * cm / 2.0,
                                          0, 2 * M_PI);
-  G4VSolid *hcal_envelope_solid = new G4Cons("FHCAL_envelope_solid_cutout",
-                                            0, m_Params->get_double_param("rMax1") * cm,
-                                            0, m_Params->get_double_param("rMax2") * cm,
-                                            m_Params->get_double_param("dz") * cm / 2.0,
-                                            0, 2 * M_PI);
+  G4VSolid* hcal_envelope_solid = new G4Cons("FHCAL_envelope_solid_cutout",
+                                             0, m_Params->get_double_param("rMax1") * cm,
+                                             0, m_Params->get_double_param("rMax2") * cm,
+                                             m_Params->get_double_param("dz") * cm / 2.0,
+                                             0, 2 * M_PI);
   hcal_envelope_solid = new G4SubtractionSolid(G4String("FHCAL_envelope_solid"), hcal_envelope_solid, beampipe_cutout, 0, G4ThreeVector(m_Params->get_double_param("xoffset") * cm, m_Params->get_double_param("yoffset") * cm, 0.));
-  
+
   G4LogicalVolume* hcal_envelope_log = new G4LogicalVolume(hcal_envelope_solid, WorldMaterial, "hFHCAL_envelope", 0, 0, 0);
 
   m_DisplayAction->AddVolume(hcal_envelope_log, "FHcalEnvelope");
@@ -196,12 +196,13 @@ PHG4ForwardHcalDetector::ConstructTower()
   G4Material* material_wls = G4Material::GetMaterial(m_Params->get_string_param("scintillator"));
   G4Material* material_support = G4Material::GetMaterial(m_Params->get_string_param("support"));
 
-  if(m_Params->get_int_param("absorber_FeTungsten")==1){
+  if (m_Params->get_int_param("absorber_FeTungsten") == 1)
+  {
     G4double density;
     G4int natoms;
-    material_absorber = new G4Material("FeTungstenMix",  density =  10.1592*g/cm3, natoms=2);
-    material_absorber->AddMaterial(G4Material::GetMaterial("G4_Fe"), 80*perCent);  // Steel
-    material_absorber->AddMaterial(G4Material::GetMaterial("G4_W"),  20*perCent);  // Tungsten
+    material_absorber = new G4Material("FeTungstenMix", density = 10.1592 * g / cm3, natoms = 2);
+    material_absorber->AddMaterial(G4Material::GetMaterial("G4_Fe"), 80 * perCent);  // Steel
+    material_absorber->AddMaterial(G4Material::GetMaterial("G4_W"), 20 * perCent);   // Tungsten
   }
   G4LogicalVolume* logic_absorber = new G4LogicalVolume(solid_absorber,
                                                         material_absorber,
@@ -479,12 +480,11 @@ int PHG4ForwardHcalDetector::ParseParametersFromTable()
 
   parit = m_GlobalParameterMap.find("xoffset");
   if (parit != m_GlobalParameterMap.end())
-    m_Params->set_double_param("xoffset", parit->second);  
+    m_Params->set_double_param("xoffset", parit->second);
 
   parit = m_GlobalParameterMap.find("yoffset");
   if (parit != m_GlobalParameterMap.end())
-    m_Params->set_double_param("yoffset", parit->second);  
-  
+    m_Params->set_double_param("yoffset", parit->second);
 
   return 0;
 }

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalDisplayAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalDisplayAction.cc
@@ -51,9 +51,8 @@ void PHG4ForwardHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol
       visatt->SetColour(G4Colour::Gray());
       if (showdetails)
         visatt->SetVisibility(true);
-      else 
+      else
         visatt->SetVisibility(false);
-
     }
     else if (it.second == "FHcalEnvelope")
     {
@@ -64,7 +63,7 @@ void PHG4ForwardHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol
       visatt->SetColour(G4Colour::White());
       if (showdetails)
         visatt->SetVisibility(true);
-      else 
+      else
         visatt->SetVisibility(false);
     }
     else if (it.second == "WLSplate")
@@ -72,7 +71,7 @@ void PHG4ForwardHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol
       visatt->SetColour(G4Colour::Yellow());
       if (showdetails)
         visatt->SetVisibility(true);
-      else 
+      else
         visatt->SetVisibility(false);
     }
     else if (it.second == "SupportPlate")
@@ -80,7 +79,7 @@ void PHG4ForwardHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol
       visatt->SetColour(G4Colour::Gray());
       if (showdetails)
         visatt->SetVisibility(true);
-      else 
+      else
         visatt->SetVisibility(false);
     }
     else if (it.second == "SingleTower")
@@ -88,7 +87,7 @@ void PHG4ForwardHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol
       visatt->SetColour(G4Colour::Gray());
       if (showdetails)
         visatt->SetVisibility(false);
-      else 
+      else
         visatt->SetVisibility(true);
     }
     else

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalDisplayAction.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalDisplayAction.h
@@ -18,7 +18,7 @@ class PHG4ForwardHcalDisplayAction : public PHG4DisplayAction
  public:
   explicit PHG4ForwardHcalDisplayAction(const std::string &name);
   explicit PHG4ForwardHcalDisplayAction(const std::string &name, bool detailed);
-  
+
   virtual ~PHG4ForwardHcalDisplayAction();
 
   void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
@@ -28,7 +28,6 @@ class PHG4ForwardHcalDisplayAction : public PHG4DisplayAction
   std::map<G4LogicalVolume *, std::string> m_LogicalVolumeMap;
   std::vector<G4VisAttributes *> m_VisAttVec;
   bool showdetails = false;
-
 };
 
 #endif  // G4DETECTORS_PHG4FORWARDHCALDISPLAYACTION_H

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSteppingAction.cc
@@ -81,7 +81,7 @@ bool PHG4ForwardHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool
   unsigned int icopy = touch->GetVolume(1)->GetCopyNo();
   int idx_j = icopy >> 16;
   int idx_k = icopy & 0xFFFF;
-  
+
   /* Get energy deposited by this step */
   double edep = aStep->GetTotalEnergyDeposit() / GeV;
   double eion = (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) / GeV;

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSteppingAction.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSteppingAction.h
@@ -18,6 +18,7 @@ class PHParameters;
 
 class PHG4ForwardHcalSteppingAction : public PHG4SteppingAction
 {
+ using PHG4SteppingAction::SetHitNodeName;
  public:
   //! constructor
   PHG4ForwardHcalSteppingAction(PHG4ForwardHcalDetector*, const PHParameters* parameters);
@@ -27,7 +28,6 @@ class PHG4ForwardHcalSteppingAction : public PHG4SteppingAction
 
   //! stepping action
   bool UserSteppingAction(const G4Step*, bool) override;
-  ;
 
   //! reimplemented from base class
   void SetInterfacePointers(PHCompositeNode*) override;

--- a/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSubsystem.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4ForwardHcalSubsystem.h
@@ -48,11 +48,11 @@ class PHG4ForwardHcalSubsystem : public PHG4DetectorSubsystem
    */
   void SetTowerMappingFile(const std::string &filename);
 
-  void SetUseFeTungstenAbsorber(int useTungsten) {set_int_param("absorber_FeTungsten", 1); };
+  void SetUseFeTungstenAbsorber(int useTungsten) { set_int_param("absorber_FeTungsten", 1); };
 
   /** Set level of detail for display
    */
-  void SetDetailed(bool b){showdetailed = b;}
+  void SetDetailed(bool b) { showdetailed = b; }
 
  private:
   void SetDefaultParameters() override;
@@ -67,9 +67,9 @@ class PHG4ForwardHcalSubsystem : public PHG4DetectorSubsystem
   //! display attribute setting
   /*! derives from PHG4DisplayAction */
   PHG4DisplayAction *m_DisplayAction = nullptr;
-  
+
   bool showdetailed = false;
-  
+
   std::string m_HitNodeName;
   std::string m_AbsorberNodeName;
   std::string m_SupportNodeName;

--- a/simulation/g4simulation/g4eiccalos/PHG4HybridHomogeneousCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4HybridHomogeneousCalorimeterDetector.cc
@@ -12,22 +12,22 @@
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4Cons.hh>
 #include <Geant4/G4Element.hh>  // for G4Element
-#include <Geant4/G4LogicalVolume.hh>
-#include <Geant4/G4MaterialPropertiesTable.hh>
-#include <Geant4/G4OpticalSurface.hh>
 #include <Geant4/G4LogicalBorderSurface.hh>
 #include <Geant4/G4LogicalSkinSurface.hh>
+#include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
+#include <Geant4/G4MaterialPropertiesTable.hh>
+#include <Geant4/G4OpticalSurface.hh>
 #include <Geant4/G4PVPlacement.hh>
+#include <Geant4/G4Polyhedra.hh>       // for G4RotationMatrix
 #include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
-#include <Geant4/G4Polyhedra.hh>  // for G4RotationMatrix
 #include <Geant4/G4String.hh>          // for G4String
 #include <Geant4/G4SubtractionSolid.hh>
-#include <Geant4/G4UnionSolid.hh>
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
 #include <Geant4/G4Transform3D.hh>  // for G4Transform3D
 #include <Geant4/G4Types.hh>        // for G4double
+#include <Geant4/G4UnionSolid.hh>
 #include <Geant4/G4VisAttributes.hh>
 
 #include <TSystem.h>
@@ -78,7 +78,7 @@ int PHG4HybridHomogeneousCalorimeterDetector::IsInCrystalCalorimeter(G4VPhysical
 
 //_______________________________________________________________________
 void PHG4HybridHomogeneousCalorimeterDetector::ConstructMe(G4LogicalVolume* logicWorld)
-{  
+{
   if (Verbosity() > 0)
   {
     cout << "PHG4HybridHomogeneousCalorimeterDetector: Begin Construction" << endl;
@@ -101,43 +101,42 @@ void PHG4HybridHomogeneousCalorimeterDetector::ConstructMe(G4LogicalVolume* logi
 
   /* Place calorimeter tower within envelope */
   //  PlaceTower(eemc_envelope_log, singletower);
-  PlaceTower(logicWorld, singletower);//,support_frame);
+  PlaceTower(logicWorld, singletower);  //,support_frame);
 
   return;
 }
 //_______________________________________________________________________
-G4LogicalVolume* PHG4HybridHomogeneousCalorimeterDetector::ConstructSupportFrame(G4LogicalVolume *eemcenvelope)
+G4LogicalVolume* PHG4HybridHomogeneousCalorimeterDetector::ConstructSupportFrame(G4LogicalVolume* eemcenvelope)
 {
-  
   G4double frame_r_in = m_Params->get_double_param("rMin2") * cm;
   G4double frame_r_out = m_Params->get_double_param("rMax2") * cm;
   G4double frame_dz = m_Params->get_double_param("dz") * cm;
   G4double frame_z_pos = m_Params->get_double_param("place_z") * cm;
 
   G4int nSides = 12;
-  G4int nZSlices = 4;
-  G4double zPosSlice[nZSlices] = {0, 0.001, frame_dz-0.001, frame_dz};
+  const G4int nZSlices = 4;
+  G4double zPosSlice[nZSlices] = {0, 0.001, frame_dz - 0.001, frame_dz};
   G4double rinPosSlice[nZSlices] = {frame_r_in, frame_r_in, frame_r_in, frame_r_in};
   G4double routPosSlice[nZSlices] = {frame_r_out, frame_r_out, frame_r_out, frame_r_out};
 
-  G4VSolid* frame_full_solid = new G4Polyhedra( G4String("frame_full_solid"),
-                                                0,
-                                                2 * M_PI * rad,
-                                                nSides,
-                                                nZSlices,
-                                                zPosSlice,
-                                                rinPosSlice,
-                                                routPosSlice);
+  G4VSolid* frame_full_solid = new G4Polyhedra(G4String("frame_full_solid"),
+                                               0,
+                                               2 * M_PI * rad,
+                                               nSides,
+                                               nZSlices,
+                                               zPosSlice,
+                                               rinPosSlice,
+                                               routPosSlice);
   G4LogicalVolume* frame_full_logic = new G4LogicalVolume(frame_full_solid, G4Material::GetMaterial("G4_Fe"), "frame_full_logic", 0, 0, 0);
   GetDisplayAction()->AddVolume(frame_full_logic, "WIP");
 
-  G4RotationMatrix *rotFrame = new G4RotationMatrix();
+  G4RotationMatrix* rotFrame = new G4RotationMatrix();
   rotFrame->rotateZ(M_PI / 12);
-  new G4PVPlacement(rotFrame, G4ThreeVector(0,0,frame_z_pos - frame_dz/2),
-                  frame_full_logic,
-                  "frame_full_placed",
-                  eemcenvelope,
-                  0, 0, OverlapCheck());
+  new G4PVPlacement(rotFrame, G4ThreeVector(0, 0, frame_z_pos - frame_dz / 2),
+                    frame_full_logic,
+                    "frame_full_placed",
+                    eemcenvelope,
+                    0, 0, OverlapCheck());
 
   return frame_full_logic;
 }
@@ -145,7 +144,6 @@ G4LogicalVolume* PHG4HybridHomogeneousCalorimeterDetector::ConstructSupportFrame
 //_______________________________________________________________________
 G4LogicalVolume* PHG4HybridHomogeneousCalorimeterDetector::ConstructTower()
 {
-
   if (Verbosity() > 0)
   {
     cout << "PHG4HybridHomogeneousCalorimeterDetector: Build logical volume for single tower..." << endl;
@@ -162,23 +160,22 @@ G4LogicalVolume* PHG4HybridHomogeneousCalorimeterDetector::ConstructTower()
   G4double reflective_foil_thickness = m_Params->get_double_param("reflective_foil_thickness") * cm;
   G4double tedlar_thickness = m_Params->get_double_param("tedlar_thickness") * cm;
   bool doWrapping = false;
-  if(reflective_foil_thickness>0 || tedlar_thickness>0) doWrapping = true;
+  if (reflective_foil_thickness > 0 || tedlar_thickness > 0) doWrapping = true;
 
   G4int sensor_count = m_Params->get_int_param("sensor_count");
   G4double sensor_dimension = m_Params->get_double_param("sensor_dimension") * cm;
   G4double sensor_thickness = m_Params->get_double_param("sensor_thickness") * cm;
   bool doSensors = false;
-  if(sensor_dimension>0 && sensor_count>0 && sensor_thickness>0) doSensors = true;
+  if (sensor_dimension > 0 && sensor_count > 0 && sensor_thickness > 0) doSensors = true;
 
   G4double tower_dx = crystal_dx + 2 * (carbon_thickness + airgap_crystal_carbon + reflective_foil_thickness + tedlar_thickness);
   G4double tower_dy = crystal_dy + 2 * (carbon_thickness + airgap_crystal_carbon + reflective_foil_thickness + tedlar_thickness);
   G4double tower_dz = crystal_dz + 2 * (carbon_thickness);
-  if(doSensors) tower_dz = crystal_dz + 2 * (carbon_thickness) + sensor_thickness;
+  if (doSensors) tower_dz = crystal_dz + 2 * (carbon_thickness) + sensor_thickness;
   int carbon_frame_style = m_Params->get_int_param("carbon_frame_style");
 
   recoConsts* rc = recoConsts::instance();
   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
-
 
   /* create logical volume for single tower */
   // Building the single tower mother volume first
@@ -194,8 +191,9 @@ G4LogicalVolume* PHG4HybridHomogeneousCalorimeterDetector::ConstructTower()
                                       crystal_dy / 2.0,
                                       crystal_dz / 2.0);
 
-  G4Material *material_shell  = GetCarbonFiber();
-  if(carbon_frame_style==0 && carbon_thickness>0){
+  G4Material* material_shell = GetCarbonFiber();
+  if (carbon_frame_style == 0 && carbon_thickness > 0)
+  {
     /* create geometry volume for frame (carbon fiber shell) inside single_tower */
     G4VSolid* Carbon_hunk_solid = new G4Box(G4String("Carbon_hunk_solid"),
                                             tower_dx / 2.0,
@@ -218,58 +216,58 @@ G4LogicalVolume* PHG4HybridHomogeneousCalorimeterDetector::ConstructTower()
     // name_shell.str("");
     // name_shell << _towerlogicnameprefix << "_single_absorber";
     string name_shell = _towerlogicnameprefix + "_single_shell";
-    G4VPhysicalVolume* physvol_carbon = new G4PVPlacement(0, G4ThreeVector(0, 0, sensor_thickness/2), Carbon_shell_logic, name_shell, single_tower_logic, 0, 0, OverlapCheck());
+    G4VPhysicalVolume* physvol_carbon = new G4PVPlacement(0, G4ThreeVector(0, 0, sensor_thickness / 2), Carbon_shell_logic, name_shell, single_tower_logic, 0, 0, OverlapCheck());
     m_PassiveVolumeSet.insert(physvol_carbon);
-
-  } else if(carbon_frame_style==1){
+  }
+  else if (carbon_frame_style == 1)
+  {
     // the carbon spacers should go a few cm deep between the crystals
     G4double carbon_frame_depth = m_Params->get_double_param("carbon_frame_depth") * cm;
     G4VSolid* Carbon_hunk_solid = new G4Box(G4String("Carbon_hunk_solid"),
-                                                tower_dx / 2.0,
-                                                tower_dy / 2.0,
-                                                (carbon_frame_depth / 2.0));
+                                            tower_dx / 2.0,
+                                            tower_dy / 2.0,
+                                            (carbon_frame_depth / 2.0));
     G4VSolid* cutout_solid = new G4Box(G4String("cutout_solid"), (tower_dx - 2 * (carbon_thickness)) / 2.0, (tower_dy - 2 * (carbon_thickness)) / 2.0, crystal_dz);
 
     G4SubtractionSolid* Carbon_gap_solid = new G4SubtractionSolid(G4String("Carbon_gap_solid"),
-                                                                    Carbon_hunk_solid,
-                                                                    cutout_solid,
-                                                                    0,
-                                                                    G4ThreeVector(0.00 * mm, 0.00 * mm, 0.00 * mm));
+                                                                  Carbon_hunk_solid,
+                                                                  cutout_solid,
+                                                                  0,
+                                                                  G4ThreeVector(0.00 * mm, 0.00 * mm, 0.00 * mm));
     G4LogicalVolume* logic_gap = new G4LogicalVolume(Carbon_gap_solid, material_shell, "Carbon_gap_logic", 0, 0, 0);
     GetDisplayAction()->AddVolume(logic_gap, "CarbonShell");
 
-
     string name_gap = _towerlogicnameprefix + "_single_shell";
-    G4VPhysicalVolume* physvol_carbon_gap_front = new G4PVPlacement(0, G4ThreeVector(0, 0, tower_dz/2-carbon_frame_depth/2-carbon_thickness), logic_gap, name_gap + "_gap_front", single_tower_logic, 0, 0, OverlapCheck());
+    G4VPhysicalVolume* physvol_carbon_gap_front = new G4PVPlacement(0, G4ThreeVector(0, 0, tower_dz / 2 - carbon_frame_depth / 2 - carbon_thickness), logic_gap, name_gap + "_gap_front", single_tower_logic, 0, 0, OverlapCheck());
     m_PassiveVolumeSet.insert(physvol_carbon_gap_front);
-    G4VPhysicalVolume* physvol_carbon_gap_back = new G4PVPlacement(0, G4ThreeVector(0, 0, -tower_dz/2+carbon_frame_depth/2+carbon_thickness+sensor_thickness), logic_gap, name_gap + "_gap_back", single_tower_logic, 0, 0, OverlapCheck());
+    G4VPhysicalVolume* physvol_carbon_gap_back = new G4PVPlacement(0, G4ThreeVector(0, 0, -tower_dz / 2 + carbon_frame_depth / 2 + carbon_thickness + sensor_thickness), logic_gap, name_gap + "_gap_back", single_tower_logic, 0, 0, OverlapCheck());
     m_PassiveVolumeSet.insert(physvol_carbon_gap_back);
 
     G4double carbon_face_lip = m_Params->get_double_param("carbon_face_lip") * cm;
 
     G4VSolid* Carbon_hunk_solid_face = new G4Box(G4String("Carbon_hunk_solid_face"),
-                                                tower_dx / 2.0,
-                                                tower_dy / 2.0,
-                                                (carbon_thickness / 2.0));
+                                                 tower_dx / 2.0,
+                                                 tower_dy / 2.0,
+                                                 (carbon_thickness / 2.0));
     G4VSolid* cutout_solid_face = new G4Box(G4String("cutout_solid_face"), (tower_dx - 2.0 * carbon_face_lip) / 2.0, (tower_dy - 2.0 * carbon_face_lip) / 2.0, (tower_dz));
 
     G4SubtractionSolid* Carbon_face_solid = new G4SubtractionSolid(G4String("Carbon_face_solid"),
-                                                                    Carbon_hunk_solid_face,
-                                                                    cutout_solid_face,
-                                                                    0,
-                                                                    G4ThreeVector(0.00 * mm, 0.00 * mm, 0.00 * mm));
+                                                                   Carbon_hunk_solid_face,
+                                                                   cutout_solid_face,
+                                                                   0,
+                                                                   G4ThreeVector(0.00 * mm, 0.00 * mm, 0.00 * mm));
     G4LogicalVolume* logic_face = new G4LogicalVolume(Carbon_face_solid, material_shell, "Carbon_face_logic", 0, 0, 0);
     GetDisplayAction()->AddVolume(logic_face, "CarbonShell");
 
-
     string name_face = _towerlogicnameprefix + "_single_shell";
-    G4VPhysicalVolume* physvol_carbon_face_front = new G4PVPlacement(0, G4ThreeVector(0, 0, tower_dz/2-carbon_thickness/2), logic_face, name_face + "_face_front", single_tower_logic, 0, 0, OverlapCheck());
+    G4VPhysicalVolume* physvol_carbon_face_front = new G4PVPlacement(0, G4ThreeVector(0, 0, tower_dz / 2 - carbon_thickness / 2), logic_face, name_face + "_face_front", single_tower_logic, 0, 0, OverlapCheck());
     m_PassiveVolumeSet.insert(physvol_carbon_face_front);
-    G4VPhysicalVolume* physvol_carbon_face_back = new G4PVPlacement(0, G4ThreeVector(0, 0, -tower_dz/2+carbon_thickness/2+sensor_thickness), logic_face, name_face + "_face_back", single_tower_logic, 0, 0, OverlapCheck());
+    G4VPhysicalVolume* physvol_carbon_face_back = new G4PVPlacement(0, G4ThreeVector(0, 0, -tower_dz / 2 + carbon_thickness / 2 + sensor_thickness), logic_face, name_face + "_face_back", single_tower_logic, 0, 0, OverlapCheck());
     m_PassiveVolumeSet.insert(physvol_carbon_face_back);
   }
   // wrap towers in VM2000 and Tedlar foils if requested
-  if(doWrapping){
+  if (doWrapping)
+  {
     G4VSolid* VM2000_hunk_solid = new G4Box(G4String("VM2000_hunk_solid"),
                                             (crystal_dx + 2 * reflective_foil_thickness) / 2.0,
                                             (crystal_dy + 2 * reflective_foil_thickness) / 2.0,
@@ -278,16 +276,16 @@ G4LogicalVolume* PHG4HybridHomogeneousCalorimeterDetector::ConstructTower()
     G4VSolid* cutout_solid_VM2000 = new G4Box(G4String("cutout_solid_VM2000"), crystal_dx / 2.0, crystal_dy / 2.0, crystal_dz);
 
     G4SubtractionSolid* VM2000_foil_solid = new G4SubtractionSolid(G4String("VM2000_foil_solid"),
-                                                                    VM2000_hunk_solid,
-                                                                    cutout_solid_VM2000,
-                                                                    0,
-                                                                    G4ThreeVector(0.00 * mm, 0.00 * mm, 0.00 * mm));
+                                                                   VM2000_hunk_solid,
+                                                                   cutout_solid_VM2000,
+                                                                   0,
+                                                                   G4ThreeVector(0.00 * mm, 0.00 * mm, 0.00 * mm));
 
     G4LogicalVolume* VM2000_foil_logic = new G4LogicalVolume(VM2000_foil_solid, GetVM2000Material(), "VM2000_foil_logic", 0, 0, 0);
     GetDisplayAction()->AddVolume(VM2000_foil_logic, "VM2000");
 
     string name_VM2000foil = _towerlogicnameprefix + "_single_foil_VM2000";
-    G4VPhysicalVolume* physvol_VM2000 = new G4PVPlacement(0, G4ThreeVector(0, 0, sensor_thickness/2), VM2000_foil_logic, name_VM2000foil, single_tower_logic, 0, 0, OverlapCheck());
+    G4VPhysicalVolume* physvol_VM2000 = new G4PVPlacement(0, G4ThreeVector(0, 0, sensor_thickness / 2), VM2000_foil_logic, name_VM2000foil, single_tower_logic, 0, 0, OverlapCheck());
     m_PassiveVolumeSet.insert(physvol_VM2000);
 
     /* create geometry volume for frame (carbon fiber shell) inside single_tower */
@@ -299,33 +297,34 @@ G4LogicalVolume* PHG4HybridHomogeneousCalorimeterDetector::ConstructTower()
     G4VSolid* cutout_solid_Tedlar = new G4Box(G4String("cutout_solid_Tedlar"), (crystal_dx + 2 * reflective_foil_thickness) / 2.0, (crystal_dy + 2 * reflective_foil_thickness) / 2.0, crystal_dz);
 
     G4SubtractionSolid* Tedlar_foil_solid = new G4SubtractionSolid(G4String("Tedlar_foil_solid"),
-                                                                    Tedlar_hunk_solid,
-                                                                    cutout_solid_Tedlar,
-                                                                    0,
-                                                                    G4ThreeVector(0.00 * mm, 0.00 * mm, 0.00 * mm));
+                                                                   Tedlar_hunk_solid,
+                                                                   cutout_solid_Tedlar,
+                                                                   0,
+                                                                   G4ThreeVector(0.00 * mm, 0.00 * mm, 0.00 * mm));
 
     G4LogicalVolume* Tedlar_foil_logic = new G4LogicalVolume(Tedlar_foil_solid, GetTedlarMaterial(), "Tedlar_foil_logic", 0, 0, 0);
     GetDisplayAction()->AddVolume(Tedlar_foil_logic, "Tedlar");
 
     string name_Tedlarfoil = _towerlogicnameprefix + "_single_foil_Tedlar";
-    G4VPhysicalVolume* physvol_Tedlar = new G4PVPlacement(0, G4ThreeVector(0, 0, sensor_thickness/2), Tedlar_foil_logic, name_Tedlarfoil, single_tower_logic, 0, 0, OverlapCheck());
+    G4VPhysicalVolume* physvol_Tedlar = new G4PVPlacement(0, G4ThreeVector(0, 0, sensor_thickness / 2), Tedlar_foil_logic, name_Tedlarfoil, single_tower_logic, 0, 0, OverlapCheck());
     m_PassiveVolumeSet.insert(physvol_Tedlar);
-
   }
-  /* create logical volumes for crystal inside single_tower */  
+  /* create logical volumes for crystal inside single_tower */
   G4double M_para = m_Params->get_double_param("material");
   // set default material for hom calo
-  G4Material *material_Scin   = G4Material::GetMaterial("G4_PbWO4");
-  if(M_para>0) material_Scin  = GetScintillatorMaterial(M_para);
+  G4Material* material_Scin = G4Material::GetMaterial("G4_PbWO4");
+  if (M_para > 0) material_Scin = GetScintillatorMaterial(M_para);
 
-  if(m_doLightProp){
+  if (m_doLightProp)
+  {
     //scintillation and optical properties for the crystal
     CrystalTable(material_Scin);
   }
 
   G4LogicalVolume* logic_crystal = new G4LogicalVolume(solid_crystal, material_Scin, "single_crystal_logic", 0, 0, 0);
 
-  if(m_doLightProp){
+  if (m_doLightProp)
+  {
     //crystal optical surface
     SurfaceTable(logic_crystal);
   }
@@ -333,34 +332,34 @@ G4LogicalVolume* PHG4HybridHomogeneousCalorimeterDetector::ConstructTower()
 
   /* Place crystal in logical tower volume */
   string name_crystal = _towerlogicnameprefix + "_single_crystal";
-  G4VPhysicalVolume* physvol_crys = new G4PVPlacement(0, G4ThreeVector(0, 0, sensor_thickness/2), logic_crystal, name_crystal, single_tower_logic, 0, 0, OverlapCheck());
+  G4VPhysicalVolume* physvol_crys = new G4PVPlacement(0, G4ThreeVector(0, 0, sensor_thickness / 2), logic_crystal, name_crystal, single_tower_logic, 0, 0, OverlapCheck());
   m_ActiveVolumeSet.insert(physvol_crys);
 
-  if(doSensors){
-    G4VSolid *single_sensor_solid = new G4Box("single_sensor_solid", sensor_dimension/2., sensor_dimension/2., sensor_thickness/2.);
-    G4Material *material_Sensor = G4Material::GetMaterial("G4_Si");
+  if (doSensors)
+  {
+    G4VSolid* single_sensor_solid = new G4Box("single_sensor_solid", sensor_dimension / 2., sensor_dimension / 2., sensor_thickness / 2.);
+    G4Material* material_Sensor = G4Material::GetMaterial("G4_Si");
 
     G4LogicalVolume* single_sensor_logic = new G4LogicalVolume(single_sensor_solid, material_Sensor, "single_sensor_logic", 0, 0, 0);
     GetDisplayAction()->AddVolume(single_sensor_logic, "Sensor");
 
     string name_sensor = _towerlogicnameprefix + "_single_sensor";
 
-    G4VPhysicalVolume* physvol_sensor_0 = new G4PVPlacement(0, G4ThreeVector(0, 0, -tower_dz/2 +carbon_thickness + sensor_thickness/2), single_sensor_logic, name_sensor, single_tower_logic, 0, 0, OverlapCheck());
+    G4VPhysicalVolume* physvol_sensor_0 = new G4PVPlacement(0, G4ThreeVector(0, 0, -tower_dz / 2 + carbon_thickness + sensor_thickness / 2), single_sensor_logic, name_sensor, single_tower_logic, 0, 0, OverlapCheck());
     m_ActiveVolumeSet.insert(physvol_sensor_0);
-    if(m_doLightProp){
+    if (m_doLightProp)
+    {
       MakeBoundary(physvol_crys, physvol_sensor_0);
     }
   }
   if (Verbosity() > 0)
     cout << "PHG4HybridHomogeneousCalorimeterDetector: Building logical volume for single tower done." << endl;
-  
+
   return single_tower_logic;
 }
 
-
-int PHG4HybridHomogeneousCalorimeterDetector::PlaceTower(G4LogicalVolume* eemcenvelope, G4LogicalVolume* singletower)//, G4LogicalVolume* framelogic)
+int PHG4HybridHomogeneousCalorimeterDetector::PlaceTower(G4LogicalVolume* eemcenvelope, G4LogicalVolume* singletower)  //, G4LogicalVolume* framelogic)
 {
- 
   /* Loop over all tower positions in vector and place tower */
   typedef std::map<std::string, towerposition>::iterator it_type;
   for (it_type iterator = _map_tower.begin(); iterator != _map_tower.end(); ++iterator)
@@ -377,7 +376,6 @@ int PHG4HybridHomogeneousCalorimeterDetector::PlaceTower(G4LogicalVolume* eemcen
                       iterator->first,
                       eemcenvelope,
                       0, copyno, OverlapCheck());
-
   }
 
   return 0;
@@ -387,157 +385,154 @@ int PHG4HybridHomogeneousCalorimeterDetector::PlaceTower(G4LogicalVolume* eemcen
 G4Material*
 PHG4HybridHomogeneousCalorimeterDetector::GetScintillatorMaterial(float setting)
 {
+  G4Element* ele_O = new G4Element("Oxygen", "O", 8., 16.00 * g / mole);
+  G4Element* ele_Si = new G4Element("Silicon", "Si", 14., 28.09 * g / mole);
+  G4Element* ele_B = new G4Element("Boron", "B", 5., 10.811 * g / mole);
+  G4Element* ele_Na = new G4Element("Sodium", "Na", 11., 22.99 * g / mole);
+  G4Element* ele_Mg = new G4Element("Magnesium", "Mg", 12., 24.30 * g / mole);
+  G4Element* ele_Pb = new G4Element("Lead", "Pb", 82., 207.2 * g / mole);
+  G4Element* ele_Ba = new G4Element("Barium", "Ba", 56., 137.3 * g / mole);
+  G4Element* ele_Gd = new G4Element("Gadolinium", "Gd", 64., 157.3 * g / mole);
 
-  G4Element* ele_O = new G4Element("Oxygen", "O", 8., 16.00*g/mole);
-  G4Element* ele_Si = new G4Element("Silicon", "Si", 14., 28.09*g/mole);
-  G4Element* ele_B = new G4Element("Boron", "B", 5., 10.811*g/mole);
-  G4Element* ele_Na = new G4Element("Sodium", "Na", 11., 22.99*g/mole);
-  G4Element* ele_Mg = new G4Element("Magnesium", "Mg", 12., 24.30*g/mole);
-  G4Element* ele_Pb = new G4Element("Lead", "Pb", 82., 207.2*g/mole);
-  G4Element* ele_Ba = new G4Element("Barium", "Ba", 56., 137.3*g/mole);
-  G4Element* ele_Gd = new G4Element("Gadolinium", "Gd", 64., 157.3*g/mole);
-        
-  G4Material *material_Scin = G4Material::GetMaterial("G4_PbWO4");
+  G4Material* material_Scin = G4Material::GetMaterial("G4_PbWO4");
 
-  if( (setting > 0.) && (setting < 1.) )
-    {
-      material_Scin = G4Material::GetMaterial("G4_PbWO4");
-  // g4MatData.push_back(0.0333333*mm/MeV);
-      if (Verbosity()) cout << "Set G4_PbWO4..." << endl;
-    }
-  else if( (setting > 1.) && (setting < 2.) )
-    {
-      material_Scin = G4Material::GetMaterial("G4_GLASS_LEAD");
-      if (Verbosity()) cout << "Set G4_GLASS_LEAD..." << endl;      
-    }
-  else if( (setting > 2.) && (setting < 3.) )
-    {
-      material_Scin = G4Material::GetMaterial("G4_BARIUM_SULFATE");
-      if (Verbosity()) cout << "Set G4_BARIUM_SULFATE..." << endl;      
-    }
-  else if( (setting > 3.) && (setting < 4.) )
-    {
-      material_Scin = G4Material::GetMaterial("G4_CESIUM_IODIDE");
-      if (Verbosity()) cout << "Set G4_CESIUM_IODIDE..." << endl;      
-    }
-  else if( (setting > 4.) && (setting < 5.) )
-    {      
-      material_Scin = new G4Material("material_Scin", 4.5*g/cm3, 5);
-      material_Scin->AddElement(ele_Si, 21.9*perCent);
-      material_Scin->AddElement(ele_B, 8.8*perCent);
-      material_Scin->AddElement(ele_Na, 10.4*perCent);
-      material_Scin->AddElement(ele_Mg, 6.5*perCent);
-      material_Scin->AddElement(ele_O, 52.4*perCent);
+  if ((setting > 0.) && (setting < 1.))
+  {
+    material_Scin = G4Material::GetMaterial("G4_PbWO4");
+    // g4MatData.push_back(0.0333333*mm/MeV);
+    if (Verbosity()) cout << "Set G4_PbWO4..." << endl;
+  }
+  else if ((setting > 1.) && (setting < 2.))
+  {
+    material_Scin = G4Material::GetMaterial("G4_GLASS_LEAD");
+    if (Verbosity()) cout << "Set G4_GLASS_LEAD..." << endl;
+  }
+  else if ((setting > 2.) && (setting < 3.))
+  {
+    material_Scin = G4Material::GetMaterial("G4_BARIUM_SULFATE");
+    if (Verbosity()) cout << "Set G4_BARIUM_SULFATE..." << endl;
+  }
+  else if ((setting > 3.) && (setting < 4.))
+  {
+    material_Scin = G4Material::GetMaterial("G4_CESIUM_IODIDE");
+    if (Verbosity()) cout << "Set G4_CESIUM_IODIDE..." << endl;
+  }
+  else if ((setting > 4.) && (setting < 5.))
+  {
+    material_Scin = new G4Material("material_Scin", 4.5 * g / cm3, 5);
+    material_Scin->AddElement(ele_Si, 21.9 * perCent);
+    material_Scin->AddElement(ele_B, 8.8 * perCent);
+    material_Scin->AddElement(ele_Na, 10.4 * perCent);
+    material_Scin->AddElement(ele_Mg, 6.5 * perCent);
+    material_Scin->AddElement(ele_O, 52.4 * perCent);
 
-      if (Verbosity()) cout << "Set Sciglass..." << endl;
-    }
-  else if( (setting > 5.) && (setting < 6.) )
-    {
-      material_Scin = new G4Material("material_Scin", 9.0*g/cm3, 5);
-      material_Scin->AddElement(ele_Si, 21.9*perCent);
-      material_Scin->AddElement(ele_B, 8.8*perCent);
-      material_Scin->AddElement(ele_Na, 10.4*perCent);
-      material_Scin->AddElement(ele_Mg, 6.5*perCent);
-      material_Scin->AddElement(ele_O, 52.4*perCent);
+    if (Verbosity()) cout << "Set Sciglass..." << endl;
+  }
+  else if ((setting > 5.) && (setting < 6.))
+  {
+    material_Scin = new G4Material("material_Scin", 9.0 * g / cm3, 5);
+    material_Scin->AddElement(ele_Si, 21.9 * perCent);
+    material_Scin->AddElement(ele_B, 8.8 * perCent);
+    material_Scin->AddElement(ele_Na, 10.4 * perCent);
+    material_Scin->AddElement(ele_Mg, 6.5 * perCent);
+    material_Scin->AddElement(ele_O, 52.4 * perCent);
 
-      if (Verbosity()) cout << "Set heavier Sciglass..." << endl;
-    }
-  else if( (setting > 6.) && (setting < 7.) )
-    {
-      material_Scin = new G4Material("material_Scin", 4.5*g/cm3, 3);
-      material_Scin->AddElement(ele_Si, 21.9*perCent);
-      material_Scin->AddElement(ele_O, 52.4*perCent);
-      material_Scin->AddElement(ele_Pb, 25.7*perCent);
+    if (Verbosity()) cout << "Set heavier Sciglass..." << endl;
+  }
+  else if ((setting > 6.) && (setting < 7.))
+  {
+    material_Scin = new G4Material("material_Scin", 4.5 * g / cm3, 3);
+    material_Scin->AddElement(ele_Si, 21.9 * perCent);
+    material_Scin->AddElement(ele_O, 52.4 * perCent);
+    material_Scin->AddElement(ele_Pb, 25.7 * perCent);
 
-      if (Verbosity()) cout << "Set Sciglass contained lead..." << endl;
-    }
-  else if( (setting > 7.) && (setting < 8.) )
-    {
-      material_Scin = new G4Material("material_Scin", 4.22*g/cm3, 4);
-      material_Scin->AddElement(ele_O, 0.261);
-      material_Scin->AddElement(ele_Ba, 0.3875);
-      material_Scin->AddElement(ele_Si, 0.1369);
-      material_Scin->AddElement(ele_Gd, 0.2146);
+    if (Verbosity()) cout << "Set Sciglass contained lead..." << endl;
+  }
+  else if ((setting > 7.) && (setting < 8.))
+  {
+    material_Scin = new G4Material("material_Scin", 4.22 * g / cm3, 4);
+    material_Scin->AddElement(ele_O, 0.261);
+    material_Scin->AddElement(ele_Ba, 0.3875);
+    material_Scin->AddElement(ele_Si, 0.1369);
+    material_Scin->AddElement(ele_Gd, 0.2146);
 
-      if (Verbosity()) cout << "Set Sciglass from Nathaly" << endl;
-    }
-  else if( (setting > 8.) && (setting < 9.) )
-    {
-      material_Scin = new G4Material("material_Scin", 3.8*g/cm3, 3);
-      material_Scin->AddElement(ele_O, 0.293);
-      material_Scin->AddElement(ele_Ba, 0.502);
-      material_Scin->AddElement(ele_Si, 0.205);
+    if (Verbosity()) cout << "Set Sciglass from Nathaly" << endl;
+  }
+  else if ((setting > 8.) && (setting < 9.))
+  {
+    material_Scin = new G4Material("material_Scin", 3.8 * g / cm3, 3);
+    material_Scin->AddElement(ele_O, 0.293);
+    material_Scin->AddElement(ele_Ba, 0.502);
+    material_Scin->AddElement(ele_Si, 0.205);
 
-      if (Verbosity()) cout << "Set Sciglass from g4e" << endl;
-    }
-  
+    if (Verbosity()) cout << "Set Sciglass from g4e" << endl;
+  }
+
   return material_Scin;
 }
 
-
 //_____________________________________________________________________________
-void PHG4HybridHomogeneousCalorimeterDetector::CrystalTable(G4Material *mat) {
-
+void PHG4HybridHomogeneousCalorimeterDetector::CrystalTable(G4Material* mat)
+{
   //scintillation and optical properties
 
   //already done
-  if(mat->GetMaterialPropertiesTable()) return;
+  if (mat->GetMaterialPropertiesTable()) return;
 
   //G4cout << "OpTable::CrystalTable, " << mat->GetMaterialPropertiesTable() << G4endl;
 
   const G4int ntab = 2;
-  G4double scin_en[] = {2.9*eV, 3.*eV}; // 420 nm (the range is 414 - 428 nm)
+  G4double scin_en[] = {2.9 * eV, 3. * eV};  // 420 nm (the range is 414 - 428 nm)
   G4double scin_fast[] = {1., 1.};
 
-  G4MaterialPropertiesTable *tab = new G4MaterialPropertiesTable();
+  G4MaterialPropertiesTable* tab = new G4MaterialPropertiesTable();
 
   tab->AddProperty("FASTCOMPONENT", scin_en, scin_fast, ntab);
-  tab->AddConstProperty("FASTTIMECONSTANT", 6*ns);
-  tab->AddConstProperty("SCINTILLATIONYIELD", 200/MeV); // 200/MEV nominal  10
+  tab->AddConstProperty("FASTTIMECONSTANT", 6 * ns);
+  tab->AddConstProperty("SCINTILLATIONYIELD", 200 / MeV);  // 200/MEV nominal  10
   tab->AddConstProperty("RESOLUTIONSCALE", 1.);
 
-  G4double opt_en[] = {1.551*eV, 3.545*eV}; // 350 - 800 nm
+  G4double opt_en[] = {1.551 * eV, 3.545 * eV};  // 350 - 800 nm
   G4double opt_r[] = {2.4, 2.4};
-  G4double opt_abs[] = {200*cm, 200*cm};
+  G4double opt_abs[] = {200 * cm, 200 * cm};
 
   tab->AddProperty("RINDEX", opt_en, opt_r, ntab);
   tab->AddProperty("ABSLENGTH", opt_en, opt_abs, ntab);
 
   mat->SetMaterialPropertiesTable(tab);
 
-}//CrystalTable
+}  //CrystalTable
 
 //_____________________________________________________________________________
-void PHG4HybridHomogeneousCalorimeterDetector::SurfaceTable(G4LogicalVolume *vol) {
-
+void PHG4HybridHomogeneousCalorimeterDetector::SurfaceTable(G4LogicalVolume* vol)
+{
   //crystal optical surface
 
-  G4OpticalSurface *surface = new G4OpticalSurface("CrystalSurface", unified, polished, dielectric_metal);
-  //G4LogicalSkinSurface *csurf = 
+  G4OpticalSurface* surface = new G4OpticalSurface("CrystalSurface", unified, polished, dielectric_metal);
+  //G4LogicalSkinSurface *csurf =
   new G4LogicalSkinSurface("CrystalSurfaceL", vol, surface);
 
   //surface material
   const G4int ntab = 2;
-  G4double opt_en[] = {1.551*eV, 3.545*eV}; // 350 - 800 nm
+  G4double opt_en[] = {1.551 * eV, 3.545 * eV};  // 350 - 800 nm
   G4double reflectivity[] = {0.8, 0.8};
   G4double efficiency[] = {0.9, 0.9};
-  G4MaterialPropertiesTable *surfmat = new G4MaterialPropertiesTable();
+  G4MaterialPropertiesTable* surfmat = new G4MaterialPropertiesTable();
   surfmat->AddProperty("REFLECTIVITY", opt_en, reflectivity, ntab);
   surfmat->AddProperty("EFFICIENCY", opt_en, efficiency, ntab);
   surface->SetMaterialPropertiesTable(surfmat);
   //csurf->DumpInfo();
 
-}//SurfaceTable
-
+}  //SurfaceTable
 
 //_____________________________________________________________________________
-void PHG4HybridHomogeneousCalorimeterDetector::MakeBoundary(G4VPhysicalVolume *crystal, G4VPhysicalVolume *opdet) {
-
+void PHG4HybridHomogeneousCalorimeterDetector::MakeBoundary(G4VPhysicalVolume* crystal, G4VPhysicalVolume* opdet)
+{
   //optical boundary between the crystal and optical photons detector
 
-  G4OpticalSurface *surf = new G4OpticalSurface("OpDetS");
+  G4OpticalSurface* surf = new G4OpticalSurface("OpDetS");
   //surf->SetType(dielectric_dielectric); // photons go to the detector, must have rindex defined
-  surf->SetType(dielectric_metal); // photon is absorbed when reaching the detector, no material rindex required
+  surf->SetType(dielectric_metal);  // photon is absorbed when reaching the detector, no material rindex required
   //surf->SetFinish(ground);
   surf->SetFinish(polished);
   //surf->SetModel(unified);
@@ -546,26 +541,22 @@ void PHG4HybridHomogeneousCalorimeterDetector::MakeBoundary(G4VPhysicalVolume *c
   new G4LogicalBorderSurface("OpDetB", crystal, opdet, surf);
 
   const G4int ntab = 2;
-  G4double opt_en[] = {1.551*eV, 3.545*eV}; // 350 - 800 nm
+  G4double opt_en[] = {1.551 * eV, 3.545 * eV};  // 350 - 800 nm
   //G4double reflectivity[] = {0., 0.};
   G4double reflectivity[] = {0.1, 0.1};
   //G4double reflectivity[] = {0.9, 0.9};
   //G4double reflectivity[] = {1., 1.};
   G4double efficiency[] = {1., 1.};
 
-  G4MaterialPropertiesTable *surfmat = new G4MaterialPropertiesTable();
+  G4MaterialPropertiesTable* surfmat = new G4MaterialPropertiesTable();
   surfmat->AddProperty("REFLECTIVITY", opt_en, reflectivity, ntab);
   surfmat->AddProperty("EFFICIENCY", opt_en, efficiency, ntab);
   surf->SetMaterialPropertiesTable(surfmat);
 
-
-
-}//MakeBoundary
-
+}  //MakeBoundary
 
 G4Material* PHG4HybridHomogeneousCalorimeterDetector::GetTedlarMaterial()
 {
-    
   static string matname = "HybridHomogeneousTedlar";
   G4Material* tedlar = G4Material::GetMaterial(matname, false);  // false suppresses warning that material does not exist
   if (!tedlar)
@@ -579,10 +570,8 @@ G4Material* PHG4HybridHomogeneousCalorimeterDetector::GetTedlarMaterial()
   return tedlar;
 }
 
-
 G4Material* PHG4HybridHomogeneousCalorimeterDetector::GetVM2000Material()
 {
-    
   static string matname = "HybridHomogeneousVM2000";
   G4Material* VM2000 = G4Material::GetMaterial(matname, false);  // false suppresses warning that material does not exist
   if (!VM2000)
@@ -597,25 +586,23 @@ G4Material* PHG4HybridHomogeneousCalorimeterDetector::GetVM2000Material()
     const G4int nEntriesVM2000 = 31;
 
     G4double photonE_VM2000[nEntriesVM2000] =
-      { 1.37760*eV, 1.45864*eV, 1.54980*eV, 1.65312*eV, 1.71013*eV, 1.77120*eV, 1.83680*eV, 1.90745*eV, 1.98375*eV, 2.06640*eV, 2.10143*eV, 2.13766*eV, 2.17516*eV, 2.21400*eV, 2.25426*eV, 2.29600*eV, 2.33932*eV, 2.38431*eV, 2.43106*eV, 2.47968*eV, 2.53029*eV, 2.58300*eV, 2.63796*eV, 2.69531*eV, 2.75520*eV, 2.81782*eV, 2.88335*eV, 2.95200*eV, 3.09960*eV, 3.54241*eV, 4.13281*eV};
+        {1.37760 * eV, 1.45864 * eV, 1.54980 * eV, 1.65312 * eV, 1.71013 * eV, 1.77120 * eV, 1.83680 * eV, 1.90745 * eV, 1.98375 * eV, 2.06640 * eV, 2.10143 * eV, 2.13766 * eV, 2.17516 * eV, 2.21400 * eV, 2.25426 * eV, 2.29600 * eV, 2.33932 * eV, 2.38431 * eV, 2.43106 * eV, 2.47968 * eV, 2.53029 * eV, 2.58300 * eV, 2.63796 * eV, 2.69531 * eV, 2.75520 * eV, 2.81782 * eV, 2.88335 * eV, 2.95200 * eV, 3.09960 * eV, 3.54241 * eV, 4.13281 * eV};
     G4double refractiveIndex_VM2000[nEntriesVM2000] =
-      { 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42};
-    mptVM2000->AddProperty("RINDEX",photonE_VM2000,refractiveIndex_VM2000,nEntriesVM2000);
+        {1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42, 1.42};
+    mptVM2000->AddProperty("RINDEX", photonE_VM2000, refractiveIndex_VM2000, nEntriesVM2000);
 
     VM2000->SetMaterialPropertiesTable(mptVM2000);
-
   }
   return VM2000;
 }
-    // <material name="PolyvinylChloride">
-    //   <D value="1.3" unit="g/cm3"/>
-    //   <fraction n="0.04838" ref="H"/>
-    //   <fraction n="0.38436" ref="C"/>
-    //   <fraction n="0.56726" ref="Cl"/>
+// <material name="PolyvinylChloride">
+//   <D value="1.3" unit="g/cm3"/>
+//   <fraction n="0.04838" ref="H"/>
+//   <fraction n="0.38436" ref="C"/>
+//   <fraction n="0.56726" ref="Cl"/>
 
 int PHG4HybridHomogeneousCalorimeterDetector::ParseParametersFromTable()
 {
-
   /* Open the datafile, if it won't open return an error */
   ifstream istream_mapping(m_Params->get_string_param("mappingtower"));
   if (!istream_mapping.is_open())
@@ -786,7 +773,7 @@ int PHG4HybridHomogeneousCalorimeterDetector::ParseParametersFromTable()
   {
     m_Params->set_double_param("rot_y", parit->second * rad / deg);
   }
-  
+
   parit = _map_global_parameter.find("Grot_z");
   if (parit != _map_global_parameter.end())
   {
@@ -856,13 +843,12 @@ int PHG4HybridHomogeneousCalorimeterDetector::ParseParametersFromTable()
   {
     m_Params->set_double_param("sensor_thickness", parit->second);
   }
-  
+
   return 0;
 }
 
 G4Material* PHG4HybridHomogeneousCalorimeterDetector::GetCarbonFiber()
 {
-    
   static string matname = "HybridHomogeneousCarbonFiber";
   G4Material* carbonfiber = G4Material::GetMaterial(matname, false);  // false suppresses warning that material does not exist
   if (!carbonfiber)

--- a/simulation/g4simulation/g4eiccalos/PHG4HybridHomogeneousCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4HybridHomogeneousCalorimeterDetector.cc
@@ -164,7 +164,7 @@ G4LogicalVolume* PHG4HybridHomogeneousCalorimeterDetector::ConstructTower()
   bool doWrapping = false;
   if(reflective_foil_thickness>0 || tedlar_thickness>0) doWrapping = true;
 
-  G4int sensor_count = m_Params->get_int_param("sensor_count") * cm;
+  G4int sensor_count = m_Params->get_int_param("sensor_count");
   G4double sensor_dimension = m_Params->get_double_param("sensor_dimension") * cm;
   G4double sensor_thickness = m_Params->get_double_param("sensor_thickness") * cm;
   bool doSensors = false;

--- a/simulation/g4simulation/g4eiccalos/PHG4HybridHomogeneousCalorimeterDetector.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4HybridHomogeneousCalorimeterDetector.h
@@ -59,12 +59,12 @@ class PHG4HybridHomogeneousCalorimeterDetector : public PHG4Detector
   virtual int GetCaloType() const { return PHG4CrystalCalorimeterDefs::CaloType::nonprojective; }
 
  private:  // private stuff
-  G4LogicalVolume* ConstructSupportFrame(G4LogicalVolume *envelope);
+  G4LogicalVolume *ConstructSupportFrame(G4LogicalVolume *envelope);
   G4LogicalVolume *ConstructTower();
-  int PlaceTower(G4LogicalVolume *envelope, G4LogicalVolume *tower);//, G4LogicalVolume *support);
-  G4Material* GetScintillatorMaterial(float setting);
-  G4Material* GetTedlarMaterial();
-  G4Material* GetVM2000Material();
+  int PlaceTower(G4LogicalVolume *envelope, G4LogicalVolume *tower);  //, G4LogicalVolume *support);
+  G4Material *GetScintillatorMaterial(float setting);
+  G4Material *GetTedlarMaterial();
+  G4Material *GetVM2000Material();
   int ParseParametersFromTable();
   void CrystalTable(G4Material *mat);
   void SurfaceTable(G4LogicalVolume *vol);

--- a/simulation/g4simulation/g4eiccalos/PHG4HybridHomogeneousCalorimeterDisplayAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4HybridHomogeneousCalorimeterDisplayAction.cc
@@ -51,14 +51,14 @@ void PHG4HybridHomogeneousCalorimeterDisplayAction::ApplyDisplayAction(G4VPhysic
     else if (it.second == "Crystal")
     {
       visatt->SetColour(G4Colour::Cyan());
-      visatt->SetColour(127./ 255,255./ 255,212./ 255, 0.2);
+      visatt->SetColour(127. / 255, 255. / 255, 212. / 255, 0.2);
       visatt->SetForceSolid(true);
       // visatt->SetForceWireframe(true);
       // visatt->SetVisibility(false);
     }
     else if (it.second == "Sensor")
     {
-      visatt->SetColour(255./ 255,165./ 255,0./ 255, 0.2);
+      visatt->SetColour(255. / 255, 165. / 255, 0. / 255, 0.2);
       visatt->SetForceSolid(true);
       // visatt->SetForceWireframe(true);
       // visatt->SetVisibility(false);

--- a/simulation/g4simulation/g4eiccalos/PHG4HybridHomogeneousCalorimeterSteppingAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4HybridHomogeneousCalorimeterSteppingAction.cc
@@ -22,12 +22,12 @@
 #include <Geant4/G4StepStatus.hh>  // for fGeomBoundary, fAtRest...
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
+#include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
 #include <Geant4/G4Track.hh>                  // for G4Track
 #include <Geant4/G4TrackStatus.hh>            // for fStopAndKill
 #include <Geant4/G4Types.hh>                  // for G4double
 #include <Geant4/G4VPhysicalVolume.hh>        // for G4VPhysicalVolume
 #include <Geant4/G4VTouchable.hh>             // for G4VTouchable
-#include <Geant4/G4TouchableHandle.hh>                // for G4TouchableHandle
 #include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
 #include <TSystem.h>

--- a/simulation/g4simulation/g4eiccalos/PHG4HybridHomogeneousCalorimeterSubsystem.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4HybridHomogeneousCalorimeterSubsystem.h
@@ -50,7 +50,7 @@ class PHG4HybridHomogeneousCalorimeterSubsystem : public PHG4DetectorSubsystem
   void SetProjectiveGeometry(const std::string &filename1, const std::string &filename2);
   /** Select projective geometry for calorimeter
    */
-  void DoFullLightPropagation(bool doProp) {_do_lightpropagation = doProp;};
+  void DoFullLightPropagation(bool doProp) { _do_lightpropagation = doProp; };
 
  private:
   //! set detector specific parameters and their defaults

--- a/simulation/g4simulation/g4eiccalos/PHG4LFHcalDetector.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4LFHcalDetector.cc
@@ -11,9 +11,16 @@
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4Trap.hh>
+#include <Geant4/G4Torus.hh>
 #include <Geant4/G4Cons.hh>
+#include <Geant4/G4Tubs.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4SubtractionSolid.hh>
+#include <Geant4/G4ExtrudedSolid.hh>
+#include <Geant4/G4TwoVector.hh>
+#include <Geant4/G4OpticalSurface.hh>
+#include <Geant4/G4LogicalSkinSurface.hh>
+#include <Geant4/G4LogicalBorderSurface.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4PVReplica.hh>
@@ -47,6 +54,7 @@ PHG4LFHcalDetector::PHG4LFHcalDetector(PHG4Subsystem* subsys, PHCompositeNode* N
   , m_AbsorberActiveFlag(m_Params->get_int_param("absorberactive"))
   , m_TowerLogicNamePrefix("hHcalTower")
   , m_SuperDetector("NONE")
+  , m_doLightProp(false)
 {
   if (m_Params->get_string_param("mapping_file").empty())
   {
@@ -145,18 +153,25 @@ PHG4LFHcalDetector::ConstructTower()
   //**********************************************************************************************
   /* read variables from external inputs */
   //**********************************************************************************************
-  double TowerDx  = m_Params->get_double_param("tower_dx") * cm;
-  double TowerDy  = m_Params->get_double_param("tower_dy") * cm;
-  double TowerDz  = m_Params->get_double_param("tower_dz") * cm;
-  double WlsDw    = m_Params->get_double_param("wls_dw") * cm;
+  G4double TowerDx  = m_Params->get_double_param("tower_dx") * cm;
+  G4double TowerDy  = m_Params->get_double_param("tower_dy") * cm;
+  G4double TowerDz  = m_Params->get_double_param("tower_dz") * cm;
+  G4double WlsDw    = m_Params->get_double_param("wls_dw") * cm;
+  G4double thick_frame_width    = m_Params->get_double_param("frame_width") * cm;
+  G4double thin_frame_width    = 0;
+  if(thick_frame_width>0)
+    thin_frame_width    = 0.1 * mm;
+  // double width_coating    = m_Params->get_double_param("width_coating") * cm;
   G4double thickness_absorber     = m_Params->get_double_param("thickness_absorber") * cm;
   G4double thickness_scintillator = m_Params->get_double_param("thickness_scintillator") * cm;
   G4int nlayers                   = TowerDz / (thickness_absorber + thickness_scintillator);
-  G4Material* material_scintillator = G4Material::GetMaterial(m_Params->get_string_param("scintillator"));
+  G4Material* material_scintillator = GetScintillatorMaterial();//G4Material::GetMaterial(m_Params->get_string_param("scintillator"));
   G4Material* material_absorber     = G4Material::GetMaterial(m_Params->get_string_param("absorber"));
   G4Material* material_absorber_W     = G4Material::GetMaterial(m_Params->get_string_param("absorber_W"));
-  G4Material* material_wls          = G4Material::GetMaterial(m_Params->get_string_param("scintillator"));
-  
+  G4Material* material_wls          = GetWLSFiberMaterial();//G4Material::GetMaterial(m_Params->get_string_param("scintillator"));
+  int embed_fiber                 = m_Params->get_int_param("embed_fiber");
+  G4double fiber_thickness        = 0.2*mm;
+  // G4double fiber_thickness        = 1.0*mm;
   //**********************************************************************************************
   /* create logical volume for single tower */
   //**********************************************************************************************
@@ -172,13 +187,20 @@ PHG4LFHcalDetector::ConstructTower()
                                                             "single_tower_logic",
                                                             0, 0, 0);
 
+  G4double notch_length = 2.0*cm;
+  std::vector<G4TwoVector> poligon = {
+    {(-TowerDx)/2.0+thin_frame_width,(-TowerDy)/2.0+thick_frame_width},
+    {(-TowerDx)/2.0+thin_frame_width,(TowerDy)/2.0-thick_frame_width},
+    {(TowerDx - WlsDw)/2.0-thin_frame_width,(TowerDy)/2.0-thick_frame_width},
+    {(TowerDx - WlsDw)/2.0-thin_frame_width,(-TowerDy+notch_length)/2.0+thick_frame_width},
+    {(TowerDx)/2.0-thin_frame_width,(-TowerDy+notch_length)/2.0+thick_frame_width},
+    {(TowerDx)/2.0-thin_frame_width,(-TowerDy)/2.0+thick_frame_width}};
   //**********************************************************************************************
   /* create logical and geometry volumes for minitower read-out unit */
   //**********************************************************************************************
-  G4VSolid* miniblock_solid         = new G4Box("miniblock_solid",
-                                                (TowerDx - WlsDw) / 2.0,
-                                                (TowerDy ) / 2.0,
-                                                (thickness_absorber + thickness_scintillator) / 2.0);
+  std::vector< G4ExtrudedSolid::ZSection> zsections_miniblock = {{-(thickness_absorber + thickness_scintillator) / 2.0,{0,0},1.0}, {(thickness_absorber + thickness_scintillator) / 2.0, {0,0},1.}};
+  G4VSolid* miniblock_solid = new G4ExtrudedSolid("miniblock_solid", poligon, zsections_miniblock);
+
   G4LogicalVolume* miniblock_logic  = new G4LogicalVolume(miniblock_solid,
                                                           WorldMaterial,
                                                           "miniblock_logic",
@@ -192,15 +214,104 @@ PHG4LFHcalDetector::ConstructTower()
   //**********************************************************************************************
   /* create logical & geometry volumes for scintillator and absorber plates to place inside mini read-out unit */
   //**********************************************************************************************
-  G4VSolid* solid_absorber = new G4Box("single_plate_absorber_solid",
-                                       (TowerDx - WlsDw) / 2.0,
-                                       (TowerDy ) / 2.0,
-                                       thickness_absorber / 2.0);
+  std::vector< G4ExtrudedSolid::ZSection> zsections_scintillator = {{-thickness_scintillator/2,{0,0},1.0}, {thickness_scintillator/2, {0,0},1.}};
 
-  G4VSolid* solid_scintillator = new G4Box("single_plate_scintillator",
-                                           (TowerDx - WlsDw) / 2.0,
-                                           (TowerDy ) / 2.0,
-                                           thickness_scintillator / 2.0);
+  G4VSolid* solid_scintillator = new G4ExtrudedSolid("single_plate_scintillator", poligon, zsections_scintillator);
+
+  G4VPhysicalVolume* physvol_fiber_loop_0 = nullptr;
+  G4VPhysicalVolume* physvol_fiber_loop_1 = nullptr;
+  G4VPhysicalVolume* physvol_fiber_straight_1 = nullptr;
+  G4LogicalVolume* logic_embed_fiber_loop = nullptr;
+  G4LogicalVolume* logic_embed_fiber_loop_2 = nullptr;
+  G4LogicalVolume* logic_embed_fiber_straight_1 = nullptr;
+  G4double cutout_margin = 0.1*fiber_thickness;
+  G4double fiber_bending_R_1 = notch_length/2.0 - (TowerDy/2 - thick_frame_width - (0.9*(TowerDx - WlsDw - 2 * thin_frame_width)/2.0) - (2*cutout_margin));
+  G4double fiber_bending_R = 1.0*cm;
+  if(embed_fiber){
+    G4VSolid* solid_embed_fiber_loop = new G4Torus("solid_embed_fiber_loop",
+                                        0, fiber_thickness / 2.0,
+                                        (0.9*(TowerDx - WlsDw - 2 * thin_frame_width)/2.0) - (fiber_thickness + 2* cutout_margin)/2.0,
+                                        -0.4*M_PI, 1.9*M_PI);
+    G4VSolid* solid_embed_fiber_loop_2 = new G4Torus("solid_embed_fiber_loop_2",
+                                        0, fiber_thickness / 2.0,
+                                        (2*fiber_bending_R_1) / 2.0 - (fiber_thickness + 2* cutout_margin)/2.0,
+                                        -0.5*M_PI, 0.5*M_PI);
+    G4VSolid* solid_embed_fiber_straight_1 = new G4Tubs("solid_embed_fiber_straight_1",
+                                            0,
+                                            fiber_thickness/2.0 ,
+                                            // (TowerDx/2.0 - fiber_bending_R_1 - thin_frame_width) / 2.0,
+                                            ((TowerDx - WlsDw+fiber_thickness)/2.0-(fiber_bending_R_1))/2.0,
+                                            0, 2.0*M_PI);
+    solid_scintillator = new G4SubtractionSolid(G4String("single_plate_scintillator_cu"),
+                solid_scintillator, solid_embed_fiber_loop,
+                0, G4ThreeVector(0, 0, -thickness_scintillator/2+(fiber_thickness+cutout_margin) / 2.0));
+    solid_scintillator = new G4SubtractionSolid(G4String("single_plate_scintillator_cu2"),
+                solid_scintillator, solid_embed_fiber_loop_2,
+                0, G4ThreeVector((TowerDx - WlsDw+fiber_thickness/2.0)/2.0-(fiber_bending_R_1)+(thin_frame_width)+cutout_margin, -0.9*(TowerDx - WlsDw - thin_frame_width)/2.0+(fiber_bending_R_1), -thickness_scintillator/2+(fiber_thickness+cutout_margin) / 2.0));
+    G4RotationMatrix* wls_rotm_fibrcu = new G4RotationMatrix();
+    wls_rotm_fibrcu->rotateY(90 * deg);
+    solid_scintillator = new G4SubtractionSolid(G4String("single_plate_scintillator_cu3"),
+                solid_scintillator, solid_embed_fiber_straight_1,
+                wls_rotm_fibrcu, G4ThreeVector(
+                  ((TowerDx - WlsDw+fiber_thickness)/2.0-(fiber_bending_R_1))/2.0,//(TowerDx/2-((TowerDx - WlsDw+fiber_thickness/2.0)/2.0-(fiber_bending_R_1)+(thin_frame_width)+cutout_margin))/2+fiber_bending_R_1/2+(fiber_thickness),
+                  -0.9*(TowerDx - WlsDw - thin_frame_width)/2.0+ (fiber_thickness + 2* cutout_margin)/2.0,
+                  -thickness_scintillator/2+(fiber_thickness+cutout_margin) / 2.0));
+    logic_embed_fiber_loop = new G4LogicalVolume(solid_embed_fiber_loop,
+                                                        material_wls, "logic_embed_fiber_loop",
+                                                        0, 0, 0);
+    logic_embed_fiber_loop_2 = new G4LogicalVolume(solid_embed_fiber_loop_2,
+                                                        material_wls, "logic_embed_fiber_loop_2",
+                                                        0, 0, 0);
+    logic_embed_fiber_straight_1 = new G4LogicalVolume(solid_embed_fiber_straight_1,
+                                                        material_wls, "logic_embed_fiber_straight_1",
+                                                        0, 0, 0);
+    // if(m_doLightProp){
+    //   SurfaceTable(logic_embed_fiber_loop);
+    //   SurfaceTable(logic_embed_fiber_loop_2);
+    //   SurfaceTable(logic_embed_fiber_straight_1);
+    // }
+    physvol_fiber_loop_0 = new G4PVPlacement(0, G4ThreeVector(0, 0, (thickness_absorber)/ 2.-thickness_scintillator/2+(fiber_thickness+cutout_margin) / 2.0),
+                    logic_embed_fiber_loop,
+                    "embed_fiber_loop_placed",
+                    miniblock_logic,
+                    0, 0, OverlapCheck());
+    physvol_fiber_loop_1 = new G4PVPlacement(0, G4ThreeVector(
+      // (TowerDx - WlsDw+fiber_thickness/2.0)/2.0-(fiber_bending_R_1),
+      (TowerDx - WlsDw+fiber_thickness/2.0)/2.0-(fiber_bending_R_1)+(thin_frame_width)+cutout_margin,
+      // (TowerDx)/2.0-(fiber_bending_R_1) - thin_frame_width,
+      -0.9*(TowerDx - WlsDw - thin_frame_width)/2.0+(fiber_bending_R_1),
+      (thickness_absorber)/ 2.-thickness_scintillator/2+(fiber_thickness+cutout_margin) / 2.0),
+                    logic_embed_fiber_loop_2,
+                    "embed_fiber_loop_2_placed",
+                    miniblock_logic,
+                    0, 0, OverlapCheck());
+    G4RotationMatrix* wls_rotm_fibr = new G4RotationMatrix();
+    wls_rotm_fibr->rotateY(90 * deg);
+    physvol_fiber_straight_1 = new G4PVPlacement(wls_rotm_fibr, G4ThreeVector(
+      // (TowerDx/2.0 - fiber_bending_R_1 - thin_frame_width) / 2.0,
+      ((TowerDx - WlsDw+fiber_thickness)/2.0-(fiber_bending_R_1))/2.0,
+      // (TowerDx/2-((TowerDx - WlsDw+fiber_thickness/2.0)/2.0-(fiber_bending_R_1)+(thin_frame_width)+cutout_margin))/2,
+      -0.9*(TowerDx - WlsDw - thin_frame_width)/2.0+ (fiber_thickness + 2* cutout_margin)/2.0,
+      (thickness_absorber)/ 2.-thickness_scintillator/2+(fiber_thickness+cutout_margin) / 2.0),
+                    logic_embed_fiber_straight_1,
+                    "embed_fiber_straight_1_placed",
+                    miniblock_logic,
+                    0, 0, OverlapCheck());
+    if(m_doLightProp){
+      MakeBoundary(physvol_fiber_loop_0, physvol_fiber_loop_1,true);
+      MakeBoundary(physvol_fiber_loop_1, physvol_fiber_straight_1,true);
+    }
+    m_DisplayAction->AddVolume(logic_embed_fiber_loop, "WLSfiber");
+    m_DisplayAction->AddVolume(logic_embed_fiber_loop_2, "WLSfiber");
+    m_DisplayAction->AddVolume(logic_embed_fiber_straight_1, "WLSfiber");
+  }
+  // G4VSolid* solid_absorber = new G4Box("single_plate_absorber_solid",
+  //                                      (TowerDx - WlsDw) / 2.0,
+  //                                      (TowerDy ) / 2.0,
+  //                                      thickness_absorber / 2.0);
+
+  std::vector< G4ExtrudedSolid::ZSection> zsections_absorber = {{-thickness_absorber/2,{0,0},1.0}, {thickness_absorber/2, {0,0},1.}};
+  G4VSolid* solid_absorber = new G4ExtrudedSolid("single_plate_absorber_solid", poligon, zsections_absorber);
   G4LogicalVolume* logic_absorber = new G4LogicalVolume(solid_absorber,
                                                         material_absorber,
                                                         "single_plate_absorber_logic",
@@ -216,6 +327,9 @@ PHG4LFHcalDetector::ConstructTower()
                                                      "hLFHCAL_scintillator_plate_logic",
                                                      0, 0, 0);
   m_ScintiLogicalVolSet.insert(logic_scint);
+  // if(m_doLightProp){
+  //   SurfaceTable(logic_scint);
+  // }
   m_DisplayAction->AddVolume(logic_absorber, "Absorber");
   m_DisplayAction->AddVolume(logic_absorber_W, "Absorber_W");
   m_DisplayAction->AddVolume(logic_scint, "Scintillator");
@@ -229,12 +343,16 @@ PHG4LFHcalDetector::ConstructTower()
                     miniblock_logic,
                     0, 0, OverlapCheck());
 
-  new G4PVPlacement(0, G4ThreeVector(0, 0, (thickness_absorber)/ 2.),
+  G4VPhysicalVolume* scintillator_placed = new G4PVPlacement(0, G4ThreeVector(0, 0, (thickness_absorber)/ 2.),
                     logic_scint,
                     name_scintillator,
                     miniblock_logic,
                     0, 0, OverlapCheck());
-
+  if(m_doLightProp && embed_fiber){
+    MakeBoundary_Fiber_Scint(physvol_fiber_loop_0, scintillator_placed);
+    MakeBoundary_Fiber_Scint(physvol_fiber_loop_1, scintillator_placed);
+    MakeBoundary_Fiber_Scint(physvol_fiber_straight_1, scintillator_placed);
+  }
   // place Tungsten absorber and scintillator in a separate miniblock
   new G4PVPlacement(0, G4ThreeVector(0, 0, -thickness_scintillator/2),
                     logic_absorber_W,
@@ -247,35 +365,81 @@ PHG4LFHcalDetector::ConstructTower()
                     name_scintillator,
                     miniblock_W_logic,
                     0, 0, OverlapCheck());
-
-  
+  if(embed_fiber){
+    G4VPhysicalVolume* physvol_fiber_loop_W_0 = new G4PVPlacement(0, G4ThreeVector(0, 0, (thickness_absorber)/ 2.-thickness_scintillator/2+(fiber_thickness+cutout_margin) / 2.0),
+                    logic_embed_fiber_loop,
+                    "embed_fiber_loop_W_placed",
+                    miniblock_W_logic,
+                    0, 0, OverlapCheck());
+    G4VPhysicalVolume* physvol_fiber_loop_W_1 = new G4PVPlacement(0, G4ThreeVector(
+      (TowerDx - WlsDw+fiber_thickness/2.0)/2.0-(fiber_bending_R_1)+(thin_frame_width)+cutout_margin,
+      // (TowerDx)/2.0-(fiber_bending_R_1) - thin_frame_width,
+      -0.9*(TowerDx - WlsDw - thin_frame_width)/2.0+(fiber_bending_R_1),
+      (thickness_absorber)/ 2.-thickness_scintillator/2+(fiber_thickness+cutout_margin) / 2.0),
+                    logic_embed_fiber_loop_2,
+                    "embed_fiber_loop_W_2_placed",
+                    miniblock_W_logic,
+                    0, 0, OverlapCheck());
+    G4RotationMatrix* wls_rotm_fibr = new G4RotationMatrix();
+    wls_rotm_fibr->rotateY(90 * deg);
+    G4VPhysicalVolume* physvol_fiber_loop_W_2 = new G4PVPlacement(wls_rotm_fibr, G4ThreeVector(
+      ((TowerDx - WlsDw+fiber_thickness)/2.0-(fiber_bending_R_1))/2.0,
+      // (TowerDx/2-((TowerDx - WlsDw+fiber_thickness/2.0)/2.0-(fiber_bending_R_1)+(thin_frame_width)+cutout_margin))/2,
+      -0.9*(TowerDx - WlsDw - thin_frame_width)/2.0+ (fiber_thickness + 2* cutout_margin)/2.0,
+      (thickness_absorber)/ 2.-thickness_scintillator/2+(fiber_thickness+cutout_margin) / 2.0),
+                    logic_embed_fiber_straight_1,
+                    "embed_fiber_straight_W_1_placed",
+                    miniblock_W_logic,
+                    0, 0, OverlapCheck());
+    if(m_doLightProp){
+      MakeBoundary(physvol_fiber_loop_W_0, physvol_fiber_loop_W_1,true);
+      MakeBoundary(physvol_fiber_loop_W_1, physvol_fiber_loop_W_2,true);
+    }
+  }
   //**********************************************************************************************
   /* create wavelength shifting "fiber-block"  */
   //**********************************************************************************************
-//     G4VSolid* solid_WLS_plate = new G4Trap("single_plate_wls", 
-//                                              TowerDz / 2.0 /*pDz*/, 0.*degree /*pTheta*/, 40.*degree /*pPhi*/, 
-//                                             WlsDw/2 /*pDy1*/, WlsDw/2.0 /*pDx1*/, WlsDw/2.0 /*pDx2*/, 0.*degree /*pAlp1*/,
-//                                              TowerDy / 2.0 /*pDy2*/, WlsDw/2.0 /*pDx3*/, WlsDw/2.0 /*pDx4*/, 0.*degree  /*pAlp2*/);
+  if(thin_frame_width>0){
+    G4Material* material_frame = G4Material::GetMaterial("G4_Fe");
 
-  G4VSolid* solid_WLS_plate = new G4Trap("single_plate_wls", 
-                                          WlsDw, TowerDz, TowerDx,  WlsDw);
-  G4LogicalVolume* logic_wls = new G4LogicalVolume(solid_WLS_plate,
-                                                   material_wls,
-                                                   "hLFHCAL_wls_plate_logic",
-                                                   0, 0, 0);  
-  m_DisplayAction->AddVolume(logic_wls, "WLSplate");
-  G4RotationMatrix wls_rotm;
-  wls_rotm.rotateX(90 * deg);
-  wls_rotm.rotateY(-180 * deg);
-  wls_rotm.rotateZ(90 * deg);
+    G4VSolid* solid_frame_plate = new G4Box("single_plate_frame", 
+                                            (thin_frame_width)/2, (TowerDy-2*thick_frame_width)/2, TowerDz/2);
+    G4LogicalVolume* logic_frame = new G4LogicalVolume(solid_frame_plate,
+                                                    material_frame,
+                                                    "hLFHCAL_frame_plate_logic",
+                                                    0, 0, 0);  
+    m_DisplayAction->AddVolume(logic_frame, "Frame");
 
-  string name_wls = m_TowerLogicNamePrefix + "_single_plate_wls";
-  new G4PVPlacement(G4Transform3D(wls_rotm, G4ThreeVector((TowerDy-WlsDw)/2, (TowerDx+WlsDw)/4-WlsDw/2, 0.)),
-                    logic_wls,
-                    name_wls,
-                    single_tower_logic,
-                    0, 0, OverlapCheck());
-  
+    new G4PVPlacement(0, G4ThreeVector(-TowerDx/2+thin_frame_width/2, 0, 0.),
+                      logic_frame,
+                      m_TowerLogicNamePrefix + "_single_plate_frame_left",
+                      single_tower_logic,
+                      0, 0, OverlapCheck());
+    new G4PVPlacement(0, G4ThreeVector(TowerDx/2-thin_frame_width/2, 0, 0.),
+                      logic_frame,
+                      m_TowerLogicNamePrefix + "_single_plate_frame_right",
+                      single_tower_logic,
+                      0, 0, OverlapCheck());
+
+    G4VSolid* solid_cover_plate = new G4Box("single_plate_cover", 
+                                            TowerDx/2, thick_frame_width/2, TowerDz/2);
+    G4LogicalVolume* logic_cover = new G4LogicalVolume(solid_cover_plate,
+                                                    material_frame,
+                                                    "hLFHCAL_cover_plate_logic",
+                                                    0, 0, 0);  
+    m_DisplayAction->AddVolume(logic_cover, "Frame");
+
+    new G4PVPlacement(0, G4ThreeVector(0, -TowerDy/2+thick_frame_width/2, 0.),
+                      logic_cover,
+                      m_TowerLogicNamePrefix + "_single_plate_cover_top",
+                      single_tower_logic,
+                      0, 0, OverlapCheck());
+    new G4PVPlacement(0, G4ThreeVector(0, TowerDy/2-thick_frame_width/2, 0.),
+                      logic_cover,
+                      m_TowerLogicNamePrefix + "_single_plate_cover_bottom",
+                      single_tower_logic,
+                      0, 0, OverlapCheck());
+  }
   
   
   //**********************************************************************************************
@@ -292,10 +456,9 @@ PHG4LFHcalDetector::ConstructTower()
     WTowerLength = 10*(thickness_absorber+thickness_scintillator);
     std::cout << "using 10 layer tungsten tailcatcher in LFHCAL" << std::endl;
   }
-  G4VSolid* single_tower_solidRep = new G4Box("single_tower_solidRep",
-                                          (TowerDx - WlsDw) / 2.0,
-                                          TowerDy / 2.0,
-                                          SteelTowerLength / 2.0);
+
+  std::vector< G4ExtrudedSolid::ZSection> zsections_steeltower = {{-(SteelTowerLength) / 2.0,{0,0},1.0}, {(SteelTowerLength) / 2.0, {0,0},1.}};
+  G4VSolid* single_tower_solidRep = new G4ExtrudedSolid("single_tower_solidRep", poligon, zsections_steeltower);
 
   G4LogicalVolume* single_tower_logicRep = new G4LogicalVolume(single_tower_solidRep,
                                                             WorldMaterial,
@@ -305,19 +468,18 @@ PHG4LFHcalDetector::ConstructTower()
   new G4PVReplica(name_tower,miniblock_logic,single_tower_logicRep,
                       kZAxis,nLayersSteel, thickness_absorber+thickness_scintillator,0);
   
-  new G4PVPlacement(0, G4ThreeVector(-WlsDw / 2.0, 0, -WTowerLength/2),
+  new G4PVPlacement(0, G4ThreeVector(0, 0, -WTowerLength/2),
                   single_tower_logicRep,
                   name_tower,
                   single_tower_logic,
                   0, 0, OverlapCheck());
 
   m_DisplayAction->AddVolume(single_tower_logicRep, "SingleTower");
+  m_DisplayAction->AddVolume(single_tower_logic, "SingleTower");
 
   if(m_Params->get_int_param("usetailcatcher")){
-    G4VSolid* single_tower_W_solidRep = new G4Box("single_tower_W_solidRep",
-                                            (TowerDx - WlsDw) / 2.0,
-                                            TowerDy / 2.0,
-                                            WTowerLength / 2.0);
+    std::vector< G4ExtrudedSolid::ZSection> zsections_wtower = {{-(WTowerLength) / 2.0,{0,0},1.0}, {(WTowerLength) / 2.0, {0,0},1.}};
+    G4VSolid* single_tower_W_solidRep = new G4ExtrudedSolid("single_tower_W_solidRep", poligon, zsections_wtower);
 
     G4LogicalVolume* single_tower_W_logicRep = new G4LogicalVolume(single_tower_W_solidRep,
                                                               WorldMaterial,
@@ -327,7 +489,7 @@ PHG4LFHcalDetector::ConstructTower()
     new G4PVReplica(name_tower_W,miniblock_W_logic,single_tower_W_logicRep,
                         kZAxis,nLayersTungsten, thickness_absorber+thickness_scintillator,0);
 
-    new G4PVPlacement(0, G4ThreeVector(-WlsDw / 2.0, 0, SteelTowerLength/2),
+    new G4PVPlacement(0, G4ThreeVector(0, 0, SteelTowerLength/2),
                     single_tower_W_logicRep,
                     name_tower_W,
                     single_tower_logic,
@@ -335,6 +497,110 @@ PHG4LFHcalDetector::ConstructTower()
 
     m_DisplayAction->AddVolume(single_tower_W_logicRep, "SingleTower_W");
 
+  }
+  if(embed_fiber){
+    G4double spacer_width = 1.5*mm;
+    G4double add_spacing = spacer_width+0.1*mm;
+    G4double extraspacing = add_spacing;
+    for(int ilay=0;ilay<nlayers;ilay++){
+      if((SteelTowerLength+WTowerLength - ilay*(thickness_absorber + thickness_scintillator) - thickness_absorber - thickness_scintillator/2 - fiber_bending_R/2) / 2.0 > 0){
+        G4VSolid* solid_long_fiber_tmp = new G4Tubs("solid_long_fiber_tmp_" + std::to_string(ilay),
+                                                0,
+                                                fiber_thickness/2.0 ,
+                                                (SteelTowerLength+WTowerLength - ilay*(thickness_absorber + thickness_scintillator) - thickness_absorber - fiber_thickness/2 - fiber_bending_R/2) / 2.0,
+                                                0, 2.0*M_PI);
+
+        G4LogicalVolume* logic_long_fiber_tmp = new G4LogicalVolume(solid_long_fiber_tmp,
+                                                                  material_wls,
+                                                                  "logic_long_fiber_tmp" + std::to_string(ilay),
+                                                                  0, 0, 0);
+        new G4PVPlacement(0, G4ThreeVector(
+          (TowerDx - WlsDw+fiber_thickness/2.0)/2.0,
+          TowerDy/2-thick_frame_width-fiber_thickness-ilay*(1.01*fiber_thickness)-extraspacing,
+          (ilay*(thickness_absorber + thickness_scintillator)  + thickness_absorber + fiber_thickness/2 + fiber_bending_R/2)/ 2.0),
+                        logic_long_fiber_tmp,
+                        "phys_long_fiber_tmp" + std::to_string(ilay),
+                        single_tower_logic,
+                        0, 0, OverlapCheck());
+        m_DisplayAction->AddVolume(logic_long_fiber_tmp, "WLSfiber");
+      }
+
+      // short fiber piece from loop to backward readout
+      G4double shortup_fiber_length = TowerDy/2-thick_frame_width-fiber_thickness-ilay*(1.01*fiber_thickness)-extraspacing - fiber_bending_R/2 + TowerDy/2 -thick_frame_width - notch_length/2;
+      G4VSolid* solid_shortup_fiber_tmp = new G4Tubs("solid_shortup_fiber_tmp_" + std::to_string(ilay),
+                                                0,
+                                                fiber_thickness/2.0 ,
+                                                shortup_fiber_length / 2.0,
+                                                0, 2.0*M_PI);
+      G4LogicalVolume* logic_shortup_fiber_tmp = new G4LogicalVolume(solid_shortup_fiber_tmp,
+                                                                material_wls,
+                                                                "logic_shortup_fiber_tmp" + std::to_string(ilay),
+                                                                0, 0, 0);
+      
+      G4RotationMatrix* wls_rotm_fibr3 = new G4RotationMatrix();
+      wls_rotm_fibr3->rotateX(90 * deg);
+      new G4PVPlacement(wls_rotm_fibr3, G4ThreeVector(
+        (TowerDx - WlsDw+fiber_thickness/2.0)/2.0,
+        TowerDy/2-thick_frame_width-fiber_thickness-ilay*(1.01*fiber_thickness)-extraspacing - fiber_bending_R/2 - (shortup_fiber_length/2.0),
+        -TowerDz/2+ilay*(thickness_absorber + thickness_scintillator)+ thickness_absorber + fiber_thickness/2),
+                      logic_shortup_fiber_tmp,
+                      "phys_shortup_fiber_tmp" + std::to_string(ilay),
+                      single_tower_logic,
+                      0, 0, OverlapCheck());
+      m_DisplayAction->AddVolume(logic_shortup_fiber_tmp, "WLSfiber");
+
+
+      // curved fiber piece to backward readout
+      G4VSolid* solid_fiber_curved = new G4Torus("solid_fiber_curved",
+                                          0, fiber_thickness / 2.0,
+                                          (fiber_bending_R) / 2.0,
+                                          0.5*M_PI, 0.5*M_PI);
+      if(ilay==nlayers-1){
+        solid_fiber_curved = new G4Torus("solid_fiber_curved_lastlayer",
+                                          0, fiber_thickness / 2.0,
+                                          (fiber_bending_R) / 2.0,
+                                          0.6*M_PI, 0.4*M_PI);
+      }
+      G4LogicalVolume* logic_fiber_curved = new G4LogicalVolume(solid_fiber_curved,
+                                                                material_wls,
+                                                                "logic_fiber_curved" + std::to_string(ilay),
+                                                                0, 0, 0);
+
+      G4RotationMatrix* wls_rotm_fibr2 = new G4RotationMatrix();
+      wls_rotm_fibr2->rotateY(90 * deg);
+      new G4PVPlacement(wls_rotm_fibr2, G4ThreeVector(
+        (TowerDx - WlsDw+fiber_thickness/2.0)/2.0,
+        TowerDy/2-thick_frame_width-fiber_thickness-ilay*(1.01*fiber_thickness)-extraspacing - fiber_bending_R/2,
+        -TowerDz/2+ilay*(thickness_absorber + thickness_scintillator)+ thickness_absorber + fiber_thickness/2 + fiber_bending_R/2),
+                      logic_fiber_curved,
+                      "phys_fiber_curved" + std::to_string(ilay),
+                      single_tower_logic,
+                      0, 0, OverlapCheck());
+      m_DisplayAction->AddVolume(logic_fiber_curved, "WLSfiber");
+      if((ilay+1)%10==0){
+        if(((SteelTowerLength+WTowerLength - ilay*(thickness_absorber + thickness_scintillator) - thickness_absorber - thickness_scintillator/2 - thickness_absorber/2) / 2.0)>0){
+          G4VSolid* solid_spacer_tmp = new G4Box("solid_spacer_tmp_" + std::to_string(ilay),
+                                                (WlsDw)/4,
+                                                spacer_width/2.0 ,
+                                                (SteelTowerLength+WTowerLength - ilay*(thickness_absorber + thickness_scintillator) - thickness_absorber - thickness_scintillator/2 - thickness_absorber/2) / 2.0);
+
+          G4LogicalVolume* logic_spacer_tmp = new G4LogicalVolume(solid_spacer_tmp,
+                                                                    G4Material::GetMaterial("CFRP_INTT"), // carbon fiber + epoxy
+                                                                    "logic_spacer_tmp" + std::to_string(ilay),
+                                                                    0, 0, 0);
+          new G4PVPlacement(0, G4ThreeVector(
+            (TowerDx - WlsDw/2)/2.0-thin_frame_width,
+            TowerDy/2-thick_frame_width-fiber_thickness-(ilay+0.5)*(1.01*fiber_thickness)-extraspacing - add_spacing/2,
+            (ilay*(thickness_absorber + thickness_scintillator)  + thickness_absorber + thickness_scintillator/2 + thickness_absorber/2)/ 2.0),
+                          logic_spacer_tmp,
+                          "phys_spacer_tmp" + std::to_string(ilay),
+                          single_tower_logic,
+                          0, 0, OverlapCheck());
+          m_DisplayAction->AddVolume(logic_spacer_tmp, "Spacer");
+        }
+        extraspacing += add_spacing;
+      }
+    }
   }
   if (Verbosity() > 0)
   {
@@ -367,6 +633,290 @@ int PHG4LFHcalDetector::PlaceTower(G4LogicalVolume* hcalenvelope, G4LogicalVolum
 
   return 0;
 }
+
+
+//_______________________________________________________________________
+G4Material* PHG4LFHcalDetector::GetScintillatorMaterial()
+{
+
+	G4double density;
+	G4int ncomponents;
+  G4Material* material_ScintFEMC = new G4Material("PolystyreneFEMC", density = 1.03 * g / cm3, ncomponents=2);
+  material_ScintFEMC->AddElement(G4Element::GetElement("C"), 8);
+  material_ScintFEMC->AddElement(G4Element::GetElement("H"), 8);
+
+  if(m_doLightProp){
+    // const G4int ntab = 31;
+    // G4double opt_en[] =
+    //   { 1.37760*eV, 1.45864*eV, 1.54980*eV, 1.65312*eV, 1.71013*eV, 1.77120*eV, 1.83680*eV, 1.90745*eV, 1.98375*eV, 2.06640*eV,
+    //     2.10143*eV, 2.13766*eV, 2.17516*eV, 2.21400*eV, 2.25426*eV, 2.29600*eV, 2.33932*eV, 2.38431*eV, 2.43106*eV, 2.47968*eV,
+    //     2.53029*eV, 2.58300*eV, 2.63796*eV, 2.69531*eV, 2.75520*eV, 2.81782*eV, 2.88335*eV, 2.95200*eV, 3.09960*eV, 3.54241*eV,
+    //     4.13281*eV }; // 350 - 800 nm
+    // G4double opt_abs[] =
+    //   { 2.714*m, 3.619*m, 5.791*m, 4.343*m, 7.896*m, 5.429*m, 36.19*m, 17.37*m, 36.19*m, 5.429*m,
+    //     13.00*m, 14.50*m, 16.00*m, 18.00*m, 16.50*m, 17.00*m, 14.00*m, 16.00*m, 15.00*m, 14.50*m,
+    //     13.00*m, 12.00*m, 10.00*m, 8.000*m, 7.238*m, 4.000*m, 1.200*m, 0.500*m, 0.200*m, 0.200*m,
+    //     0.100*m };
+
+    const G4int nEntries = 50;
+    G4double photonEnergy[nEntries] =
+      { 2.00*eV,2.03*eV,2.06*eV,2.09*eV,2.12*eV,
+        2.15*eV,2.18*eV,2.21*eV,2.24*eV,2.27*eV,
+        2.30*eV,2.33*eV,2.36*eV,2.39*eV,2.42*eV,
+        2.45*eV,2.48*eV,2.51*eV,2.54*eV,2.57*eV,
+        2.60*eV,2.63*eV,2.66*eV,2.69*eV,2.72*eV,
+        2.75*eV,2.78*eV,2.81*eV,2.84*eV,2.87*eV,
+        2.90*eV,2.93*eV,2.96*eV,2.99*eV,3.02*eV,
+        3.05*eV,3.08*eV,3.11*eV,3.14*eV,3.17*eV,
+        3.20*eV,3.23*eV,3.26*eV,3.29*eV,3.32*eV,
+        3.35*eV,3.38*eV,3.41*eV,3.44*eV,3.47*eV};
+    G4double scintilFast[nEntries] =
+      { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+        1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
+    const G4int ntab = 4;
+
+    G4double wls_Energy[] = { 2.00 * eV, 2.87 * eV, 2.90 * eV,
+                                        3.47 * eV };
+
+    G4double rIndexPstyrene[] = { 1.5, 1.5, 1.5, 1.5 };
+    G4double absorption1[]    = { 2. * cm, 2. * cm, 2. * cm, 2. * cm };
+    // G4double scintilFast[]    = { 0.0, 0.0, 1.0, 1.0 };
+    G4MaterialPropertiesTable* fMPTPStyrene = new G4MaterialPropertiesTable();
+    fMPTPStyrene->AddProperty("RINDEX", wls_Energy, rIndexPstyrene,ntab);
+    fMPTPStyrene->AddProperty("ABSLENGTH", wls_Energy, absorption1,ntab);
+    // fMPTPStyrene->AddProperty("ABSLENGTH", opt_en, opt_abs, ntab);
+    // fMPTPStyrene->AddProperty("SCINTILLATIONCOMPONENT1", wls_Energy, scintilFast,ntab);
+    fMPTPStyrene->AddProperty("SCINTILLATIONCOMPONENT1",photonEnergy, scintilFast,nEntries);
+    fMPTPStyrene->AddConstProperty("SCINTILLATIONYIELD", 10. / keV);
+    fMPTPStyrene->AddConstProperty("RESOLUTIONSCALE", 1.0);
+    fMPTPStyrene->AddConstProperty("SCINTILLATIONTIMECONSTANT", 10. * ns);
+    // fMPTPStyrene->AddConstProperty("FASTTIMECONSTANT", 10.*ns);
+
+    // fMPTPStyrene->AddProperty("FASTCOMPONENT",photonEnergy, scintilFast,nEntries);
+    material_ScintFEMC->SetMaterialPropertiesTable(fMPTPStyrene);
+  }
+  // Set the Birks Constant for the Polystyrene scintillator
+  material_ScintFEMC->GetIonisation()->SetBirksConstant(0.126 * mm / MeV);
+
+  return material_ScintFEMC;
+}
+
+//_______________________________________________________________________
+G4Material* PHG4LFHcalDetector::GetCoatingMaterial()
+{
+
+  //--------------------------------------------------
+  // TiO2
+  //--------------------------------------------------
+	G4double density,fractionmass;
+	G4int ncomponents;
+  G4Material* material_TiO2 = new G4Material("TiO2_FEMC", density = 1.52 * g / cm3, ncomponents=2);
+  material_TiO2->AddElement(G4Element::GetElement("Ti"), 1);
+  material_TiO2->AddElement(G4Element::GetElement("O"), 2);
+
+  //--------------------------------------------------
+  // Scintillator Coating - 15% TiO2 and 85% polystyrene by weight.
+  //--------------------------------------------------
+  //Coating_FEMC (Glass + Epoxy)
+  density = 1.86 * g / cm3;
+  G4Material *Coating_FEMC = new G4Material("Coating_FEMC", density, ncomponents = 2);
+  Coating_FEMC->AddMaterial(G4Material::GetMaterial("Epoxy"), fractionmass = 0.80);
+  Coating_FEMC->AddMaterial(material_TiO2, fractionmass = 0.20);
+
+  return Coating_FEMC;
+}
+
+//_____________________________________________________________________________
+void PHG4LFHcalDetector::SurfaceTable(G4LogicalVolume *vol) {
+
+  G4OpticalSurface *surface = new G4OpticalSurface("ScintWrapB1");
+
+  new G4LogicalSkinSurface("CrystalSurfaceL", vol, surface);
+
+  surface->SetType(dielectric_metal);
+  surface->SetFinish(polished);
+  surface->SetModel(glisur);
+
+  //crystal optical surface
+
+  //surface material
+  const G4int ntab = 2;
+  G4double opt_en[] = {1.551*eV, 3.545*eV}; // 350 - 800 nm
+  G4double reflectivity[] = {0.9, 0.9};
+  G4double efficiency[] = {0.99, 0.99};
+  G4MaterialPropertiesTable *surfmat = new G4MaterialPropertiesTable();
+  surfmat->AddProperty("REFLECTIVITY", opt_en, reflectivity, ntab);
+  surfmat->AddProperty("EFFICIENCY", opt_en, efficiency, ntab);
+  surface->SetMaterialPropertiesTable(surfmat);
+  //csurf->DumpInfo();
+
+}//SurfaceTable
+//_______________________________________________________________________
+G4Material* PHG4LFHcalDetector::GetWLSFiberMaterial()
+{
+  if (Verbosity() > 0)
+  {
+    std::cout << "PHG4ForwardEcalDetector: Making WLSFiberFEMC PMMA material..." << std::endl;
+  }
+
+	G4double density;
+	G4int ncomponents;
+
+  G4Material* material_WLSFiberFEMC = new G4Material("WLSFiberFEMC", density = 1.18 * g / cm3, ncomponents = 3);
+  material_WLSFiberFEMC->AddElement(G4Element::GetElement("C"), 5);
+  material_WLSFiberFEMC->AddElement(G4Element::GetElement("H"), 8);
+  material_WLSFiberFEMC->AddElement(G4Element::GetElement("O"), 2);
+  if(m_doLightProp){
+    const G4int nEntries = 50;
+    G4double photonEnergy[nEntries] =
+      { 2.00*eV,2.03*eV,2.06*eV,2.09*eV,2.12*eV,
+        2.15*eV,2.18*eV,2.21*eV,2.24*eV,2.27*eV,
+        2.30*eV,2.33*eV,2.36*eV,2.39*eV,2.42*eV,
+        2.45*eV,2.48*eV,2.51*eV,2.54*eV,2.57*eV,
+        2.60*eV,2.63*eV,2.66*eV,2.69*eV,2.72*eV,
+        2.75*eV,2.78*eV,2.81*eV,2.84*eV,2.87*eV,
+        2.90*eV,2.93*eV,2.96*eV,2.99*eV,3.02*eV,
+        3.05*eV,3.08*eV,3.11*eV,3.14*eV,3.17*eV,
+        3.20*eV,3.23*eV,3.26*eV,3.29*eV,3.32*eV,
+        3.35*eV,3.38*eV,3.41*eV,3.44*eV,3.47*eV};
+    G4double refractiveIndexWLSfiber[nEntries] =
+      { 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60,
+        1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60,
+        1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60,
+        1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60,
+        1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60};
+   
+    G4double absWLSfiber[nEntries] =
+      {5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,
+        5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,
+        5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,1.10*m,
+        1.10*m,1.10*m,1.10*m,1.10*m,1.10*m,1.10*m, 1.*mm, 1.*mm, 1.*mm, 1.*mm,
+        1.*mm, 1.*mm, 1.*mm, 1.*mm, 1.*mm, 1.*mm, 1.*mm, 1.*mm, 1.*mm, 1.*mm};
+   
+    G4double emissionFib[nEntries] =
+      {0.05, 0.10, 0.30, 0.50, 0.75, 1.00, 1.50, 1.85, 2.30, 2.75,
+        3.25, 3.80, 4.50, 5.20, 6.00, 7.00, 8.50, 9.50, 11.1, 12.4,
+        12.9, 13.0, 12.8, 12.3, 11.1, 11.0, 12.0, 11.0, 17.0, 16.9,
+        15.0, 9.00, 2.50, 1.00, 0.05, 0.00, 0.00, 0.00, 0.00, 0.00,
+        0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00};
+    // Add entries into properties table
+    G4MaterialPropertiesTable* mptWLSfiber = new G4MaterialPropertiesTable();
+    mptWLSfiber->AddProperty("RINDEX", photonEnergy, refractiveIndexWLSfiber,nEntries);
+    mptWLSfiber->AddProperty("WLSABSLENGTH", photonEnergy, absWLSfiber,nEntries);
+    mptWLSfiber->AddProperty("WLSCOMPONENT", photonEnergy, emissionFib,nEntries);
+    mptWLSfiber->AddConstProperty("WLSTIMECONSTANT", 0.5 * ns);
+    material_WLSFiberFEMC->SetMaterialPropertiesTable(mptWLSfiber);
+  }
+  if (Verbosity() > 0)
+  {
+    std::cout << "PHG4ForwardEcalDetector:  Making WLSFiberFEMC material done." << std::endl;
+  }
+
+  return material_WLSFiberFEMC;
+}
+
+
+
+//_____________________________________________________________________________
+void PHG4LFHcalDetector::MakeBoundary(G4VPhysicalVolume *crystal, G4VPhysicalVolume *opdet, bool isFiber) {
+
+  //optical boundary between the crystal and optical photons detector
+
+  G4OpticalSurface *surf = new G4OpticalSurface("OpDetS");
+  surf->SetType(dielectric_dielectric); // photons go to the detector, must have rindex defined
+  // surf->SetType(dielectric_metal); // photon is absorbed when reaching the detector, no material rindex required
+  //surf->SetFinish(ground);
+  surf->SetFinish(polished);
+  //surf->SetModel(unified);
+  surf->SetModel(glisur);
+
+  new G4LogicalBorderSurface("OpDetB", crystal, opdet, surf);
+
+  const G4int ntab = 2;
+  G4double opt_en[] = {1.551*eV, 3.545*eV}; // 350 - 800 nm
+  //G4double reflectivity[] = {0., 0.};
+  G4double reflectivityFiber[] = {0.0, 0.0};
+  //G4double reflectivity[] = {0.9, 0.9};
+  //G4double reflectivity[] = {1., 1.};
+  G4double efficiency[] = {1., 1.};
+  G4double RefractiveIndexBoundary[] = { 1.0, 1.0};
+
+  G4MaterialPropertiesTable *surfmat = new G4MaterialPropertiesTable();
+  surfmat->AddProperty("EFFICIENCY", opt_en, efficiency, ntab);
+  surfmat->AddProperty("RINDEX", opt_en, RefractiveIndexBoundary, ntab);
+  surfmat->AddProperty("REFLECTIVITY", opt_en, reflectivityFiber, ntab);
+  surf->SetMaterialPropertiesTable(surfmat);
+
+
+
+}//MakeBoundary
+
+//_____________________________________________________________________________
+void PHG4LFHcalDetector::MakeBoundary_Fiber_Scint(G4VPhysicalVolume *fiber, G4VPhysicalVolume *scinti) {
+
+  //optical boundary between the fiber and scintillator
+
+  G4OpticalSurface *ScintToFiberS = new G4OpticalSurface("ScintToFiberS");
+  ScintToFiberS->SetType(dielectric_dielectric); // photons go to the detector, must have rindex defined
+  // ScintToFiberS->SetType(dielectric_metal); // photon is absorbed when reaching the detector, no material rindex required
+  //ScintToFiberS->SetFinish(ground);
+  ScintToFiberS->SetFinish(groundair);
+  // ScintToFiberS->SetFinish(polished);
+  //ScintToFiberS->SetModel(unified);
+  ScintToFiberS->SetModel(glisur);
+
+  new G4LogicalBorderSurface("ScintToFiberB", scinti, fiber, ScintToFiberS);
+
+  const G4int ntab = 2;
+  G4double opt_en[] = {1.551*eV, 3.545*eV}; // 350 - 800 nm
+  //G4double reflectivity[] = {0., 0.};
+  G4double reflectivity[] = {0.01, 0.01};
+  //G4double reflectivity[] = {0.9, 0.9};
+  //G4double reflectivity[] = {1., 1.};
+  G4double efficiency[] = {1., 1.};
+  G4double RefractiveIndexBoundary[] = { 1.4, 1.4};
+
+  G4MaterialPropertiesTable *ScintToFiberSmat = new G4MaterialPropertiesTable();
+  ScintToFiberSmat->AddProperty("EFFICIENCY", opt_en, efficiency, ntab);
+  ScintToFiberSmat->AddProperty("RINDEX", opt_en, RefractiveIndexBoundary, ntab);
+  ScintToFiberSmat->AddProperty("REFLECTIVITY", opt_en, reflectivity, ntab);
+  ScintToFiberS->SetMaterialPropertiesTable(ScintToFiberSmat);
+
+  //optical boundary between the fiber and scintillator
+
+  G4OpticalSurface *FiberToScintSurface = new G4OpticalSurface("ScintToFiberS");
+  // FiberToScintSurface->SetType(dielectric_dielectric); // photons go to the detector, must have rindex defined
+  FiberToScintSurface->SetType(dielectric_metal); // photon is absorbed when reaching the detector, no material rindex required
+  //FiberToScintSurface->SetFinish(ground);
+  // FiberToScintSurface->SetFinish(groundair);
+  FiberToScintSurface->SetFinish(polished);
+  //FiberToScintSurface->SetModel(unified);
+  FiberToScintSurface->SetModel(glisur);
+
+  new G4LogicalBorderSurface("ScintToFiberB", scinti, fiber, FiberToScintSurface);
+
+  const G4int ntab2 = 2;
+  G4double opt_en2[] = {1.551*eV, 3.545*eV}; // 350 - 800 nm
+  //G4double reflectivity[] = {0., 0.};
+  // G4double reflectivity2[] = {0.01, 0.01};
+  //G4double reflectivity[] = {0.9, 0.9};
+  G4double reflectivity2[] = {1., 1.};
+  G4double efficiency2[] = {1., 1.};
+  G4double RefractiveIndexBoundary2[] = { 1.6, 1.6};
+
+  G4MaterialPropertiesTable *FiberToScintSurfacemat = new G4MaterialPropertiesTable();
+  FiberToScintSurfacemat->AddProperty("EFFICIENCY", opt_en2, efficiency2, ntab2);
+  FiberToScintSurfacemat->AddProperty("RINDEX", opt_en2, RefractiveIndexBoundary2, ntab2);
+  FiberToScintSurfacemat->AddProperty("REFLECTIVITY", opt_en2, reflectivity2, ntab2);
+  FiberToScintSurface->SetMaterialPropertiesTable(FiberToScintSurfacemat);
+
+
+
+}//MakeBoundary
 
 int PHG4LFHcalDetector::ParseParametersFromTable()
 {
@@ -556,9 +1106,21 @@ int PHG4LFHcalDetector::ParseParametersFromTable()
   if (parit != m_GlobalParameterMap.end())
     m_Params->set_double_param("yoffset", parit->second);  
   
+  parit = m_GlobalParameterMap.find("frame_width");
+  if (parit != m_GlobalParameterMap.end())
+    m_Params->set_double_param("frame_width", parit->second);  
+  
+  parit = m_GlobalParameterMap.find("width_coating");
+  if (parit != m_GlobalParameterMap.end())
+    m_Params->set_double_param("width_coating", parit->second);  
+  
   parit = m_GlobalParameterMap.find("usetailcatcher");
   if (parit != m_GlobalParameterMap.end())
     m_Params->set_int_param("usetailcatcher", parit->second);  
+  
+  parit = m_GlobalParameterMap.find("embed_fiber");
+  if (parit != m_GlobalParameterMap.end())
+    m_Params->set_int_param("embed_fiber", parit->second);  
   
   //! TODO make this better!
   if(m_Params->get_int_param("usetailcatcher")){

--- a/simulation/g4simulation/g4eiccalos/PHG4LFHcalDetector.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4LFHcalDetector.cc
@@ -10,24 +10,24 @@
 #include <phool/recoConsts.h>
 
 #include <Geant4/G4Box.hh>
-#include <Geant4/G4Trap.hh>
-#include <Geant4/G4Torus.hh>
 #include <Geant4/G4Cons.hh>
-#include <Geant4/G4Tubs.hh>
-#include <Geant4/G4LogicalVolume.hh>
-#include <Geant4/G4SubtractionSolid.hh>
 #include <Geant4/G4ExtrudedSolid.hh>
-#include <Geant4/G4TwoVector.hh>
-#include <Geant4/G4OpticalSurface.hh>
-#include <Geant4/G4LogicalSkinSurface.hh>
 #include <Geant4/G4LogicalBorderSurface.hh>
+#include <Geant4/G4LogicalSkinSurface.hh>
+#include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
+#include <Geant4/G4OpticalSurface.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4PVReplica.hh>
 #include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
+#include <Geant4/G4SubtractionSolid.hh>
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>      // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>      // for G4Transform3D
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
+#include <Geant4/G4Torus.hh>
+#include <Geant4/G4Transform3D.hh>  // for G4Transform3D
+#include <Geant4/G4Trap.hh>
+#include <Geant4/G4Tubs.hh>
+#include <Geant4/G4TwoVector.hh>
 #include <Geant4/G4Types.hh>            // for G4double, G4int
 #include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
 
@@ -102,18 +102,18 @@ void PHG4LFHcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
   recoConsts* rc = recoConsts::instance();
   G4Material* WorldMaterial = G4Material::GetMaterial(rc->get_StringFlag("WorldMaterial"));
 
-  G4VSolid *beampipe_cutout = new G4Cons("LFHCAL_beampipe_cutout",
+  G4VSolid* beampipe_cutout = new G4Cons("LFHCAL_beampipe_cutout",
                                          0, m_Params->get_double_param("rMin1") * cm,
                                          0, m_Params->get_double_param("rMin2") * cm,
                                          m_Params->get_double_param("dz") * cm / 2.0,
                                          0, 2 * M_PI);
-  G4VSolid *hcal_envelope_solid = new G4Cons("LFHCAL_envelope_solid_cutout",
-                                            0, m_Params->get_double_param("rMax1") * cm,
-                                            0, m_Params->get_double_param("rMax2") * cm,
-                                            m_Params->get_double_param("dz") * cm / 2.0,
-                                            0, 2 * M_PI);
+  G4VSolid* hcal_envelope_solid = new G4Cons("LFHCAL_envelope_solid_cutout",
+                                             0, m_Params->get_double_param("rMax1") * cm,
+                                             0, m_Params->get_double_param("rMax2") * cm,
+                                             m_Params->get_double_param("dz") * cm / 2.0,
+                                             0, 2 * M_PI);
   hcal_envelope_solid = new G4SubtractionSolid(G4String("LFHCAL_envelope_solid"), hcal_envelope_solid, beampipe_cutout, 0, G4ThreeVector(m_Params->get_double_param("xoffset") * cm, m_Params->get_double_param("yoffset") * cm, 0.));
-  
+
   G4LogicalVolume* hcal_envelope_log = new G4LogicalVolume(hcal_envelope_solid, WorldMaterial, "hLFHCAL_envelope", 0, 0, 0);
 
   m_DisplayAction->AddVolume(hcal_envelope_log, "LFHcalEnvelope");
@@ -153,24 +153,24 @@ PHG4LFHcalDetector::ConstructTower()
   //**********************************************************************************************
   /* read variables from external inputs */
   //**********************************************************************************************
-  G4double TowerDx  = m_Params->get_double_param("tower_dx") * cm;
-  G4double TowerDy  = m_Params->get_double_param("tower_dy") * cm;
-  G4double TowerDz  = m_Params->get_double_param("tower_dz") * cm;
-  G4double WlsDw    = m_Params->get_double_param("wls_dw") * cm;
-  G4double thick_frame_width    = m_Params->get_double_param("frame_width") * cm;
-  G4double thin_frame_width    = 0;
-  if(thick_frame_width>0)
-    thin_frame_width    = 0.1 * mm;
+  G4double TowerDx = m_Params->get_double_param("tower_dx") * cm;
+  G4double TowerDy = m_Params->get_double_param("tower_dy") * cm;
+  G4double TowerDz = m_Params->get_double_param("tower_dz") * cm;
+  G4double WlsDw = m_Params->get_double_param("wls_dw") * cm;
+  G4double thick_frame_width = m_Params->get_double_param("frame_width") * cm;
+  G4double thin_frame_width = 0;
+  if (thick_frame_width > 0)
+    thin_frame_width = 0.1 * mm;
   // double width_coating    = m_Params->get_double_param("width_coating") * cm;
-  G4double thickness_absorber     = m_Params->get_double_param("thickness_absorber") * cm;
+  G4double thickness_absorber = m_Params->get_double_param("thickness_absorber") * cm;
   G4double thickness_scintillator = m_Params->get_double_param("thickness_scintillator") * cm;
-  G4int nlayers                   = TowerDz / (thickness_absorber + thickness_scintillator);
-  G4Material* material_scintillator = GetScintillatorMaterial();//G4Material::GetMaterial(m_Params->get_string_param("scintillator"));
-  G4Material* material_absorber     = G4Material::GetMaterial(m_Params->get_string_param("absorber"));
-  G4Material* material_absorber_W     = G4Material::GetMaterial(m_Params->get_string_param("absorber_W"));
-  G4Material* material_wls          = GetWLSFiberMaterial();//G4Material::GetMaterial(m_Params->get_string_param("scintillator"));
-  int embed_fiber                 = m_Params->get_int_param("embed_fiber");
-  G4double fiber_thickness        = 0.2*mm;
+  G4int nlayers = TowerDz / (thickness_absorber + thickness_scintillator);
+  G4Material* material_scintillator = GetScintillatorMaterial();  //G4Material::GetMaterial(m_Params->get_string_param("scintillator"));
+  G4Material* material_absorber = G4Material::GetMaterial(m_Params->get_string_param("absorber"));
+  G4Material* material_absorber_W = G4Material::GetMaterial(m_Params->get_string_param("absorber_W"));
+  G4Material* material_wls = GetWLSFiberMaterial();  //G4Material::GetMaterial(m_Params->get_string_param("scintillator"));
+  int embed_fiber = m_Params->get_int_param("embed_fiber");
+  G4double fiber_thickness = 0.2 * mm;
   // G4double fiber_thickness        = 1.0*mm;
   //**********************************************************************************************
   /* create logical volume for single tower */
@@ -187,34 +187,34 @@ PHG4LFHcalDetector::ConstructTower()
                                                             "single_tower_logic",
                                                             0, 0, 0);
 
-  G4double notch_length = 2.0*cm;
+  G4double notch_length = 2.0 * cm;
   std::vector<G4TwoVector> poligon = {
-    {(-TowerDx)/2.0+thin_frame_width,(-TowerDy)/2.0+thick_frame_width},
-    {(-TowerDx)/2.0+thin_frame_width,(TowerDy)/2.0-thick_frame_width},
-    {(TowerDx - WlsDw)/2.0-thin_frame_width,(TowerDy)/2.0-thick_frame_width},
-    {(TowerDx - WlsDw)/2.0-thin_frame_width,(-TowerDy+notch_length)/2.0+thick_frame_width},
-    {(TowerDx)/2.0-thin_frame_width,(-TowerDy+notch_length)/2.0+thick_frame_width},
-    {(TowerDx)/2.0-thin_frame_width,(-TowerDy)/2.0+thick_frame_width}};
+      {(-TowerDx) / 2.0 + thin_frame_width, (-TowerDy) / 2.0 + thick_frame_width},
+      {(-TowerDx) / 2.0 + thin_frame_width, (TowerDy) / 2.0 - thick_frame_width},
+      {(TowerDx - WlsDw) / 2.0 - thin_frame_width, (TowerDy) / 2.0 - thick_frame_width},
+      {(TowerDx - WlsDw) / 2.0 - thin_frame_width, (-TowerDy + notch_length) / 2.0 + thick_frame_width},
+      {(TowerDx) / 2.0 - thin_frame_width, (-TowerDy + notch_length) / 2.0 + thick_frame_width},
+      {(TowerDx) / 2.0 - thin_frame_width, (-TowerDy) / 2.0 + thick_frame_width}};
   //**********************************************************************************************
   /* create logical and geometry volumes for minitower read-out unit */
   //**********************************************************************************************
-  std::vector< G4ExtrudedSolid::ZSection> zsections_miniblock = {{-(thickness_absorber + thickness_scintillator) / 2.0,{0,0},1.0}, {(thickness_absorber + thickness_scintillator) / 2.0, {0,0},1.}};
+  std::vector<G4ExtrudedSolid::ZSection> zsections_miniblock = {{-(thickness_absorber + thickness_scintillator) / 2.0, {0, 0}, 1.0}, {(thickness_absorber + thickness_scintillator) / 2.0, {0, 0}, 1.}};
   G4VSolid* miniblock_solid = new G4ExtrudedSolid("miniblock_solid", poligon, zsections_miniblock);
 
-  G4LogicalVolume* miniblock_logic  = new G4LogicalVolume(miniblock_solid,
-                                                          WorldMaterial,
-                                                          "miniblock_logic",
-                                                          0, 0, 0);
-  G4LogicalVolume* miniblock_W_logic  = new G4LogicalVolume(miniblock_solid,
-                                                          WorldMaterial,
-                                                          "miniblock_W_logic",
-                                                          0, 0, 0);
+  G4LogicalVolume* miniblock_logic = new G4LogicalVolume(miniblock_solid,
+                                                         WorldMaterial,
+                                                         "miniblock_logic",
+                                                         0, 0, 0);
+  G4LogicalVolume* miniblock_W_logic = new G4LogicalVolume(miniblock_solid,
+                                                           WorldMaterial,
+                                                           "miniblock_W_logic",
+                                                           0, 0, 0);
   m_DisplayAction->AddVolume(miniblock_logic, "Invisible");
   m_DisplayAction->AddVolume(miniblock_W_logic, "Invisible");
   //**********************************************************************************************
   /* create logical & geometry volumes for scintillator and absorber plates to place inside mini read-out unit */
   //**********************************************************************************************
-  std::vector< G4ExtrudedSolid::ZSection> zsections_scintillator = {{-thickness_scintillator/2,{0,0},1.0}, {thickness_scintillator/2, {0,0},1.}};
+  std::vector<G4ExtrudedSolid::ZSection> zsections_scintillator = {{-thickness_scintillator / 2, {0, 0}, 1.0}, {thickness_scintillator / 2, {0, 0}, 1.}};
 
   G4VSolid* solid_scintillator = new G4ExtrudedSolid("single_plate_scintillator", poligon, zsections_scintillator);
 
@@ -224,82 +224,80 @@ PHG4LFHcalDetector::ConstructTower()
   G4LogicalVolume* logic_embed_fiber_loop = nullptr;
   G4LogicalVolume* logic_embed_fiber_loop_2 = nullptr;
   G4LogicalVolume* logic_embed_fiber_straight_1 = nullptr;
-  G4double cutout_margin = 0.1*fiber_thickness;
-  G4double fiber_bending_R_1 = notch_length/2.0 - (TowerDy/2 - thick_frame_width - (0.9*(TowerDx - WlsDw - 2 * thin_frame_width)/2.0) - (2*cutout_margin));
-  G4double fiber_bending_R = 1.0*cm;
-  if(embed_fiber){
+  G4double cutout_margin = 0.1 * fiber_thickness;
+  G4double fiber_bending_R_1 = notch_length / 2.0 - (TowerDy / 2 - thick_frame_width - (0.9 * (TowerDx - WlsDw - 2 * thin_frame_width) / 2.0) - (2 * cutout_margin));
+  G4double fiber_bending_R = 1.0 * cm;
+  if (embed_fiber)
+  {
     G4VSolid* solid_embed_fiber_loop = new G4Torus("solid_embed_fiber_loop",
-                                        0, fiber_thickness / 2.0,
-                                        (0.9*(TowerDx - WlsDw - 2 * thin_frame_width)/2.0) - (fiber_thickness + 2* cutout_margin)/2.0,
-                                        -0.4*M_PI, 1.9*M_PI);
+                                                   0, fiber_thickness / 2.0,
+                                                   (0.9 * (TowerDx - WlsDw - 2 * thin_frame_width) / 2.0) - (fiber_thickness + 2 * cutout_margin) / 2.0,
+                                                   -0.4 * M_PI, 1.9 * M_PI);
     G4VSolid* solid_embed_fiber_loop_2 = new G4Torus("solid_embed_fiber_loop_2",
-                                        0, fiber_thickness / 2.0,
-                                        (2*fiber_bending_R_1) / 2.0 - (fiber_thickness + 2* cutout_margin)/2.0,
-                                        -0.5*M_PI, 0.5*M_PI);
+                                                     0, fiber_thickness / 2.0,
+                                                     (2 * fiber_bending_R_1) / 2.0 - (fiber_thickness + 2 * cutout_margin) / 2.0,
+                                                     -0.5 * M_PI, 0.5 * M_PI);
     G4VSolid* solid_embed_fiber_straight_1 = new G4Tubs("solid_embed_fiber_straight_1",
-                                            0,
-                                            fiber_thickness/2.0 ,
-                                            // (TowerDx/2.0 - fiber_bending_R_1 - thin_frame_width) / 2.0,
-                                            ((TowerDx - WlsDw+fiber_thickness)/2.0-(fiber_bending_R_1))/2.0,
-                                            0, 2.0*M_PI);
+                                                        0,
+                                                        fiber_thickness / 2.0,
+                                                        // (TowerDx/2.0 - fiber_bending_R_1 - thin_frame_width) / 2.0,
+                                                        ((TowerDx - WlsDw + fiber_thickness) / 2.0 - (fiber_bending_R_1)) / 2.0,
+                                                        0, 2.0 * M_PI);
     solid_scintillator = new G4SubtractionSolid(G4String("single_plate_scintillator_cu"),
-                solid_scintillator, solid_embed_fiber_loop,
-                0, G4ThreeVector(0, 0, -thickness_scintillator/2+(fiber_thickness+cutout_margin) / 2.0));
+                                                solid_scintillator, solid_embed_fiber_loop,
+                                                0, G4ThreeVector(0, 0, -thickness_scintillator / 2 + (fiber_thickness + cutout_margin) / 2.0));
     solid_scintillator = new G4SubtractionSolid(G4String("single_plate_scintillator_cu2"),
-                solid_scintillator, solid_embed_fiber_loop_2,
-                0, G4ThreeVector((TowerDx - WlsDw+fiber_thickness/2.0)/2.0-(fiber_bending_R_1)+(thin_frame_width)+cutout_margin, -0.9*(TowerDx - WlsDw - thin_frame_width)/2.0+(fiber_bending_R_1), -thickness_scintillator/2+(fiber_thickness+cutout_margin) / 2.0));
+                                                solid_scintillator, solid_embed_fiber_loop_2,
+                                                0, G4ThreeVector((TowerDx - WlsDw + fiber_thickness / 2.0) / 2.0 - (fiber_bending_R_1) + (thin_frame_width) + cutout_margin, -0.9 * (TowerDx - WlsDw - thin_frame_width) / 2.0 + (fiber_bending_R_1), -thickness_scintillator / 2 + (fiber_thickness + cutout_margin) / 2.0));
     G4RotationMatrix* wls_rotm_fibrcu = new G4RotationMatrix();
     wls_rotm_fibrcu->rotateY(90 * deg);
     solid_scintillator = new G4SubtractionSolid(G4String("single_plate_scintillator_cu3"),
-                solid_scintillator, solid_embed_fiber_straight_1,
-                wls_rotm_fibrcu, G4ThreeVector(
-                  ((TowerDx - WlsDw+fiber_thickness)/2.0-(fiber_bending_R_1))/2.0,//(TowerDx/2-((TowerDx - WlsDw+fiber_thickness/2.0)/2.0-(fiber_bending_R_1)+(thin_frame_width)+cutout_margin))/2+fiber_bending_R_1/2+(fiber_thickness),
-                  -0.9*(TowerDx - WlsDw - thin_frame_width)/2.0+ (fiber_thickness + 2* cutout_margin)/2.0,
-                  -thickness_scintillator/2+(fiber_thickness+cutout_margin) / 2.0));
+                                                solid_scintillator, solid_embed_fiber_straight_1,
+                                                wls_rotm_fibrcu, G4ThreeVector(((TowerDx - WlsDw + fiber_thickness) / 2.0 - (fiber_bending_R_1)) / 2.0,  //(TowerDx/2-((TowerDx - WlsDw+fiber_thickness/2.0)/2.0-(fiber_bending_R_1)+(thin_frame_width)+cutout_margin))/2+fiber_bending_R_1/2+(fiber_thickness),
+                                                                               -0.9 * (TowerDx - WlsDw - thin_frame_width) / 2.0 + (fiber_thickness + 2 * cutout_margin) / 2.0, -thickness_scintillator / 2 + (fiber_thickness + cutout_margin) / 2.0));
     logic_embed_fiber_loop = new G4LogicalVolume(solid_embed_fiber_loop,
-                                                        material_wls, "logic_embed_fiber_loop",
-                                                        0, 0, 0);
+                                                 material_wls, "logic_embed_fiber_loop",
+                                                 0, 0, 0);
     logic_embed_fiber_loop_2 = new G4LogicalVolume(solid_embed_fiber_loop_2,
-                                                        material_wls, "logic_embed_fiber_loop_2",
-                                                        0, 0, 0);
+                                                   material_wls, "logic_embed_fiber_loop_2",
+                                                   0, 0, 0);
     logic_embed_fiber_straight_1 = new G4LogicalVolume(solid_embed_fiber_straight_1,
-                                                        material_wls, "logic_embed_fiber_straight_1",
-                                                        0, 0, 0);
+                                                       material_wls, "logic_embed_fiber_straight_1",
+                                                       0, 0, 0);
     // if(m_doLightProp){
     //   SurfaceTable(logic_embed_fiber_loop);
     //   SurfaceTable(logic_embed_fiber_loop_2);
     //   SurfaceTable(logic_embed_fiber_straight_1);
     // }
-    physvol_fiber_loop_0 = new G4PVPlacement(0, G4ThreeVector(0, 0, (thickness_absorber)/ 2.-thickness_scintillator/2+(fiber_thickness+cutout_margin) / 2.0),
-                    logic_embed_fiber_loop,
-                    "embed_fiber_loop_placed",
-                    miniblock_logic,
-                    0, 0, OverlapCheck());
+    physvol_fiber_loop_0 = new G4PVPlacement(0, G4ThreeVector(0, 0, (thickness_absorber) / 2. - thickness_scintillator / 2 + (fiber_thickness + cutout_margin) / 2.0),
+                                             logic_embed_fiber_loop,
+                                             "embed_fiber_loop_placed",
+                                             miniblock_logic,
+                                             0, 0, OverlapCheck());
     physvol_fiber_loop_1 = new G4PVPlacement(0, G4ThreeVector(
-      // (TowerDx - WlsDw+fiber_thickness/2.0)/2.0-(fiber_bending_R_1),
-      (TowerDx - WlsDw+fiber_thickness/2.0)/2.0-(fiber_bending_R_1)+(thin_frame_width)+cutout_margin,
-      // (TowerDx)/2.0-(fiber_bending_R_1) - thin_frame_width,
-      -0.9*(TowerDx - WlsDw - thin_frame_width)/2.0+(fiber_bending_R_1),
-      (thickness_absorber)/ 2.-thickness_scintillator/2+(fiber_thickness+cutout_margin) / 2.0),
-                    logic_embed_fiber_loop_2,
-                    "embed_fiber_loop_2_placed",
-                    miniblock_logic,
-                    0, 0, OverlapCheck());
+                                                    // (TowerDx - WlsDw+fiber_thickness/2.0)/2.0-(fiber_bending_R_1),
+                                                    (TowerDx - WlsDw + fiber_thickness / 2.0) / 2.0 - (fiber_bending_R_1) + (thin_frame_width) + cutout_margin,
+                                                    // (TowerDx)/2.0-(fiber_bending_R_1) - thin_frame_width,
+                                                    -0.9 * (TowerDx - WlsDw - thin_frame_width) / 2.0 + (fiber_bending_R_1), (thickness_absorber) / 2. - thickness_scintillator / 2 + (fiber_thickness + cutout_margin) / 2.0),
+                                             logic_embed_fiber_loop_2,
+                                             "embed_fiber_loop_2_placed",
+                                             miniblock_logic,
+                                             0, 0, OverlapCheck());
     G4RotationMatrix* wls_rotm_fibr = new G4RotationMatrix();
     wls_rotm_fibr->rotateY(90 * deg);
     physvol_fiber_straight_1 = new G4PVPlacement(wls_rotm_fibr, G4ThreeVector(
-      // (TowerDx/2.0 - fiber_bending_R_1 - thin_frame_width) / 2.0,
-      ((TowerDx - WlsDw+fiber_thickness)/2.0-(fiber_bending_R_1))/2.0,
-      // (TowerDx/2-((TowerDx - WlsDw+fiber_thickness/2.0)/2.0-(fiber_bending_R_1)+(thin_frame_width)+cutout_margin))/2,
-      -0.9*(TowerDx - WlsDw - thin_frame_width)/2.0+ (fiber_thickness + 2* cutout_margin)/2.0,
-      (thickness_absorber)/ 2.-thickness_scintillator/2+(fiber_thickness+cutout_margin) / 2.0),
-                    logic_embed_fiber_straight_1,
-                    "embed_fiber_straight_1_placed",
-                    miniblock_logic,
-                    0, 0, OverlapCheck());
-    if(m_doLightProp){
-      MakeBoundary(physvol_fiber_loop_0, physvol_fiber_loop_1,true);
-      MakeBoundary(physvol_fiber_loop_1, physvol_fiber_straight_1,true);
+                                                                    // (TowerDx/2.0 - fiber_bending_R_1 - thin_frame_width) / 2.0,
+                                                                    ((TowerDx - WlsDw + fiber_thickness) / 2.0 - (fiber_bending_R_1)) / 2.0,
+                                                                    // (TowerDx/2-((TowerDx - WlsDw+fiber_thickness/2.0)/2.0-(fiber_bending_R_1)+(thin_frame_width)+cutout_margin))/2,
+                                                                    -0.9 * (TowerDx - WlsDw - thin_frame_width) / 2.0 + (fiber_thickness + 2 * cutout_margin) / 2.0, (thickness_absorber) / 2. - thickness_scintillator / 2 + (fiber_thickness + cutout_margin) / 2.0),
+                                                 logic_embed_fiber_straight_1,
+                                                 "embed_fiber_straight_1_placed",
+                                                 miniblock_logic,
+                                                 0, 0, OverlapCheck());
+    if (m_doLightProp)
+    {
+      MakeBoundary(physvol_fiber_loop_0, physvol_fiber_loop_1, true);
+      MakeBoundary(physvol_fiber_loop_1, physvol_fiber_straight_1, true);
     }
     m_DisplayAction->AddVolume(logic_embed_fiber_loop, "WLSfiber");
     m_DisplayAction->AddVolume(logic_embed_fiber_loop_2, "WLSfiber");
@@ -310,7 +308,7 @@ PHG4LFHcalDetector::ConstructTower()
   //                                      (TowerDy ) / 2.0,
   //                                      thickness_absorber / 2.0);
 
-  std::vector< G4ExtrudedSolid::ZSection> zsections_absorber = {{-thickness_absorber/2,{0,0},1.0}, {thickness_absorber/2, {0,0},1.}};
+  std::vector<G4ExtrudedSolid::ZSection> zsections_absorber = {{-thickness_absorber / 2, {0, 0}, 1.0}, {thickness_absorber / 2, {0, 0}, 1.}};
   G4VSolid* solid_absorber = new G4ExtrudedSolid("single_plate_absorber_solid", poligon, zsections_absorber);
   G4LogicalVolume* logic_absorber = new G4LogicalVolume(solid_absorber,
                                                         material_absorber,
@@ -318,9 +316,9 @@ PHG4LFHcalDetector::ConstructTower()
                                                         0, 0, 0);
   m_AbsorberLogicalVolSet.insert(logic_absorber);
   G4LogicalVolume* logic_absorber_W = new G4LogicalVolume(solid_absorber,
-                                                        material_absorber_W,
-                                                        "single_plate_absorber_W_logic",
-                                                        0, 0, 0);
+                                                          material_absorber_W,
+                                                          "single_plate_absorber_W_logic",
+                                                          0, 0, 0);
   m_AbsorberLogicalVolSet.insert(logic_absorber_W);
   G4LogicalVolume* logic_scint = new G4LogicalVolume(solid_scintillator,
                                                      material_scintillator,
@@ -333,115 +331,114 @@ PHG4LFHcalDetector::ConstructTower()
   m_DisplayAction->AddVolume(logic_absorber, "Absorber");
   m_DisplayAction->AddVolume(logic_absorber_W, "Absorber_W");
   m_DisplayAction->AddVolume(logic_scint, "Scintillator");
-  string name_absorber      = m_TowerLogicNamePrefix + "_single_plate_absorber";
-  string name_absorber_W      = m_TowerLogicNamePrefix + "_single_plate_absorber_W";
-  string name_scintillator  = m_TowerLogicNamePrefix + "_single_plate_scintillator";
+  string name_absorber = m_TowerLogicNamePrefix + "_single_plate_absorber";
+  string name_absorber_W = m_TowerLogicNamePrefix + "_single_plate_absorber_W";
+  string name_scintillator = m_TowerLogicNamePrefix + "_single_plate_scintillator";
   // place Steel absorber and scintillator in miniblock
-  new G4PVPlacement(0, G4ThreeVector(0, 0, -thickness_scintillator/2),
+  new G4PVPlacement(0, G4ThreeVector(0, 0, -thickness_scintillator / 2),
                     logic_absorber,
                     name_absorber,
                     miniblock_logic,
                     0, 0, OverlapCheck());
 
-  G4VPhysicalVolume* scintillator_placed = new G4PVPlacement(0, G4ThreeVector(0, 0, (thickness_absorber)/ 2.),
-                    logic_scint,
-                    name_scintillator,
-                    miniblock_logic,
-                    0, 0, OverlapCheck());
-  if(m_doLightProp && embed_fiber){
+  G4VPhysicalVolume* scintillator_placed = new G4PVPlacement(0, G4ThreeVector(0, 0, (thickness_absorber) / 2.),
+                                                             logic_scint,
+                                                             name_scintillator,
+                                                             miniblock_logic,
+                                                             0, 0, OverlapCheck());
+  if (m_doLightProp && embed_fiber)
+  {
     MakeBoundary_Fiber_Scint(physvol_fiber_loop_0, scintillator_placed);
     MakeBoundary_Fiber_Scint(physvol_fiber_loop_1, scintillator_placed);
     MakeBoundary_Fiber_Scint(physvol_fiber_straight_1, scintillator_placed);
   }
   // place Tungsten absorber and scintillator in a separate miniblock
-  new G4PVPlacement(0, G4ThreeVector(0, 0, -thickness_scintillator/2),
+  new G4PVPlacement(0, G4ThreeVector(0, 0, -thickness_scintillator / 2),
                     logic_absorber_W,
                     name_absorber,
                     miniblock_W_logic,
                     0, 0, OverlapCheck());
 
-  new G4PVPlacement(0, G4ThreeVector(0, 0, (thickness_absorber)/ 2.),
+  new G4PVPlacement(0, G4ThreeVector(0, 0, (thickness_absorber) / 2.),
                     logic_scint,
                     name_scintillator,
                     miniblock_W_logic,
                     0, 0, OverlapCheck());
-  if(embed_fiber){
-    G4VPhysicalVolume* physvol_fiber_loop_W_0 = new G4PVPlacement(0, G4ThreeVector(0, 0, (thickness_absorber)/ 2.-thickness_scintillator/2+(fiber_thickness+cutout_margin) / 2.0),
-                    logic_embed_fiber_loop,
-                    "embed_fiber_loop_W_placed",
-                    miniblock_W_logic,
-                    0, 0, OverlapCheck());
-    G4VPhysicalVolume* physvol_fiber_loop_W_1 = new G4PVPlacement(0, G4ThreeVector(
-      (TowerDx - WlsDw+fiber_thickness/2.0)/2.0-(fiber_bending_R_1)+(thin_frame_width)+cutout_margin,
-      // (TowerDx)/2.0-(fiber_bending_R_1) - thin_frame_width,
-      -0.9*(TowerDx - WlsDw - thin_frame_width)/2.0+(fiber_bending_R_1),
-      (thickness_absorber)/ 2.-thickness_scintillator/2+(fiber_thickness+cutout_margin) / 2.0),
-                    logic_embed_fiber_loop_2,
-                    "embed_fiber_loop_W_2_placed",
-                    miniblock_W_logic,
-                    0, 0, OverlapCheck());
+  if (embed_fiber)
+  {
+    G4VPhysicalVolume* physvol_fiber_loop_W_0 = new G4PVPlacement(0, G4ThreeVector(0, 0, (thickness_absorber) / 2. - thickness_scintillator / 2 + (fiber_thickness + cutout_margin) / 2.0),
+                                                                  logic_embed_fiber_loop,
+                                                                  "embed_fiber_loop_W_placed",
+                                                                  miniblock_W_logic,
+                                                                  0, 0, OverlapCheck());
+    G4VPhysicalVolume* physvol_fiber_loop_W_1 = new G4PVPlacement(0, G4ThreeVector((TowerDx - WlsDw + fiber_thickness / 2.0) / 2.0 - (fiber_bending_R_1) + (thin_frame_width) + cutout_margin,
+                                                                                   // (TowerDx)/2.0-(fiber_bending_R_1) - thin_frame_width,
+                                                                                   -0.9 * (TowerDx - WlsDw - thin_frame_width) / 2.0 + (fiber_bending_R_1), (thickness_absorber) / 2. - thickness_scintillator / 2 + (fiber_thickness + cutout_margin) / 2.0),
+                                                                  logic_embed_fiber_loop_2,
+                                                                  "embed_fiber_loop_W_2_placed",
+                                                                  miniblock_W_logic,
+                                                                  0, 0, OverlapCheck());
     G4RotationMatrix* wls_rotm_fibr = new G4RotationMatrix();
     wls_rotm_fibr->rotateY(90 * deg);
-    G4VPhysicalVolume* physvol_fiber_loop_W_2 = new G4PVPlacement(wls_rotm_fibr, G4ThreeVector(
-      ((TowerDx - WlsDw+fiber_thickness)/2.0-(fiber_bending_R_1))/2.0,
-      // (TowerDx/2-((TowerDx - WlsDw+fiber_thickness/2.0)/2.0-(fiber_bending_R_1)+(thin_frame_width)+cutout_margin))/2,
-      -0.9*(TowerDx - WlsDw - thin_frame_width)/2.0+ (fiber_thickness + 2* cutout_margin)/2.0,
-      (thickness_absorber)/ 2.-thickness_scintillator/2+(fiber_thickness+cutout_margin) / 2.0),
-                    logic_embed_fiber_straight_1,
-                    "embed_fiber_straight_W_1_placed",
-                    miniblock_W_logic,
-                    0, 0, OverlapCheck());
-    if(m_doLightProp){
-      MakeBoundary(physvol_fiber_loop_W_0, physvol_fiber_loop_W_1,true);
-      MakeBoundary(physvol_fiber_loop_W_1, physvol_fiber_loop_W_2,true);
+    G4VPhysicalVolume* physvol_fiber_loop_W_2 = new G4PVPlacement(wls_rotm_fibr, G4ThreeVector(((TowerDx - WlsDw + fiber_thickness) / 2.0 - (fiber_bending_R_1)) / 2.0,
+                                                                                               // (TowerDx/2-((TowerDx - WlsDw+fiber_thickness/2.0)/2.0-(fiber_bending_R_1)+(thin_frame_width)+cutout_margin))/2,
+                                                                                               -0.9 * (TowerDx - WlsDw - thin_frame_width) / 2.0 + (fiber_thickness + 2 * cutout_margin) / 2.0, (thickness_absorber) / 2. - thickness_scintillator / 2 + (fiber_thickness + cutout_margin) / 2.0),
+                                                                  logic_embed_fiber_straight_1,
+                                                                  "embed_fiber_straight_W_1_placed",
+                                                                  miniblock_W_logic,
+                                                                  0, 0, OverlapCheck());
+    if (m_doLightProp)
+    {
+      MakeBoundary(physvol_fiber_loop_W_0, physvol_fiber_loop_W_1, true);
+      MakeBoundary(physvol_fiber_loop_W_1, physvol_fiber_loop_W_2, true);
     }
   }
   //**********************************************************************************************
   /* create wavelength shifting "fiber-block"  */
   //**********************************************************************************************
-  if(thin_frame_width>0){
+  if (thin_frame_width > 0)
+  {
     G4Material* material_frame = G4Material::GetMaterial("G4_Fe");
 
-    G4VSolid* solid_frame_plate = new G4Box("single_plate_frame", 
-                                            (thin_frame_width)/2, (TowerDy-2*thick_frame_width)/2, TowerDz/2);
+    G4VSolid* solid_frame_plate = new G4Box("single_plate_frame",
+                                            (thin_frame_width) / 2, (TowerDy - 2 * thick_frame_width) / 2, TowerDz / 2);
     G4LogicalVolume* logic_frame = new G4LogicalVolume(solid_frame_plate,
-                                                    material_frame,
-                                                    "hLFHCAL_frame_plate_logic",
-                                                    0, 0, 0);  
+                                                       material_frame,
+                                                       "hLFHCAL_frame_plate_logic",
+                                                       0, 0, 0);
     m_DisplayAction->AddVolume(logic_frame, "Frame");
 
-    new G4PVPlacement(0, G4ThreeVector(-TowerDx/2+thin_frame_width/2, 0, 0.),
+    new G4PVPlacement(0, G4ThreeVector(-TowerDx / 2 + thin_frame_width / 2, 0, 0.),
                       logic_frame,
                       m_TowerLogicNamePrefix + "_single_plate_frame_left",
                       single_tower_logic,
                       0, 0, OverlapCheck());
-    new G4PVPlacement(0, G4ThreeVector(TowerDx/2-thin_frame_width/2, 0, 0.),
+    new G4PVPlacement(0, G4ThreeVector(TowerDx / 2 - thin_frame_width / 2, 0, 0.),
                       logic_frame,
                       m_TowerLogicNamePrefix + "_single_plate_frame_right",
                       single_tower_logic,
                       0, 0, OverlapCheck());
 
-    G4VSolid* solid_cover_plate = new G4Box("single_plate_cover", 
-                                            TowerDx/2, thick_frame_width/2, TowerDz/2);
+    G4VSolid* solid_cover_plate = new G4Box("single_plate_cover",
+                                            TowerDx / 2, thick_frame_width / 2, TowerDz / 2);
     G4LogicalVolume* logic_cover = new G4LogicalVolume(solid_cover_plate,
-                                                    material_frame,
-                                                    "hLFHCAL_cover_plate_logic",
-                                                    0, 0, 0);  
+                                                       material_frame,
+                                                       "hLFHCAL_cover_plate_logic",
+                                                       0, 0, 0);
     m_DisplayAction->AddVolume(logic_cover, "Frame");
 
-    new G4PVPlacement(0, G4ThreeVector(0, -TowerDy/2+thick_frame_width/2, 0.),
+    new G4PVPlacement(0, G4ThreeVector(0, -TowerDy / 2 + thick_frame_width / 2, 0.),
                       logic_cover,
                       m_TowerLogicNamePrefix + "_single_plate_cover_top",
                       single_tower_logic,
                       0, 0, OverlapCheck());
-    new G4PVPlacement(0, G4ThreeVector(0, TowerDy/2-thick_frame_width/2, 0.),
+    new G4PVPlacement(0, G4ThreeVector(0, TowerDy / 2 - thick_frame_width / 2, 0.),
                       logic_cover,
                       m_TowerLogicNamePrefix + "_single_plate_cover_bottom",
                       single_tower_logic,
                       0, 0, OverlapCheck());
   }
-  
-  
+
   //**********************************************************************************************
   /* create logical volume for single tower */
   //**********************************************************************************************
@@ -449,117 +446,115 @@ PHG4LFHcalDetector::ConstructTower()
   double WTowerLength = 0.;
   int nLayersSteel = nlayers;
   int nLayersTungsten = 0;
-  if(m_Params->get_int_param("usetailcatcher")){
-    SteelTowerLength -= 10*(thickness_absorber+thickness_scintillator);
+  if (m_Params->get_int_param("usetailcatcher"))
+  {
+    SteelTowerLength -= 10 * (thickness_absorber + thickness_scintillator);
     nLayersSteel -= 10;
     nLayersTungsten = 10;
-    WTowerLength = 10*(thickness_absorber+thickness_scintillator);
+    WTowerLength = 10 * (thickness_absorber + thickness_scintillator);
     std::cout << "using 10 layer tungsten tailcatcher in LFHCAL" << std::endl;
   }
 
-  std::vector< G4ExtrudedSolid::ZSection> zsections_steeltower = {{-(SteelTowerLength) / 2.0,{0,0},1.0}, {(SteelTowerLength) / 2.0, {0,0},1.}};
+  std::vector<G4ExtrudedSolid::ZSection> zsections_steeltower = {{-(SteelTowerLength) / 2.0, {0, 0}, 1.0}, {(SteelTowerLength) / 2.0, {0, 0}, 1.}};
   G4VSolid* single_tower_solidRep = new G4ExtrudedSolid("single_tower_solidRep", poligon, zsections_steeltower);
 
   G4LogicalVolume* single_tower_logicRep = new G4LogicalVolume(single_tower_solidRep,
-                                                            WorldMaterial,
-                                                            "single_tower_logicRep",
-                                                            0, 0, 0);
+                                                               WorldMaterial,
+                                                               "single_tower_logicRep",
+                                                               0, 0, 0);
   string name_tower = m_TowerLogicNamePrefix;
-  new G4PVReplica(name_tower,miniblock_logic,single_tower_logicRep,
-                      kZAxis,nLayersSteel, thickness_absorber+thickness_scintillator,0);
-  
-  new G4PVPlacement(0, G4ThreeVector(0, 0, -WTowerLength/2),
-                  single_tower_logicRep,
-                  name_tower,
-                  single_tower_logic,
-                  0, 0, OverlapCheck());
+  new G4PVReplica(name_tower, miniblock_logic, single_tower_logicRep,
+                  kZAxis, nLayersSteel, thickness_absorber + thickness_scintillator, 0);
+
+  new G4PVPlacement(0, G4ThreeVector(0, 0, -WTowerLength / 2),
+                    single_tower_logicRep,
+                    name_tower,
+                    single_tower_logic,
+                    0, 0, OverlapCheck());
 
   m_DisplayAction->AddVolume(single_tower_logicRep, "SingleTower");
   m_DisplayAction->AddVolume(single_tower_logic, "SingleTower");
 
-  if(m_Params->get_int_param("usetailcatcher")){
-    std::vector< G4ExtrudedSolid::ZSection> zsections_wtower = {{-(WTowerLength) / 2.0,{0,0},1.0}, {(WTowerLength) / 2.0, {0,0},1.}};
+  if (m_Params->get_int_param("usetailcatcher"))
+  {
+    std::vector<G4ExtrudedSolid::ZSection> zsections_wtower = {{-(WTowerLength) / 2.0, {0, 0}, 1.0}, {(WTowerLength) / 2.0, {0, 0}, 1.}};
     G4VSolid* single_tower_W_solidRep = new G4ExtrudedSolid("single_tower_W_solidRep", poligon, zsections_wtower);
 
     G4LogicalVolume* single_tower_W_logicRep = new G4LogicalVolume(single_tower_W_solidRep,
-                                                              WorldMaterial,
-                                                              "single_tower_W_logicRep",
-                                                              0, 0, 0);
+                                                                   WorldMaterial,
+                                                                   "single_tower_W_logicRep",
+                                                                   0, 0, 0);
     string name_tower_W = m_TowerLogicNamePrefix + "_W";
-    new G4PVReplica(name_tower_W,miniblock_W_logic,single_tower_W_logicRep,
-                        kZAxis,nLayersTungsten, thickness_absorber+thickness_scintillator,0);
+    new G4PVReplica(name_tower_W, miniblock_W_logic, single_tower_W_logicRep,
+                    kZAxis, nLayersTungsten, thickness_absorber + thickness_scintillator, 0);
 
-    new G4PVPlacement(0, G4ThreeVector(0, 0, SteelTowerLength/2),
-                    single_tower_W_logicRep,
-                    name_tower_W,
-                    single_tower_logic,
-                    0, 0, OverlapCheck());
+    new G4PVPlacement(0, G4ThreeVector(0, 0, SteelTowerLength / 2),
+                      single_tower_W_logicRep,
+                      name_tower_W,
+                      single_tower_logic,
+                      0, 0, OverlapCheck());
 
     m_DisplayAction->AddVolume(single_tower_W_logicRep, "SingleTower_W");
-
   }
-  if(embed_fiber){
-    G4double spacer_width = 1.5*mm;
-    G4double add_spacing = spacer_width+0.1*mm;
+  if (embed_fiber)
+  {
+    G4double spacer_width = 1.5 * mm;
+    G4double add_spacing = spacer_width + 0.1 * mm;
     G4double extraspacing = add_spacing;
-    for(int ilay=0;ilay<nlayers;ilay++){
-      if((SteelTowerLength+WTowerLength - ilay*(thickness_absorber + thickness_scintillator) - thickness_absorber - thickness_scintillator/2 - fiber_bending_R/2) / 2.0 > 0){
+    for (int ilay = 0; ilay < nlayers; ilay++)
+    {
+      if ((SteelTowerLength + WTowerLength - ilay * (thickness_absorber + thickness_scintillator) - thickness_absorber - thickness_scintillator / 2 - fiber_bending_R / 2) / 2.0 > 0)
+      {
         G4VSolid* solid_long_fiber_tmp = new G4Tubs("solid_long_fiber_tmp_" + std::to_string(ilay),
-                                                0,
-                                                fiber_thickness/2.0 ,
-                                                (SteelTowerLength+WTowerLength - ilay*(thickness_absorber + thickness_scintillator) - thickness_absorber - fiber_thickness/2 - fiber_bending_R/2) / 2.0,
-                                                0, 2.0*M_PI);
+                                                    0,
+                                                    fiber_thickness / 2.0,
+                                                    (SteelTowerLength + WTowerLength - ilay * (thickness_absorber + thickness_scintillator) - thickness_absorber - fiber_thickness / 2 - fiber_bending_R / 2) / 2.0,
+                                                    0, 2.0 * M_PI);
 
         G4LogicalVolume* logic_long_fiber_tmp = new G4LogicalVolume(solid_long_fiber_tmp,
-                                                                  material_wls,
-                                                                  "logic_long_fiber_tmp" + std::to_string(ilay),
-                                                                  0, 0, 0);
-        new G4PVPlacement(0, G4ThreeVector(
-          (TowerDx - WlsDw+fiber_thickness/2.0)/2.0,
-          TowerDy/2-thick_frame_width-fiber_thickness-ilay*(1.01*fiber_thickness)-extraspacing,
-          (ilay*(thickness_absorber + thickness_scintillator)  + thickness_absorber + fiber_thickness/2 + fiber_bending_R/2)/ 2.0),
-                        logic_long_fiber_tmp,
-                        "phys_long_fiber_tmp" + std::to_string(ilay),
-                        single_tower_logic,
-                        0, 0, OverlapCheck());
+                                                                    material_wls,
+                                                                    "logic_long_fiber_tmp" + std::to_string(ilay),
+                                                                    0, 0, 0);
+        new G4PVPlacement(0, G4ThreeVector((TowerDx - WlsDw + fiber_thickness / 2.0) / 2.0, TowerDy / 2 - thick_frame_width - fiber_thickness - ilay * (1.01 * fiber_thickness) - extraspacing, (ilay * (thickness_absorber + thickness_scintillator) + thickness_absorber + fiber_thickness / 2 + fiber_bending_R / 2) / 2.0),
+                          logic_long_fiber_tmp,
+                          "phys_long_fiber_tmp" + std::to_string(ilay),
+                          single_tower_logic,
+                          0, 0, OverlapCheck());
         m_DisplayAction->AddVolume(logic_long_fiber_tmp, "WLSfiber");
       }
 
       // short fiber piece from loop to backward readout
-      G4double shortup_fiber_length = TowerDy/2-thick_frame_width-fiber_thickness-ilay*(1.01*fiber_thickness)-extraspacing - fiber_bending_R/2 + TowerDy/2 -thick_frame_width - notch_length/2;
+      G4double shortup_fiber_length = TowerDy / 2 - thick_frame_width - fiber_thickness - ilay * (1.01 * fiber_thickness) - extraspacing - fiber_bending_R / 2 + TowerDy / 2 - thick_frame_width - notch_length / 2;
       G4VSolid* solid_shortup_fiber_tmp = new G4Tubs("solid_shortup_fiber_tmp_" + std::to_string(ilay),
-                                                0,
-                                                fiber_thickness/2.0 ,
-                                                shortup_fiber_length / 2.0,
-                                                0, 2.0*M_PI);
+                                                     0,
+                                                     fiber_thickness / 2.0,
+                                                     shortup_fiber_length / 2.0,
+                                                     0, 2.0 * M_PI);
       G4LogicalVolume* logic_shortup_fiber_tmp = new G4LogicalVolume(solid_shortup_fiber_tmp,
-                                                                material_wls,
-                                                                "logic_shortup_fiber_tmp" + std::to_string(ilay),
-                                                                0, 0, 0);
-      
+                                                                     material_wls,
+                                                                     "logic_shortup_fiber_tmp" + std::to_string(ilay),
+                                                                     0, 0, 0);
+
       G4RotationMatrix* wls_rotm_fibr3 = new G4RotationMatrix();
       wls_rotm_fibr3->rotateX(90 * deg);
-      new G4PVPlacement(wls_rotm_fibr3, G4ThreeVector(
-        (TowerDx - WlsDw+fiber_thickness/2.0)/2.0,
-        TowerDy/2-thick_frame_width-fiber_thickness-ilay*(1.01*fiber_thickness)-extraspacing - fiber_bending_R/2 - (shortup_fiber_length/2.0),
-        -TowerDz/2+ilay*(thickness_absorber + thickness_scintillator)+ thickness_absorber + fiber_thickness/2),
-                      logic_shortup_fiber_tmp,
-                      "phys_shortup_fiber_tmp" + std::to_string(ilay),
-                      single_tower_logic,
-                      0, 0, OverlapCheck());
+      new G4PVPlacement(wls_rotm_fibr3, G4ThreeVector((TowerDx - WlsDw + fiber_thickness / 2.0) / 2.0, TowerDy / 2 - thick_frame_width - fiber_thickness - ilay * (1.01 * fiber_thickness) - extraspacing - fiber_bending_R / 2 - (shortup_fiber_length / 2.0), -TowerDz / 2 + ilay * (thickness_absorber + thickness_scintillator) + thickness_absorber + fiber_thickness / 2),
+                        logic_shortup_fiber_tmp,
+                        "phys_shortup_fiber_tmp" + std::to_string(ilay),
+                        single_tower_logic,
+                        0, 0, OverlapCheck());
       m_DisplayAction->AddVolume(logic_shortup_fiber_tmp, "WLSfiber");
-
 
       // curved fiber piece to backward readout
       G4VSolid* solid_fiber_curved = new G4Torus("solid_fiber_curved",
-                                          0, fiber_thickness / 2.0,
-                                          (fiber_bending_R) / 2.0,
-                                          0.5*M_PI, 0.5*M_PI);
-      if(ilay==nlayers-1){
+                                                 0, fiber_thickness / 2.0,
+                                                 (fiber_bending_R) / 2.0,
+                                                 0.5 * M_PI, 0.5 * M_PI);
+      if (ilay == nlayers - 1)
+      {
         solid_fiber_curved = new G4Torus("solid_fiber_curved_lastlayer",
-                                          0, fiber_thickness / 2.0,
-                                          (fiber_bending_R) / 2.0,
-                                          0.6*M_PI, 0.4*M_PI);
+                                         0, fiber_thickness / 2.0,
+                                         (fiber_bending_R) / 2.0,
+                                         0.6 * M_PI, 0.4 * M_PI);
       }
       G4LogicalVolume* logic_fiber_curved = new G4LogicalVolume(solid_fiber_curved,
                                                                 material_wls,
@@ -568,34 +563,30 @@ PHG4LFHcalDetector::ConstructTower()
 
       G4RotationMatrix* wls_rotm_fibr2 = new G4RotationMatrix();
       wls_rotm_fibr2->rotateY(90 * deg);
-      new G4PVPlacement(wls_rotm_fibr2, G4ThreeVector(
-        (TowerDx - WlsDw+fiber_thickness/2.0)/2.0,
-        TowerDy/2-thick_frame_width-fiber_thickness-ilay*(1.01*fiber_thickness)-extraspacing - fiber_bending_R/2,
-        -TowerDz/2+ilay*(thickness_absorber + thickness_scintillator)+ thickness_absorber + fiber_thickness/2 + fiber_bending_R/2),
-                      logic_fiber_curved,
-                      "phys_fiber_curved" + std::to_string(ilay),
-                      single_tower_logic,
-                      0, 0, OverlapCheck());
+      new G4PVPlacement(wls_rotm_fibr2, G4ThreeVector((TowerDx - WlsDw + fiber_thickness / 2.0) / 2.0, TowerDy / 2 - thick_frame_width - fiber_thickness - ilay * (1.01 * fiber_thickness) - extraspacing - fiber_bending_R / 2, -TowerDz / 2 + ilay * (thickness_absorber + thickness_scintillator) + thickness_absorber + fiber_thickness / 2 + fiber_bending_R / 2),
+                        logic_fiber_curved,
+                        "phys_fiber_curved" + std::to_string(ilay),
+                        single_tower_logic,
+                        0, 0, OverlapCheck());
       m_DisplayAction->AddVolume(logic_fiber_curved, "WLSfiber");
-      if((ilay+1)%10==0){
-        if(((SteelTowerLength+WTowerLength - ilay*(thickness_absorber + thickness_scintillator) - thickness_absorber - thickness_scintillator/2 - thickness_absorber/2) / 2.0)>0){
+      if ((ilay + 1) % 10 == 0)
+      {
+        if (((SteelTowerLength + WTowerLength - ilay * (thickness_absorber + thickness_scintillator) - thickness_absorber - thickness_scintillator / 2 - thickness_absorber / 2) / 2.0) > 0)
+        {
           G4VSolid* solid_spacer_tmp = new G4Box("solid_spacer_tmp_" + std::to_string(ilay),
-                                                (WlsDw)/4,
-                                                spacer_width/2.0 ,
-                                                (SteelTowerLength+WTowerLength - ilay*(thickness_absorber + thickness_scintillator) - thickness_absorber - thickness_scintillator/2 - thickness_absorber/2) / 2.0);
+                                                 (WlsDw) / 4,
+                                                 spacer_width / 2.0,
+                                                 (SteelTowerLength + WTowerLength - ilay * (thickness_absorber + thickness_scintillator) - thickness_absorber - thickness_scintillator / 2 - thickness_absorber / 2) / 2.0);
 
           G4LogicalVolume* logic_spacer_tmp = new G4LogicalVolume(solid_spacer_tmp,
-                                                                    G4Material::GetMaterial("CFRP_INTT"), // carbon fiber + epoxy
-                                                                    "logic_spacer_tmp" + std::to_string(ilay),
-                                                                    0, 0, 0);
-          new G4PVPlacement(0, G4ThreeVector(
-            (TowerDx - WlsDw/2)/2.0-thin_frame_width,
-            TowerDy/2-thick_frame_width-fiber_thickness-(ilay+0.5)*(1.01*fiber_thickness)-extraspacing - add_spacing/2,
-            (ilay*(thickness_absorber + thickness_scintillator)  + thickness_absorber + thickness_scintillator/2 + thickness_absorber/2)/ 2.0),
-                          logic_spacer_tmp,
-                          "phys_spacer_tmp" + std::to_string(ilay),
-                          single_tower_logic,
-                          0, 0, OverlapCheck());
+                                                                  G4Material::GetMaterial("CFRP_INTT"),  // carbon fiber + epoxy
+                                                                  "logic_spacer_tmp" + std::to_string(ilay),
+                                                                  0, 0, 0);
+          new G4PVPlacement(0, G4ThreeVector((TowerDx - WlsDw / 2) / 2.0 - thin_frame_width, TowerDy / 2 - thick_frame_width - fiber_thickness - (ilay + 0.5) * (1.01 * fiber_thickness) - extraspacing - add_spacing / 2, (ilay * (thickness_absorber + thickness_scintillator) + thickness_absorber + thickness_scintillator / 2 + thickness_absorber / 2) / 2.0),
+                            logic_spacer_tmp,
+                            "phys_spacer_tmp" + std::to_string(ilay),
+                            single_tower_logic,
+                            0, 0, OverlapCheck());
           m_DisplayAction->AddVolume(logic_spacer_tmp, "Spacer");
         }
         extraspacing += add_spacing;
@@ -623,7 +614,7 @@ int PHG4LFHcalDetector::PlaceTower(G4LogicalVolume* hcalenvelope, G4LogicalVolum
     }
 
     int copyno = (iterator->second.idx_j << 16) + iterator->second.idx_k;
-//     std::cout << "tower " << " idx_j = " << iterator->second.idx_j << ", idx_k = " << iterator->second.idx_k << " cpNo: " << copyno << std::endl;
+    //     std::cout << "tower " << " idx_j = " << iterator->second.idx_j << ", idx_k = " << iterator->second.idx_k << " cpNo: " << copyno << std::endl;
     new G4PVPlacement(0, G4ThreeVector(iterator->second.x, iterator->second.y, iterator->second.z),
                       singletower,
                       iterator->first,
@@ -634,18 +625,17 @@ int PHG4LFHcalDetector::PlaceTower(G4LogicalVolume* hcalenvelope, G4LogicalVolum
   return 0;
 }
 
-
 //_______________________________________________________________________
 G4Material* PHG4LFHcalDetector::GetScintillatorMaterial()
 {
-
-	G4double density;
-	G4int ncomponents;
-  G4Material* material_ScintFEMC = new G4Material("PolystyreneFEMC", density = 1.03 * g / cm3, ncomponents=2);
+  G4double density;
+  G4int ncomponents;
+  G4Material* material_ScintFEMC = new G4Material("PolystyreneFEMC", density = 1.03 * g / cm3, ncomponents = 2);
   material_ScintFEMC->AddElement(G4Element::GetElement("C"), 8);
   material_ScintFEMC->AddElement(G4Element::GetElement("H"), 8);
 
-  if(m_doLightProp){
+  if (m_doLightProp)
+  {
     // const G4int ntab = 31;
     // G4double opt_en[] =
     //   { 1.37760*eV, 1.45864*eV, 1.54980*eV, 1.65312*eV, 1.71013*eV, 1.77120*eV, 1.83680*eV, 1.90745*eV, 1.98375*eV, 2.06640*eV,
@@ -660,37 +650,37 @@ G4Material* PHG4LFHcalDetector::GetScintillatorMaterial()
 
     const G4int nEntries = 50;
     G4double photonEnergy[nEntries] =
-      { 2.00*eV,2.03*eV,2.06*eV,2.09*eV,2.12*eV,
-        2.15*eV,2.18*eV,2.21*eV,2.24*eV,2.27*eV,
-        2.30*eV,2.33*eV,2.36*eV,2.39*eV,2.42*eV,
-        2.45*eV,2.48*eV,2.51*eV,2.54*eV,2.57*eV,
-        2.60*eV,2.63*eV,2.66*eV,2.69*eV,2.72*eV,
-        2.75*eV,2.78*eV,2.81*eV,2.84*eV,2.87*eV,
-        2.90*eV,2.93*eV,2.96*eV,2.99*eV,3.02*eV,
-        3.05*eV,3.08*eV,3.11*eV,3.14*eV,3.17*eV,
-        3.20*eV,3.23*eV,3.26*eV,3.29*eV,3.32*eV,
-        3.35*eV,3.38*eV,3.41*eV,3.44*eV,3.47*eV};
+        {2.00 * eV, 2.03 * eV, 2.06 * eV, 2.09 * eV, 2.12 * eV,
+         2.15 * eV, 2.18 * eV, 2.21 * eV, 2.24 * eV, 2.27 * eV,
+         2.30 * eV, 2.33 * eV, 2.36 * eV, 2.39 * eV, 2.42 * eV,
+         2.45 * eV, 2.48 * eV, 2.51 * eV, 2.54 * eV, 2.57 * eV,
+         2.60 * eV, 2.63 * eV, 2.66 * eV, 2.69 * eV, 2.72 * eV,
+         2.75 * eV, 2.78 * eV, 2.81 * eV, 2.84 * eV, 2.87 * eV,
+         2.90 * eV, 2.93 * eV, 2.96 * eV, 2.99 * eV, 3.02 * eV,
+         3.05 * eV, 3.08 * eV, 3.11 * eV, 3.14 * eV, 3.17 * eV,
+         3.20 * eV, 3.23 * eV, 3.26 * eV, 3.29 * eV, 3.32 * eV,
+         3.35 * eV, 3.38 * eV, 3.41 * eV, 3.44 * eV, 3.47 * eV};
     G4double scintilFast[nEntries] =
-      { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-        1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
-        1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+        {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+         1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
 
     const G4int ntab = 4;
 
-    G4double wls_Energy[] = { 2.00 * eV, 2.87 * eV, 2.90 * eV,
-                                        3.47 * eV };
+    G4double wls_Energy[] = {2.00 * eV, 2.87 * eV, 2.90 * eV,
+                             3.47 * eV};
 
-    G4double rIndexPstyrene[] = { 1.5, 1.5, 1.5, 1.5 };
-    G4double absorption1[]    = { 2. * cm, 2. * cm, 2. * cm, 2. * cm };
+    G4double rIndexPstyrene[] = {1.5, 1.5, 1.5, 1.5};
+    G4double absorption1[] = {2. * cm, 2. * cm, 2. * cm, 2. * cm};
     // G4double scintilFast[]    = { 0.0, 0.0, 1.0, 1.0 };
     G4MaterialPropertiesTable* fMPTPStyrene = new G4MaterialPropertiesTable();
-    fMPTPStyrene->AddProperty("RINDEX", wls_Energy, rIndexPstyrene,ntab);
-    fMPTPStyrene->AddProperty("ABSLENGTH", wls_Energy, absorption1,ntab);
+    fMPTPStyrene->AddProperty("RINDEX", wls_Energy, rIndexPstyrene, ntab);
+    fMPTPStyrene->AddProperty("ABSLENGTH", wls_Energy, absorption1, ntab);
     // fMPTPStyrene->AddProperty("ABSLENGTH", opt_en, opt_abs, ntab);
     // fMPTPStyrene->AddProperty("SCINTILLATIONCOMPONENT1", wls_Energy, scintilFast,ntab);
-    fMPTPStyrene->AddProperty("SCINTILLATIONCOMPONENT1",photonEnergy, scintilFast,nEntries);
+    fMPTPStyrene->AddProperty("SCINTILLATIONCOMPONENT1", photonEnergy, scintilFast, nEntries);
     fMPTPStyrene->AddConstProperty("SCINTILLATIONYIELD", 10. / keV);
     fMPTPStyrene->AddConstProperty("RESOLUTIONSCALE", 1.0);
     fMPTPStyrene->AddConstProperty("SCINTILLATIONTIMECONSTANT", 10. * ns);
@@ -708,13 +698,12 @@ G4Material* PHG4LFHcalDetector::GetScintillatorMaterial()
 //_______________________________________________________________________
 G4Material* PHG4LFHcalDetector::GetCoatingMaterial()
 {
-
   //--------------------------------------------------
   // TiO2
   //--------------------------------------------------
-	G4double density,fractionmass;
-	G4int ncomponents;
-  G4Material* material_TiO2 = new G4Material("TiO2_FEMC", density = 1.52 * g / cm3, ncomponents=2);
+  G4double density, fractionmass;
+  G4int ncomponents;
+  G4Material* material_TiO2 = new G4Material("TiO2_FEMC", density = 1.52 * g / cm3, ncomponents = 2);
   material_TiO2->AddElement(G4Element::GetElement("Ti"), 1);
   material_TiO2->AddElement(G4Element::GetElement("O"), 2);
 
@@ -723,7 +712,7 @@ G4Material* PHG4LFHcalDetector::GetCoatingMaterial()
   //--------------------------------------------------
   //Coating_FEMC (Glass + Epoxy)
   density = 1.86 * g / cm3;
-  G4Material *Coating_FEMC = new G4Material("Coating_FEMC", density, ncomponents = 2);
+  G4Material* Coating_FEMC = new G4Material("Coating_FEMC", density, ncomponents = 2);
   Coating_FEMC->AddMaterial(G4Material::GetMaterial("Epoxy"), fractionmass = 0.80);
   Coating_FEMC->AddMaterial(material_TiO2, fractionmass = 0.20);
 
@@ -731,9 +720,9 @@ G4Material* PHG4LFHcalDetector::GetCoatingMaterial()
 }
 
 //_____________________________________________________________________________
-void PHG4LFHcalDetector::SurfaceTable(G4LogicalVolume *vol) {
-
-  G4OpticalSurface *surface = new G4OpticalSurface("ScintWrapB1");
+void PHG4LFHcalDetector::SurfaceTable(G4LogicalVolume* vol)
+{
+  G4OpticalSurface* surface = new G4OpticalSurface("ScintWrapB1");
 
   new G4LogicalSkinSurface("CrystalSurfaceL", vol, surface);
 
@@ -745,16 +734,16 @@ void PHG4LFHcalDetector::SurfaceTable(G4LogicalVolume *vol) {
 
   //surface material
   const G4int ntab = 2;
-  G4double opt_en[] = {1.551*eV, 3.545*eV}; // 350 - 800 nm
+  G4double opt_en[] = {1.551 * eV, 3.545 * eV};  // 350 - 800 nm
   G4double reflectivity[] = {0.9, 0.9};
   G4double efficiency[] = {0.99, 0.99};
-  G4MaterialPropertiesTable *surfmat = new G4MaterialPropertiesTable();
+  G4MaterialPropertiesTable* surfmat = new G4MaterialPropertiesTable();
   surfmat->AddProperty("REFLECTIVITY", opt_en, reflectivity, ntab);
   surfmat->AddProperty("EFFICIENCY", opt_en, efficiency, ntab);
   surface->SetMaterialPropertiesTable(surfmat);
   //csurf->DumpInfo();
 
-}//SurfaceTable
+}  //SurfaceTable
 //_______________________________________________________________________
 G4Material* PHG4LFHcalDetector::GetWLSFiberMaterial()
 {
@@ -763,51 +752,52 @@ G4Material* PHG4LFHcalDetector::GetWLSFiberMaterial()
     std::cout << "PHG4ForwardEcalDetector: Making WLSFiberFEMC PMMA material..." << std::endl;
   }
 
-	G4double density;
-	G4int ncomponents;
+  G4double density;
+  G4int ncomponents;
 
   G4Material* material_WLSFiberFEMC = new G4Material("WLSFiberFEMC", density = 1.18 * g / cm3, ncomponents = 3);
   material_WLSFiberFEMC->AddElement(G4Element::GetElement("C"), 5);
   material_WLSFiberFEMC->AddElement(G4Element::GetElement("H"), 8);
   material_WLSFiberFEMC->AddElement(G4Element::GetElement("O"), 2);
-  if(m_doLightProp){
+  if (m_doLightProp)
+  {
     const G4int nEntries = 50;
     G4double photonEnergy[nEntries] =
-      { 2.00*eV,2.03*eV,2.06*eV,2.09*eV,2.12*eV,
-        2.15*eV,2.18*eV,2.21*eV,2.24*eV,2.27*eV,
-        2.30*eV,2.33*eV,2.36*eV,2.39*eV,2.42*eV,
-        2.45*eV,2.48*eV,2.51*eV,2.54*eV,2.57*eV,
-        2.60*eV,2.63*eV,2.66*eV,2.69*eV,2.72*eV,
-        2.75*eV,2.78*eV,2.81*eV,2.84*eV,2.87*eV,
-        2.90*eV,2.93*eV,2.96*eV,2.99*eV,3.02*eV,
-        3.05*eV,3.08*eV,3.11*eV,3.14*eV,3.17*eV,
-        3.20*eV,3.23*eV,3.26*eV,3.29*eV,3.32*eV,
-        3.35*eV,3.38*eV,3.41*eV,3.44*eV,3.47*eV};
+        {2.00 * eV, 2.03 * eV, 2.06 * eV, 2.09 * eV, 2.12 * eV,
+         2.15 * eV, 2.18 * eV, 2.21 * eV, 2.24 * eV, 2.27 * eV,
+         2.30 * eV, 2.33 * eV, 2.36 * eV, 2.39 * eV, 2.42 * eV,
+         2.45 * eV, 2.48 * eV, 2.51 * eV, 2.54 * eV, 2.57 * eV,
+         2.60 * eV, 2.63 * eV, 2.66 * eV, 2.69 * eV, 2.72 * eV,
+         2.75 * eV, 2.78 * eV, 2.81 * eV, 2.84 * eV, 2.87 * eV,
+         2.90 * eV, 2.93 * eV, 2.96 * eV, 2.99 * eV, 3.02 * eV,
+         3.05 * eV, 3.08 * eV, 3.11 * eV, 3.14 * eV, 3.17 * eV,
+         3.20 * eV, 3.23 * eV, 3.26 * eV, 3.29 * eV, 3.32 * eV,
+         3.35 * eV, 3.38 * eV, 3.41 * eV, 3.44 * eV, 3.47 * eV};
     G4double refractiveIndexWLSfiber[nEntries] =
-      { 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60,
-        1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60,
-        1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60,
-        1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60,
-        1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60};
-   
+        {1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60,
+         1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60,
+         1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60,
+         1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60,
+         1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60};
+
     G4double absWLSfiber[nEntries] =
-      {5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,
-        5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,
-        5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,1.10*m,
-        1.10*m,1.10*m,1.10*m,1.10*m,1.10*m,1.10*m, 1.*mm, 1.*mm, 1.*mm, 1.*mm,
-        1.*mm, 1.*mm, 1.*mm, 1.*mm, 1.*mm, 1.*mm, 1.*mm, 1.*mm, 1.*mm, 1.*mm};
-   
+        {5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m,
+         5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m,
+         5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m, 5.40 * m, 1.10 * m,
+         1.10 * m, 1.10 * m, 1.10 * m, 1.10 * m, 1.10 * m, 1.10 * m, 1. * mm, 1. * mm, 1. * mm, 1. * mm,
+         1. * mm, 1. * mm, 1. * mm, 1. * mm, 1. * mm, 1. * mm, 1. * mm, 1. * mm, 1. * mm, 1. * mm};
+
     G4double emissionFib[nEntries] =
-      {0.05, 0.10, 0.30, 0.50, 0.75, 1.00, 1.50, 1.85, 2.30, 2.75,
-        3.25, 3.80, 4.50, 5.20, 6.00, 7.00, 8.50, 9.50, 11.1, 12.4,
-        12.9, 13.0, 12.8, 12.3, 11.1, 11.0, 12.0, 11.0, 17.0, 16.9,
-        15.0, 9.00, 2.50, 1.00, 0.05, 0.00, 0.00, 0.00, 0.00, 0.00,
-        0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00};
+        {0.05, 0.10, 0.30, 0.50, 0.75, 1.00, 1.50, 1.85, 2.30, 2.75,
+         3.25, 3.80, 4.50, 5.20, 6.00, 7.00, 8.50, 9.50, 11.1, 12.4,
+         12.9, 13.0, 12.8, 12.3, 11.1, 11.0, 12.0, 11.0, 17.0, 16.9,
+         15.0, 9.00, 2.50, 1.00, 0.05, 0.00, 0.00, 0.00, 0.00, 0.00,
+         0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00};
     // Add entries into properties table
     G4MaterialPropertiesTable* mptWLSfiber = new G4MaterialPropertiesTable();
-    mptWLSfiber->AddProperty("RINDEX", photonEnergy, refractiveIndexWLSfiber,nEntries);
-    mptWLSfiber->AddProperty("WLSABSLENGTH", photonEnergy, absWLSfiber,nEntries);
-    mptWLSfiber->AddProperty("WLSCOMPONENT", photonEnergy, emissionFib,nEntries);
+    mptWLSfiber->AddProperty("RINDEX", photonEnergy, refractiveIndexWLSfiber, nEntries);
+    mptWLSfiber->AddProperty("WLSABSLENGTH", photonEnergy, absWLSfiber, nEntries);
+    mptWLSfiber->AddProperty("WLSCOMPONENT", photonEnergy, emissionFib, nEntries);
     mptWLSfiber->AddConstProperty("WLSTIMECONSTANT", 0.5 * ns);
     material_WLSFiberFEMC->SetMaterialPropertiesTable(mptWLSfiber);
   }
@@ -819,15 +809,13 @@ G4Material* PHG4LFHcalDetector::GetWLSFiberMaterial()
   return material_WLSFiberFEMC;
 }
 
-
-
 //_____________________________________________________________________________
-void PHG4LFHcalDetector::MakeBoundary(G4VPhysicalVolume *crystal, G4VPhysicalVolume *opdet, bool isFiber) {
-
+void PHG4LFHcalDetector::MakeBoundary(G4VPhysicalVolume* crystal, G4VPhysicalVolume* opdet, bool isFiber)
+{
   //optical boundary between the crystal and optical photons detector
 
-  G4OpticalSurface *surf = new G4OpticalSurface("OpDetS");
-  surf->SetType(dielectric_dielectric); // photons go to the detector, must have rindex defined
+  G4OpticalSurface* surf = new G4OpticalSurface("OpDetS");
+  surf->SetType(dielectric_dielectric);  // photons go to the detector, must have rindex defined
   // surf->SetType(dielectric_metal); // photon is absorbed when reaching the detector, no material rindex required
   //surf->SetFinish(ground);
   surf->SetFinish(polished);
@@ -837,31 +825,29 @@ void PHG4LFHcalDetector::MakeBoundary(G4VPhysicalVolume *crystal, G4VPhysicalVol
   new G4LogicalBorderSurface("OpDetB", crystal, opdet, surf);
 
   const G4int ntab = 2;
-  G4double opt_en[] = {1.551*eV, 3.545*eV}; // 350 - 800 nm
+  G4double opt_en[] = {1.551 * eV, 3.545 * eV};  // 350 - 800 nm
   //G4double reflectivity[] = {0., 0.};
   G4double reflectivityFiber[] = {0.0, 0.0};
   //G4double reflectivity[] = {0.9, 0.9};
   //G4double reflectivity[] = {1., 1.};
   G4double efficiency[] = {1., 1.};
-  G4double RefractiveIndexBoundary[] = { 1.0, 1.0};
+  G4double RefractiveIndexBoundary[] = {1.0, 1.0};
 
-  G4MaterialPropertiesTable *surfmat = new G4MaterialPropertiesTable();
+  G4MaterialPropertiesTable* surfmat = new G4MaterialPropertiesTable();
   surfmat->AddProperty("EFFICIENCY", opt_en, efficiency, ntab);
   surfmat->AddProperty("RINDEX", opt_en, RefractiveIndexBoundary, ntab);
   surfmat->AddProperty("REFLECTIVITY", opt_en, reflectivityFiber, ntab);
   surf->SetMaterialPropertiesTable(surfmat);
 
-
-
-}//MakeBoundary
+}  //MakeBoundary
 
 //_____________________________________________________________________________
-void PHG4LFHcalDetector::MakeBoundary_Fiber_Scint(G4VPhysicalVolume *fiber, G4VPhysicalVolume *scinti) {
-
+void PHG4LFHcalDetector::MakeBoundary_Fiber_Scint(G4VPhysicalVolume* fiber, G4VPhysicalVolume* scinti)
+{
   //optical boundary between the fiber and scintillator
 
-  G4OpticalSurface *ScintToFiberS = new G4OpticalSurface("ScintToFiberS");
-  ScintToFiberS->SetType(dielectric_dielectric); // photons go to the detector, must have rindex defined
+  G4OpticalSurface* ScintToFiberS = new G4OpticalSurface("ScintToFiberS");
+  ScintToFiberS->SetType(dielectric_dielectric);  // photons go to the detector, must have rindex defined
   // ScintToFiberS->SetType(dielectric_metal); // photon is absorbed when reaching the detector, no material rindex required
   //ScintToFiberS->SetFinish(ground);
   ScintToFiberS->SetFinish(groundair);
@@ -872,15 +858,15 @@ void PHG4LFHcalDetector::MakeBoundary_Fiber_Scint(G4VPhysicalVolume *fiber, G4VP
   new G4LogicalBorderSurface("ScintToFiberB", scinti, fiber, ScintToFiberS);
 
   const G4int ntab = 2;
-  G4double opt_en[] = {1.551*eV, 3.545*eV}; // 350 - 800 nm
+  G4double opt_en[] = {1.551 * eV, 3.545 * eV};  // 350 - 800 nm
   //G4double reflectivity[] = {0., 0.};
   G4double reflectivity[] = {0.01, 0.01};
   //G4double reflectivity[] = {0.9, 0.9};
   //G4double reflectivity[] = {1., 1.};
   G4double efficiency[] = {1., 1.};
-  G4double RefractiveIndexBoundary[] = { 1.4, 1.4};
+  G4double RefractiveIndexBoundary[] = {1.4, 1.4};
 
-  G4MaterialPropertiesTable *ScintToFiberSmat = new G4MaterialPropertiesTable();
+  G4MaterialPropertiesTable* ScintToFiberSmat = new G4MaterialPropertiesTable();
   ScintToFiberSmat->AddProperty("EFFICIENCY", opt_en, efficiency, ntab);
   ScintToFiberSmat->AddProperty("RINDEX", opt_en, RefractiveIndexBoundary, ntab);
   ScintToFiberSmat->AddProperty("REFLECTIVITY", opt_en, reflectivity, ntab);
@@ -888,9 +874,9 @@ void PHG4LFHcalDetector::MakeBoundary_Fiber_Scint(G4VPhysicalVolume *fiber, G4VP
 
   //optical boundary between the fiber and scintillator
 
-  G4OpticalSurface *FiberToScintSurface = new G4OpticalSurface("ScintToFiberS");
+  G4OpticalSurface* FiberToScintSurface = new G4OpticalSurface("ScintToFiberS");
   // FiberToScintSurface->SetType(dielectric_dielectric); // photons go to the detector, must have rindex defined
-  FiberToScintSurface->SetType(dielectric_metal); // photon is absorbed when reaching the detector, no material rindex required
+  FiberToScintSurface->SetType(dielectric_metal);  // photon is absorbed when reaching the detector, no material rindex required
   //FiberToScintSurface->SetFinish(ground);
   // FiberToScintSurface->SetFinish(groundair);
   FiberToScintSurface->SetFinish(polished);
@@ -900,23 +886,21 @@ void PHG4LFHcalDetector::MakeBoundary_Fiber_Scint(G4VPhysicalVolume *fiber, G4VP
   new G4LogicalBorderSurface("ScintToFiberB", scinti, fiber, FiberToScintSurface);
 
   const G4int ntab2 = 2;
-  G4double opt_en2[] = {1.551*eV, 3.545*eV}; // 350 - 800 nm
+  G4double opt_en2[] = {1.551 * eV, 3.545 * eV};  // 350 - 800 nm
   //G4double reflectivity[] = {0., 0.};
   // G4double reflectivity2[] = {0.01, 0.01};
   //G4double reflectivity[] = {0.9, 0.9};
   G4double reflectivity2[] = {1., 1.};
   G4double efficiency2[] = {1., 1.};
-  G4double RefractiveIndexBoundary2[] = { 1.6, 1.6};
+  G4double RefractiveIndexBoundary2[] = {1.6, 1.6};
 
-  G4MaterialPropertiesTable *FiberToScintSurfacemat = new G4MaterialPropertiesTable();
+  G4MaterialPropertiesTable* FiberToScintSurfacemat = new G4MaterialPropertiesTable();
   FiberToScintSurfacemat->AddProperty("EFFICIENCY", opt_en2, efficiency2, ntab2);
   FiberToScintSurfacemat->AddProperty("RINDEX", opt_en2, RefractiveIndexBoundary2, ntab2);
   FiberToScintSurfacemat->AddProperty("REFLECTIVITY", opt_en2, reflectivity2, ntab2);
   FiberToScintSurface->SetMaterialPropertiesTable(FiberToScintSurfacemat);
 
-
-
-}//MakeBoundary
+}  //MakeBoundary
 
 int PHG4LFHcalDetector::ParseParametersFromTable()
 {
@@ -1088,48 +1072,50 @@ int PHG4LFHcalDetector::ParseParametersFromTable()
 
   parit = m_GlobalParameterMap.find("thickness_absorber");
   if (parit != m_GlobalParameterMap.end())
-    m_Params->set_double_param("thickness_absorber", parit->second);  
+    m_Params->set_double_param("thickness_absorber", parit->second);
 
   parit = m_GlobalParameterMap.find("thickness_scintillator");
   if (parit != m_GlobalParameterMap.end())
-    m_Params->set_double_param("thickness_scintillator", parit->second);  
+    m_Params->set_double_param("thickness_scintillator", parit->second);
 
   parit = m_GlobalParameterMap.find("nlayerspertowerseg");
   if (parit != m_GlobalParameterMap.end())
-    m_Params->set_int_param("nlayerspertowerseg", (int)parit->second);  
+    m_Params->set_int_param("nlayerspertowerseg", (int) parit->second);
 
   parit = m_GlobalParameterMap.find("xoffset");
   if (parit != m_GlobalParameterMap.end())
-    m_Params->set_double_param("xoffset", parit->second);  
+    m_Params->set_double_param("xoffset", parit->second);
 
   parit = m_GlobalParameterMap.find("yoffset");
   if (parit != m_GlobalParameterMap.end())
-    m_Params->set_double_param("yoffset", parit->second);  
-  
+    m_Params->set_double_param("yoffset", parit->second);
+
   parit = m_GlobalParameterMap.find("frame_width");
   if (parit != m_GlobalParameterMap.end())
-    m_Params->set_double_param("frame_width", parit->second);  
-  
+    m_Params->set_double_param("frame_width", parit->second);
+
   parit = m_GlobalParameterMap.find("width_coating");
   if (parit != m_GlobalParameterMap.end())
-    m_Params->set_double_param("width_coating", parit->second);  
-  
+    m_Params->set_double_param("width_coating", parit->second);
+
   parit = m_GlobalParameterMap.find("usetailcatcher");
   if (parit != m_GlobalParameterMap.end())
-    m_Params->set_int_param("usetailcatcher", parit->second);  
-  
+    m_Params->set_int_param("usetailcatcher", parit->second);
+
   parit = m_GlobalParameterMap.find("embed_fiber");
   if (parit != m_GlobalParameterMap.end())
-    m_Params->set_int_param("embed_fiber", parit->second);  
-  
+    m_Params->set_int_param("embed_fiber", parit->second);
+
   //! TODO make this better!
-  if(m_Params->get_int_param("usetailcatcher")){
-    m_Params->set_double_param("zdepthcatcheroffset", m_Params->get_double_param("place_z") + (m_Params->get_double_param("tower_dz")/2) - (10 * (m_Params->get_double_param("thickness_scintillator")+m_Params->get_double_param("thickness_absorber"))));
-    m_Params->set_int_param("nLayerOffsetTailcatcher",  (int)((m_Params->get_double_param("tower_dz")- (10 * (m_Params->get_double_param("thickness_scintillator")+m_Params->get_double_param("thickness_absorber"))))/(m_Params->get_double_param("thickness_scintillator")+m_Params->get_double_param("thickness_absorber"))));
+  if (m_Params->get_int_param("usetailcatcher"))
+  {
+    m_Params->set_double_param("zdepthcatcheroffset", m_Params->get_double_param("place_z") + (m_Params->get_double_param("tower_dz") / 2) - (10 * (m_Params->get_double_param("thickness_scintillator") + m_Params->get_double_param("thickness_absorber"))));
+    m_Params->set_int_param("nLayerOffsetTailcatcher", (int) ((m_Params->get_double_param("tower_dz") - (10 * (m_Params->get_double_param("thickness_scintillator") + m_Params->get_double_param("thickness_absorber")))) / (m_Params->get_double_param("thickness_scintillator") + m_Params->get_double_param("thickness_absorber"))));
   }
-  if (Verbosity() > 1){
-    std::cout << "PHG4 detector LFHCal - Absorber: " << m_Params->get_double_param("thickness_absorber") << " cm\t Scintilator: "<< m_Params->get_double_param("thickness_scintillator") << " cm\t layers per segment: " << m_Params->get_int_param("nlayerspertowerseg") << std::endl;
+  if (Verbosity() > 1)
+  {
+    std::cout << "PHG4 detector LFHCal - Absorber: " << m_Params->get_double_param("thickness_absorber") << " cm\t Scintilator: " << m_Params->get_double_param("thickness_scintillator") << " cm\t layers per segment: " << m_Params->get_int_param("nlayerspertowerseg") << std::endl;
   }
-  
+
   return 0;
 }

--- a/simulation/g4simulation/g4eiccalos/PHG4LFHcalDetector.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4LFHcalDetector.h
@@ -43,7 +43,7 @@ class PHG4LFHcalDetector : public PHG4Detector
   void SuperDetector(const std::string &name) { m_SuperDetector = name; }
   const std::string SuperDetector() const { return m_SuperDetector; }
 
-  PHParameters* getParamsDet() const {return m_Params;}
+  PHParameters *getParamsDet() const { return m_Params; }
 
   int get_Layer() const { return m_Layer; }
 
@@ -53,9 +53,9 @@ class PHG4LFHcalDetector : public PHG4Detector
   G4LogicalVolume *ConstructTower();
   int PlaceTower(G4LogicalVolume *envelope, G4LogicalVolume *tower);
   int ParseParametersFromTable();
-  G4Material*  GetScintillatorMaterial();
-  G4Material*  GetCoatingMaterial();
-  G4Material*  GetWLSFiberMaterial();
+  G4Material *GetScintillatorMaterial();
+  G4Material *GetCoatingMaterial();
+  G4Material *GetWLSFiberMaterial();
   void SurfaceTable(G4LogicalVolume *vol);
   void MakeBoundary(G4VPhysicalVolume *crystal, G4VPhysicalVolume *opdet, bool isFiber);
   void MakeBoundary_Fiber_Scint(G4VPhysicalVolume *crystal, G4VPhysicalVolume *opdet);

--- a/simulation/g4simulation/g4eiccalos/PHG4LFHcalDetector.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4LFHcalDetector.h
@@ -4,6 +4,7 @@
 #define G4DETECTORS_PHG4LFHCALDETECTOR_H
 
 #include <g4main/PHG4Detector.h>
+#include <Geant4/G4Material.hh>
 
 #include <Geant4/G4Types.hh>  // for G4double
 
@@ -46,11 +47,18 @@ class PHG4LFHcalDetector : public PHG4Detector
 
   int get_Layer() const { return m_Layer; }
 
+  void DoFullLightProp(bool doProp) { m_doLightProp = doProp; }
+
  private:
   G4LogicalVolume *ConstructTower();
   int PlaceTower(G4LogicalVolume *envelope, G4LogicalVolume *tower);
   int ParseParametersFromTable();
-
+  G4Material*  GetScintillatorMaterial();
+  G4Material*  GetCoatingMaterial();
+  G4Material*  GetWLSFiberMaterial();
+  void SurfaceTable(G4LogicalVolume *vol);
+  void MakeBoundary(G4VPhysicalVolume *crystal, G4VPhysicalVolume *opdet, bool isFiber);
+  void MakeBoundary_Fiber_Scint(G4VPhysicalVolume *crystal, G4VPhysicalVolume *opdet);
   struct towerposition
   {
     G4double x;
@@ -75,6 +83,8 @@ class PHG4LFHcalDetector : public PHG4Detector
 
   std::set<G4LogicalVolume *> m_AbsorberLogicalVolSet;
   std::set<G4LogicalVolume *> m_ScintiLogicalVolSet;
+
+  bool m_doLightProp = false;
 };
 
 #endif

--- a/simulation/g4simulation/g4eiccalos/PHG4LFHcalDisplayAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4LFHcalDisplayAction.cc
@@ -44,7 +44,7 @@ void PHG4LFHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
     {
       continue;
     }
-    std::cout << showdetails << "\t" << it.second ;
+    // std::cout << showdetails << "\t" << it.second ;
     G4VisAttributes *visatt = new G4VisAttributes();
     visatt->SetForceSolid(true);
     m_VisAttVec.push_back(visatt);  // for later deletion
@@ -52,21 +52,39 @@ void PHG4LFHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
     {
         visatt->SetVisibility(false);
     }
+    else if (it.second == "Wireframe")
+    {
+        visatt->SetColour(G4Colour::Red());
+        visatt->SetForceWireframe(true);
+        visatt->SetVisibility(true);
+    }
     else if (it.second == "Absorber_W")
     {
       if (showdetails){
         visatt->SetColour(G4Colour::Black());
         visatt->SetVisibility(true);
-        std::cout << " is visible" ;
+        // visatt->SetForceWireframe(true);
+        // std::cout << " is visible" ;
       } else 
         visatt->SetVisibility(false);
     }
     else if (it.second == "Absorber")
     {
       if (showdetails){
-        visatt->SetColour(G4Colour::Blue());
+        visatt->SetColour(4 * 21. / 255, 4 * 27. / 255, 4 * 31. / 255);
         visatt->SetVisibility(true);
-        std::cout << " is visible" ;
+        // visatt->SetForceWireframe(true);
+        // std::cout << " is visible" ;
+      } else 
+        visatt->SetVisibility(false);
+    }
+    else if (it.second == "Spacer")
+    {
+      if (showdetails){
+        visatt->SetColour(220. / 255, 220. / 255, 220. / 255);
+        visatt->SetVisibility(true);
+        // visatt->SetForceWireframe(true);
+        // std::cout << " is visible" ;
       } else 
         visatt->SetVisibility(false);
     }
@@ -79,18 +97,35 @@ void PHG4LFHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
     else if (it.second == "Scintillator")
     {
       if (showdetails){
-        visatt->SetColour(G4Colour::White());
+        // visatt->SetColour(G4Colour::White());
+        visatt->SetColour(127./ 255,255./ 255,212./ 255, 0.5);
         visatt->SetVisibility(true);
-        std::cout << " is visible" ;
+        // visatt->SetForceWireframe(true);
+        // std::cout << " is visible" ;
       } else 
         visatt->SetVisibility(false);
     }
-    else if (it.second == "WLSplate" || it.second == "WLSfiber")
+    else if (it.second == "WLSfiber")
+    {
+      if (showdetails){
+        // visatt->SetColour(G4Colour::Blue());
+        visatt->SetColour(20./ 255,10./ 255,200./ 255, 1.0);
+        // visatt->SetColour(152./ 255,10./ 255,10./ 255, 1.0);
+        // visatt->SetColour(152./ 255,251./ 255,152./ 255, 0.9);
+        visatt->SetVisibility(true);
+        // std::cout << " is visible" ;
+      } else 
+        visatt->SetVisibility(false);
+    }
+    else if (it.second == "Frame")
     {
       if (showdetails){
         visatt->SetColour(G4Colour::Yellow());
+        // visatt->SetColour(152./ 255,10./ 255,10./ 255, 0.9);
+        // visatt->SetColour(152./ 255,251./ 255,152./ 255, 0.9);
         visatt->SetVisibility(true);
-        std::cout << " is visible" ;
+        visatt->SetForceWireframe(true);
+        // std::cout << " is visible" ;
       } else 
         visatt->SetVisibility(false);
     }
@@ -101,7 +136,7 @@ void PHG4LFHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
       else {
         visatt->SetColour(G4Colour::Black());
         visatt->SetVisibility(true);
-        std::cout << " is visible" ;
+        // std::cout << " is visible" ;
       }
     }
     else if (it.second == "SingleTower")
@@ -111,7 +146,7 @@ void PHG4LFHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
       else {
         visatt->SetColour(G4Colour::Blue());
         visatt->SetVisibility(true);
-        std::cout << " is visible" ;
+        // std::cout << " is visible" ;
       }
     }
     else
@@ -119,7 +154,7 @@ void PHG4LFHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
       cout << "unknown logical volume " << it.second << endl;
       gSystem->Exit(1);
     }
-    std::cout << std::endl ;
+    // std::cout << std::endl ;
     logvol->SetVisAttributes(visatt);
   }
   return;

--- a/simulation/g4simulation/g4eiccalos/PHG4LFHcalDisplayAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4LFHcalDisplayAction.cc
@@ -9,7 +9,7 @@
 #include <TSystem.h>
 
 #include <iostream>
-#include <utility>                     // for pair
+#include <utility>  // for pair
 
 using namespace std;
 
@@ -50,42 +50,48 @@ void PHG4LFHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
     m_VisAttVec.push_back(visatt);  // for later deletion
     if (it.second == "Invisible")
     {
-        visatt->SetVisibility(false);
+      visatt->SetVisibility(false);
     }
     else if (it.second == "Wireframe")
     {
-        visatt->SetColour(G4Colour::Red());
-        visatt->SetForceWireframe(true);
-        visatt->SetVisibility(true);
+      visatt->SetColour(G4Colour::Red());
+      visatt->SetForceWireframe(true);
+      visatt->SetVisibility(true);
     }
     else if (it.second == "Absorber_W")
     {
-      if (showdetails){
+      if (showdetails)
+      {
         visatt->SetColour(G4Colour::Black());
         visatt->SetVisibility(true);
         // visatt->SetForceWireframe(true);
         // std::cout << " is visible" ;
-      } else 
+      }
+      else
         visatt->SetVisibility(false);
     }
     else if (it.second == "Absorber")
     {
-      if (showdetails){
+      if (showdetails)
+      {
         visatt->SetColour(4 * 21. / 255, 4 * 27. / 255, 4 * 31. / 255);
         visatt->SetVisibility(true);
         // visatt->SetForceWireframe(true);
         // std::cout << " is visible" ;
-      } else 
+      }
+      else
         visatt->SetVisibility(false);
     }
     else if (it.second == "Spacer")
     {
-      if (showdetails){
+      if (showdetails)
+      {
         visatt->SetColour(220. / 255, 220. / 255, 220. / 255);
         visatt->SetVisibility(true);
         // visatt->SetForceWireframe(true);
         // std::cout << " is visible" ;
-      } else 
+      }
+      else
         visatt->SetVisibility(false);
     }
     else if (it.second == "LFHcalEnvelope")
@@ -96,44 +102,51 @@ void PHG4LFHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
     }
     else if (it.second == "Scintillator")
     {
-      if (showdetails){
+      if (showdetails)
+      {
         // visatt->SetColour(G4Colour::White());
-        visatt->SetColour(127./ 255,255./ 255,212./ 255, 0.5);
+        visatt->SetColour(127. / 255, 255. / 255, 212. / 255, 0.5);
         visatt->SetVisibility(true);
         // visatt->SetForceWireframe(true);
         // std::cout << " is visible" ;
-      } else 
+      }
+      else
         visatt->SetVisibility(false);
     }
     else if (it.second == "WLSfiber")
     {
-      if (showdetails){
+      if (showdetails)
+      {
         // visatt->SetColour(G4Colour::Blue());
-        visatt->SetColour(20./ 255,10./ 255,200./ 255, 1.0);
+        visatt->SetColour(20. / 255, 10. / 255, 200. / 255, 1.0);
         // visatt->SetColour(152./ 255,10./ 255,10./ 255, 1.0);
         // visatt->SetColour(152./ 255,251./ 255,152./ 255, 0.9);
         visatt->SetVisibility(true);
         // std::cout << " is visible" ;
-      } else 
+      }
+      else
         visatt->SetVisibility(false);
     }
     else if (it.second == "Frame")
     {
-      if (showdetails){
+      if (showdetails)
+      {
         visatt->SetColour(G4Colour::Yellow());
         // visatt->SetColour(152./ 255,10./ 255,10./ 255, 0.9);
         // visatt->SetColour(152./ 255,251./ 255,152./ 255, 0.9);
         visatt->SetVisibility(true);
         visatt->SetForceWireframe(true);
         // std::cout << " is visible" ;
-      } else 
+      }
+      else
         visatt->SetVisibility(false);
     }
     else if (it.second == "SingleTower_W")
     {
       if (showdetails)
         visatt->SetVisibility(false);
-      else {
+      else
+      {
         visatt->SetColour(G4Colour::Black());
         visatt->SetVisibility(true);
         // std::cout << " is visible" ;
@@ -143,7 +156,8 @@ void PHG4LFHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
     {
       if (showdetails)
         visatt->SetVisibility(false);
-      else {
+      else
+      {
         visatt->SetColour(G4Colour::Blue());
         visatt->SetVisibility(true);
         // std::cout << " is visible" ;

--- a/simulation/g4simulation/g4eiccalos/PHG4LFHcalDisplayAction.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4LFHcalDisplayAction.h
@@ -23,7 +23,7 @@ class PHG4LFHcalDisplayAction : public PHG4DisplayAction
 
   void ApplyDisplayAction(G4VPhysicalVolume *physvol);
   void AddVolume(G4LogicalVolume *logvol, const std::string &mat) { m_LogicalVolumeMap[logvol] = mat; }
-  
+
  private:
   std::map<G4LogicalVolume *, std::string> m_LogicalVolumeMap;
   std::vector<G4VisAttributes *> m_VisAttVec;

--- a/simulation/g4simulation/g4eiccalos/PHG4LFHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4LFHcalSteppingAction.cc
@@ -82,15 +82,15 @@ bool PHG4LFHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
   unsigned int layer = touch->GetVolume(1)->GetCopyNo();
   int idx_j = icopy >> 16;
   int idx_k = icopy & 0xFFFF;
-  int idx_l = (int)(layer / m_NlayersPerTowerSeg);
+  int idx_l = (int) (layer / m_NlayersPerTowerSeg);
 
   if (Verbosity() > 2)
-    std::cout << "\t" << icopy << "\t idx_j =" << idx_j << ", idx_k =" << idx_k << ", idx_l =" << idx_l <<"\t id:" << icopy << "\t layer:" << layer << std::endl;
-  
+    std::cout << "\t" << icopy << "\t idx_j =" << idx_j << ", idx_k =" << idx_k << ", idx_l =" << idx_l << "\t id:" << icopy << "\t layer:" << layer << std::endl;
+
   /* Get energy deposited by this step */
   double edep = aStep->GetTotalEnergyDeposit() / GeV;
   double eion = (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) / GeV;
-  
+
   /* Get pointer to associated Geant4 track */
   const G4Track* aTrack = aStep->GetTrack();
 
@@ -212,7 +212,7 @@ bool PHG4LFHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     m_Hit->set_x(1, postPoint->GetPosition().x() / cm);
     m_Hit->set_y(1, postPoint->GetPosition().y() / cm);
     m_Hit->set_z(1, postPoint->GetPosition().z() / cm);
-    
+
     m_Hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
 
     /* sum up the energy to get total deposited */
@@ -315,5 +315,4 @@ void PHG4LFHcalSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
       std::cout << "PHG4LFHcalSteppingAction::SetTopNode - unable to find " << absorbernodename << std::endl;
     }
   }
-    
 }

--- a/simulation/g4simulation/g4eiccalos/PHG4LFHcalSubsystem.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4LFHcalSubsystem.cc
@@ -113,7 +113,7 @@ int PHG4LFHcalSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
 int PHG4LFHcalSubsystem::process_event(PHCompositeNode* topNode)
 {
   // pass top node to stepping action so that it gets
-  // relevant nodes needed internally  
+  // relevant nodes needed internally
   if (m_SteppingAction)
   {
     m_SteppingAction->SetInterfacePointers(topNode);
@@ -155,7 +155,6 @@ void PHG4LFHcalSubsystem::SetDefaultParameters()
   set_default_double_param("zdepthcatcheroffset", 1000000.);
   set_default_int_param("nLayerOffsetTailcatcher", 0);
   set_default_int_param("embed_fiber", 0);
-  
 
   std::ostringstream mappingfilename;
   const char* calibroot = getenv("CALIBRATIONROOT");

--- a/simulation/g4simulation/g4eiccalos/PHG4LFHcalSubsystem.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4LFHcalSubsystem.cc
@@ -53,6 +53,7 @@ int PHG4LFHcalSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
   m_Detector->SuperDetector(SuperDetector());
   m_Detector->OverlapCheck(CheckOverlap());
   m_Detector->Verbosity(Verbosity());
+  m_Detector->DoFullLightProp(_do_lightpropagation);
 
   std::set<std::string> nodes;
   if (GetParams()->get_int_param("active"))
@@ -139,7 +140,7 @@ void PHG4LFHcalSubsystem::SetDefaultParameters()
   set_default_double_param("rMax1", 262.);
   set_default_double_param("rMin2", 5.);
   set_default_double_param("rMax2", 336.9);
-  set_default_double_param("wls_dw", 0.1);
+  set_default_double_param("wls_dw", 0.125);
   set_default_double_param("rot_x", 0.);
   set_default_double_param("rot_y", 0.);
   set_default_double_param("rot_z", 0.);
@@ -149,8 +150,11 @@ void PHG4LFHcalSubsystem::SetDefaultParameters()
   set_default_double_param("thickness_scintillator", 0.4);
   set_default_int_param("nlayerspertowerseg", 10);
   set_default_int_param("usetailcatcher", 0);
+  set_default_double_param("frame_width", 0.);
+  set_default_double_param("width_coating", 0.);
   set_default_double_param("zdepthcatcheroffset", 1000000.);
   set_default_int_param("nLayerOffsetTailcatcher", 0);
+  set_default_int_param("embed_fiber", 0);
   
 
   std::ostringstream mappingfilename;

--- a/simulation/g4simulation/g4eiccalos/PHG4LFHcalSubsystem.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4LFHcalSubsystem.h
@@ -41,6 +41,8 @@ class PHG4LFHcalSubsystem : public PHG4DetectorSubsystem
   PHG4SteppingAction *GetSteppingAction() const { return m_SteppingAction; }
   PHG4DisplayAction *GetDisplayAction() const { return m_DisplayAction; }
 
+  void DoFullLightPropagation(bool doProp) {_do_lightpropagation = doProp;};
+
   /** Set mapping file for calorimeter towers
    */
   void SetTowerMappingFile(const std::string &filename);
@@ -67,6 +69,7 @@ class PHG4LFHcalSubsystem : public PHG4DetectorSubsystem
   /*! derives from PHG4DisplayAction */
   PHG4DisplayAction *m_DisplayAction = nullptr;
   bool showdetailed = false;
+  bool _do_lightpropagation = false;
 };
 
 #endif

--- a/simulation/g4simulation/g4eiccalos/PHG4LFHcalSubsystem.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4LFHcalSubsystem.h
@@ -41,20 +41,19 @@ class PHG4LFHcalSubsystem : public PHG4DetectorSubsystem
   PHG4SteppingAction *GetSteppingAction() const { return m_SteppingAction; }
   PHG4DisplayAction *GetDisplayAction() const { return m_DisplayAction; }
 
-  void DoFullLightPropagation(bool doProp) {_do_lightpropagation = doProp;};
+  void DoFullLightPropagation(bool doProp) { _do_lightpropagation = doProp; };
 
   /** Set mapping file for calorimeter towers
    */
   void SetTowerMappingFile(const std::string &filename);
   /** Set layers per tower segment by hand, has to be set in addition to mapping file
    */
-  void SetLayerPerTowerSegment(int layerPerTowerSeg) {set_int_param("nlayerspertowerseg", layerPerTowerSeg); }
-  
+  void SetLayerPerTowerSegment(int layerPerTowerSeg) { set_int_param("nlayerspertowerseg", layerPerTowerSeg); }
+
   /** Set level of detail for display
    */
-  void SetDetailed(bool b){showdetailed = b;}
+  void SetDetailed(bool b) { showdetailed = b; }
 
-  
  private:
   void SetDefaultParameters();
 

--- a/simulation/g4simulation/g4eiccalos/PHG4ProjCrystalCalorimeterDetector.cc
+++ b/simulation/g4simulation/g4eiccalos/PHG4ProjCrystalCalorimeterDetector.cc
@@ -20,11 +20,11 @@
 #include <Geant4/G4Transform3D.hh>  // for G4Transform3D
 #include <Geant4/G4Trd.hh>
 #include <Geant4/G4TwoVector.hh>
-#include <Geant4/G4Types.hh>            // for G4double, G4int
+#include <Geant4/G4Types.hh>  // for G4double, G4int
 
 #include <TSystem.h>
 
-#include <cmath> // for M_PI
+#include <cmath>  // for M_PI
 #include <cstdlib>
 #include <iostream>
 #include <sstream>

--- a/simulation/g4simulation/g4eiccalos/PHG4ProjCrystalCalorimeterDetector.h
+++ b/simulation/g4simulation/g4eiccalos/PHG4ProjCrystalCalorimeterDetector.h
@@ -9,7 +9,7 @@
 
 #include <Geant4/G4Types.hh>  // for G4double, G4int
 
-#include <set>                               // for set
+#include <set>     // for set
 #include <string>  // for string
 
 class G4LogicalVolume;

--- a/simulation/g4simulation/g4eiccalos/RawTowerBuilderByHitIndexBECAL.cc
+++ b/simulation/g4simulation/g4eiccalos/RawTowerBuilderByHitIndexBECAL.cc
@@ -3,38 +3,38 @@
 #include <calobase/RawTowerContainer.h>
 #include <calobase/RawTowerv1.h>
 
-#include <calobase/RawTower.h>                 // for RawTower
-#include <calobase/RawTowerDefs.h>             // for convert_name_to_caloid
-#include <calobase/RawTowerGeom.h>             // for RawTowerGeom
-#include <calobase/RawTowerGeomv4.h>
-#include <calobase/RawTowerGeomContainer.h>    // for RawTowerGeomContainer
+#include <calobase/RawTower.h>               // for RawTower
+#include <calobase/RawTowerDefs.h>           // for convert_name_to_caloid
+#include <calobase/RawTowerGeom.h>           // for RawTowerGeom
+#include <calobase/RawTowerGeomContainer.h>  // for RawTowerGeomContainer
 #include <calobase/RawTowerGeomContainer_Cylinderv1.h>
+#include <calobase/RawTowerGeomv4.h>
 
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>                // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHNode.h>                      // for PHNode
+#include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
-#include <phool/PHObject.h>                    // for PHObject
+#include <phool/PHObject.h>  // for PHObject
 #include <phool/getClass.h>
-#include <phool/phool.h>                       // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
 #include <TRotation.h>
 #include <TVector3.h>
 
-#include <cstdlib>                            // for exit
-#include <exception>                           // for exception
+#include <cstdlib>    // for exit
+#include <exception>  // for exception
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <sstream>
 #include <stdexcept>
-#include <utility>                             // for pair, make_pair
+#include <utility>  // for pair, make_pair
 
 using namespace std;
 
@@ -131,12 +131,12 @@ int RawTowerBuilderByHitIndexBECAL::process_event(PHCompositeNode *topNode)
   if (Verbosity())
   {
     towerE = m_Towers->getTotalEdep();
-    std::cout << "towers before compression: "<< m_Towers->size() << "\t" << m_Detector << std::endl;
+    std::cout << "towers before compression: " << m_Towers->size() << "\t" << m_Detector << std::endl;
   }
   m_Towers->compress(m_Emin);
   if (Verbosity())
   {
-    std::cout << "storing towers: "<< m_Towers->size() << std::endl;
+    std::cout << "storing towers: " << m_Towers->size() << std::endl;
     cout << "Energy lost by dropping towers with less than " << m_Emin
          << " energy, lost energy: " << towerE - m_Towers->getTotalEdep() << endl;
     m_Towers->identify();
@@ -181,7 +181,7 @@ void RawTowerBuilderByHitIndexBECAL::CreateNodes(PHCompositeNode *topNode)
 
   // Create the tower geometry node on the tree
   m_Geoms = new RawTowerGeomContainer_Cylinderv1(RawTowerDefs::convert_name_to_caloid(m_Detector));
-  
+
   string NodeNameTowerGeometries = "TOWERGEOM_" + m_Detector;
 
   PHIODataNode<PHObject> *geomNode = new PHIODataNode<PHObject>(m_Geoms, NodeNameTowerGeometries, "PHObject");
@@ -255,11 +255,10 @@ bool RawTowerBuilderByHitIndexBECAL::ReadGeometryFromTable()
       double rot_z, rot_y, rot_x;
       double size_z, size_y1, size_x1, size_y2, size_x2, p_Theta;
       std::string dummys;
- 
- 
-      if (!(iss >> dummys >> ideta_k >> idphi_j >>  size_x1 >>  size_x2 >> size_y1 >> size_y2 >> size_z >> p_Theta >> cx >> cy >> cz >> rot_x >> rot_y >> rot_z))
+
+      if (!(iss >> dummys >> ideta_k >> idphi_j >> size_x1 >> size_x2 >> size_y1 >> size_y2 >> size_z >> p_Theta >> cx >> cy >> cz >> rot_x >> rot_y >> rot_z))
       {
-        std::cout << "ERROR in PHG4ForwardHcalDetector: Failed to read line in mapping file " <<  m_MappingTowerFile << std::endl;
+        std::cout << "ERROR in PHG4ForwardHcalDetector: Failed to read line in mapping file " << m_MappingTowerFile << std::endl;
         exit(1);
       }
 
@@ -275,9 +274,9 @@ bool RawTowerBuilderByHitIndexBECAL::ReadGeometryFromTable()
       temp_geo->set_rotz(rot_z);
 
       m_Geoms->add_tower_geometry(temp_geo);
-
-    }else{
-      
+    }
+    else
+    {
       string parname;
       double parval;
       if (!(iss >> parname >> parval))
@@ -300,44 +299,40 @@ bool RawTowerBuilderByHitIndexBECAL::ReadGeometryFromTable()
       {
         radius = parit->second;  // in cm
       }
-      
+
       parit = m_GlobalParameterMap.find("tower_length");
       if (parit != m_GlobalParameterMap.end())
       {
         tower_length = parit->second;  // in cm
       }
-
     }
-
   }
 
-  m_Geoms->set_radius(radius + 0.5*tower_length); 
-  //cout << PHWHERE << "BECAL radius set to " <<  m_Geoms->get_radius() << " cm" << endl; 
-    
+  m_Geoms->set_radius(radius + 0.5 * tower_length);
+  //cout << PHWHERE << "BECAL radius set to " <<  m_Geoms->get_radius() << " cm" << endl;
+
   RawTowerGeomContainer::ConstRange all_towers = m_Geoms->get_tower_geometries();
-   
+
   for (RawTowerGeomContainer::ConstIterator it = all_towers.first;
-   it != all_towers.second; ++it)
+       it != all_towers.second; ++it)
   {
     double x_temp = it->second->get_center_x();
     double y_temp = it->second->get_center_y();
     double z_temp = it->second->get_center_z();
-    double roty   = it->second->get_roty();
-    double rotz   = it->second->get_rotz();
-  
+    double roty = it->second->get_roty();
+    double rotz = it->second->get_rotz();
 
-    double x_tempfinal =  x_temp + thickness_wall/2*abs(cos(roty - M_PI_2))*cos(rotz);
-    double y_tempfinal =  y_temp + thickness_wall/2*abs(cos(roty - M_PI_2))*sin(rotz);
-    double z_tempfinal =  z_temp + thickness_wall*sin(roty - M_PI_2);
+    double x_tempfinal = x_temp + thickness_wall / 2 * abs(cos(roty - M_PI_2)) * cos(rotz);
+    double y_tempfinal = y_temp + thickness_wall / 2 * abs(cos(roty - M_PI_2)) * sin(rotz);
+    double z_tempfinal = z_temp + thickness_wall * sin(roty - M_PI_2);
 
     it->second->set_center_x(x_tempfinal);
     it->second->set_center_y(y_tempfinal);
     it->second->set_center_z(z_tempfinal);
 
-
     if (Verbosity() > 2)
     {
-      cout << "*** Tower x y z : " << x_temp << " " << y_temp << " " << z_temp << endl;    
+      cout << "*** Tower x y z : " << x_temp << " " << y_temp << " " << z_temp << endl;
     }
   }
   if (Verbosity())
@@ -346,5 +341,4 @@ bool RawTowerBuilderByHitIndexBECAL::ReadGeometryFromTable()
   }
 
   return true;
-
 }

--- a/simulation/g4simulation/g4eiccalos/RawTowerBuilderByHitIndexBECAL.h
+++ b/simulation/g4simulation/g4eiccalos/RawTowerBuilderByHitIndexBECAL.h
@@ -6,7 +6,7 @@
 #include <fun4all/SubsysReco.h>
 
 #include <map>
-#include <string> 
+#include <string>
 
 class PHCompositeNode;
 class RawTowerContainer;
@@ -84,9 +84,9 @@ class RawTowerBuilderByHitIndexBECAL : public SubsysReco
 
   RawTowerDefs::CalorimeterId m_CaloId;
 
-  double thickness_wall = -1.; 
-  double radius = 85.0; 
-  double tower_length = 45.5; 
+  double thickness_wall = -1.;
+  double radius = 85.0;
+  double tower_length = 45.5;
 
   double m_Emin;
 

--- a/simulation/g4simulation/g4eiccalos/RawTowerBuilderByHitIndexLHCal.cc
+++ b/simulation/g4simulation/g4eiccalos/RawTowerBuilderByHitIndexLHCal.cc
@@ -3,39 +3,39 @@
 #include <calobase/RawTowerContainer.h>
 #include <calobase/RawTowerv2.h>
 
-#include <calobase/RawTower.h>                 // for RawTower
-#include <calobase/RawTowerDefs.h>             // for convert_name_to_caloid
-#include <calobase/RawTowerGeom.h>             // for RawTowerGeom
-#include <calobase/RawTowerGeomv3.h>
-#include <calobase/RawTowerGeomContainer.h>    // for RawTowerGeomContainer
+#include <calobase/RawTower.h>               // for RawTower
+#include <calobase/RawTowerDefs.h>           // for convert_name_to_caloid
+#include <calobase/RawTowerGeom.h>           // for RawTowerGeom
+#include <calobase/RawTowerGeomContainer.h>  // for RawTowerGeomContainer
 #include <calobase/RawTowerGeomContainerv1.h>
+#include <calobase/RawTowerGeomv3.h>
 
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>                // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHNode.h>                      // for PHNode
+#include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
-#include <phool/PHObject.h>                    // for PHObject
+#include <phool/PHObject.h>  // for PHObject
 #include <phool/getClass.h>
-#include <phool/phool.h>                       // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
 #include <TRotation.h>
 #include <TVector3.h>
 
-#include <cstdlib>                            // for exit
-#include <exception>                           // for exception
+#include <bitset>
+#include <cstdlib>    // for exit
+#include <exception>  // for exception
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <sstream>
 #include <stdexcept>
-#include <utility>                             // for pair, make_pair
-#include <bitset>
+#include <utility>  // for pair, make_pair
 
 using namespace std;
 
@@ -124,8 +124,7 @@ int RawTowerBuilderByHitIndexLHCal::process_event(PHCompositeNode *topNode)
     RawTowerDefs::keytype calotowerid = RawTowerDefs::encode_towerid(m_CaloId,
                                                                      g4hit_i->get_index_j(),
                                                                      g4hit_i->get_index_k(),
-                                                                     g4hit_i->get_index_l()
-                                                                    );
+                                                                     g4hit_i->get_index_l());
     /* add the energy to the corresponding tower */
     RawTowerv2 *tower = dynamic_cast<RawTowerv2 *>(m_Towers->getTower(calotowerid));
     if (!tower)
@@ -133,13 +132,13 @@ int RawTowerBuilderByHitIndexLHCal::process_event(PHCompositeNode *topNode)
       tower = new RawTowerv2(calotowerid);
       tower->set_energy(0);
       m_Towers->AddTower(tower->get_id(), tower);
-      if (Verbosity() > 2) 
+      if (Verbosity() > 2)
       {
-        std::cout << "in: " <<  g4hit_i->get_index_j() << "\t" << g4hit_i->get_index_k() << "\t" << g4hit_i->get_index_l() << std::endl;
-        std::cout << "decoded: " <<  tower->get_bineta() << "\t" << tower->get_binphi()  << "\t" << tower->get_binl()  << std::endl;
+        std::cout << "in: " << g4hit_i->get_index_j() << "\t" << g4hit_i->get_index_k() << "\t" << g4hit_i->get_index_l() << std::endl;
+        std::cout << "decoded: " << tower->get_bineta() << "\t" << tower->get_binphi() << "\t" << tower->get_binl() << std::endl;
       }
     }
-    tower->add_ecell((g4hit_i->get_index_j() << (10+4)) + (g4hit_i->get_index_k()<< 4)+ g4hit_i->get_index_l(), g4hit_i->get_light_yield());
+    tower->add_ecell((g4hit_i->get_index_j() << (10 + 4)) + (g4hit_i->get_index_k() << 4) + g4hit_i->get_index_l(), g4hit_i->get_light_yield());
     tower->set_energy(tower->get_energy() + g4hit_i->get_light_yield());
     tower->add_eshower(g4hit_i->get_shower_id(), g4hit_i->get_edep());
   }
@@ -154,7 +153,7 @@ int RawTowerBuilderByHitIndexLHCal::process_event(PHCompositeNode *topNode)
   m_Towers->compress(m_Emin);
   if (Verbosity())
   {
-    std::cout << "storing towers: "<< m_Towers->size() << std::endl;
+    std::cout << "storing towers: " << m_Towers->size() << std::endl;
     cout << "Energy lost by dropping towers with less than " << m_Emin
          << " energy, lost energy: " << towerE - m_Towers->getTotalEdep() << endl;
     m_Towers->identify();
@@ -249,7 +248,6 @@ bool RawTowerBuilderByHitIndexLHCal::ReadGeometryFromTable()
     }
   }
 
-  
   string line_mapping;
 
   while (getline(istream_mapping, line_mapping))
@@ -282,7 +280,8 @@ bool RawTowerBuilderByHitIndexLHCal::ReadGeometryFromTable()
         exit(1);
       }
 
-      for (int il = 0; il < m_NTowerSeg; il++){
+      for (int il = 0; il < m_NTowerSeg; il++)
+      {
         /* Construct unique Tower ID */
         unsigned int temp_id = RawTowerDefs::encode_towerid(m_CaloId, idx_j, idx_k, il);
 
@@ -290,12 +289,12 @@ bool RawTowerBuilderByHitIndexLHCal::ReadGeometryFromTable()
         RawTowerGeom *temp_geo = new RawTowerGeomv3(temp_id);
         temp_geo->set_center_x(pos_x);
         temp_geo->set_center_y(pos_y);
-        
-        float blocklength = m_NLayersPerTowerSeg*(m_ThicknessAbsorber+m_ThicknessScintilator);
-        temp_geo->set_center_z(pos_z-0.5*size_z+(il+0.5)*blocklength);
+
+        float blocklength = m_NLayersPerTowerSeg * (m_ThicknessAbsorber + m_ThicknessScintilator);
+        temp_geo->set_center_z(pos_z - 0.5 * size_z + (il + 0.5) * blocklength);
         temp_geo->set_size_x(size_x);
         temp_geo->set_size_y(size_y);
-        temp_geo->set_size_z(m_NLayersPerTowerSeg*(m_ThicknessAbsorber+m_ThicknessScintilator));
+        temp_geo->set_size_z(m_NLayersPerTowerSeg * (m_ThicknessAbsorber + m_ThicknessScintilator));
         temp_geo->set_tower_type((int) type);
 
         /* Insert this tower into position map */
@@ -318,7 +317,7 @@ bool RawTowerBuilderByHitIndexLHCal::ReadGeometryFromTable()
       }
 
       m_GlobalParameterMap.insert(make_pair(parname, parval));
-      
+
       /* Update member variables for global parameters based on parsed parameter file */
       std::map<string, double>::iterator parit;
 
@@ -359,22 +358,22 @@ bool RawTowerBuilderByHitIndexLHCal::ReadGeometryFromTable()
         m_ThicknessScintilator = parit->second;
 
       if ((m_ThicknessAbsorber + m_ThicknessScintilator) != 0.)
-        m_NLayers = (int)(m_TowerDepth / (m_ThicknessAbsorber + m_ThicknessScintilator));
+        m_NLayers = (int) (m_TowerDepth / (m_ThicknessAbsorber + m_ThicknessScintilator));
 
       parit = m_GlobalParameterMap.find("nlayerspertowerseg");
       if (parit != m_GlobalParameterMap.end())
-        m_NLayersPerTowerSeg = (int)parit->second;
+        m_NLayersPerTowerSeg = (int) parit->second;
 
       if (m_NLayersPerTowerSeg > 0)
-        m_NTowerSeg = (int)(m_NLayers/m_NLayersPerTowerSeg);
-      
+        m_NTowerSeg = (int) (m_NLayers / m_NLayersPerTowerSeg);
+
       if (Verbosity() > 1)
       {
-        std::cout << "RawTowerBuilder LHCal - Absorber: " << m_ThicknessAbsorber << " cm\t Scintilator: "<< m_ThicknessScintilator << " cm\t #Layers: " << m_NLayers << "\t layers per segment: " << m_NLayersPerTowerSeg <<  "\t #segment: "<< m_NTowerSeg << std::endl;
+        std::cout << "RawTowerBuilder LHCal - Absorber: " << m_ThicknessAbsorber << " cm\t Scintilator: " << m_ThicknessScintilator << " cm\t #Layers: " << m_NLayers << "\t layers per segment: " << m_NLayersPerTowerSeg << "\t #segment: " << m_NTowerSeg << std::endl;
       }
     }
   }
-    
+
   /* Correct tower geometries for global calorimter translation / rotation 
    * after reading parameters from file */
   RawTowerGeomContainer::ConstRange all_towers = m_Geoms->get_tower_geometries();

--- a/simulation/g4simulation/g4eiccalos/RawTowerBuilderByHitIndexLHCal.h
+++ b/simulation/g4simulation/g4eiccalos/RawTowerBuilderByHitIndexLHCal.h
@@ -95,7 +95,7 @@ class RawTowerBuilderByHitIndexLHCal : public SubsysReco
   double m_Emin;
   double m_TowerDepth;
   double m_ThicknessAbsorber;
-  double  m_ThicknessScintilator;
+  double m_ThicknessScintilator;
   int m_NLayers;
   int m_NLayersPerTowerSeg;
   int m_NTowerSeg;


### PR DESCRIPTION
This PR introduces the possibility to do light propagation for EEMCH, FEMC and LFHCAL (not perfect yet and should ONLY be used for small studies due to processing time and memory consumption).

In addition, the geometry for the above mentioned calorimeters has been greatly improved by incorporating supports, missing materials, readout fibers, SiPM chips, and more..

Macro changes still need to be ported and are currently only in a devel-fork: https://github.com/raymondEhlers/macros-1/commit/98a30f9de72087615c1ec3e6e4233ce89527daf6

![LFHCAL_zoom2](https://user-images.githubusercontent.com/26540097/146221918-b84abcfa-56b8-4c24-a856-982f2f562048.png)
![FEMC_twr_plated](https://user-images.githubusercontent.com/26540097/146221963-465a1273-1413-4778-9f57-a89f3670d29f.png)
![lightpropagation_EEMC](https://user-images.githubusercontent.com/26540097/146222011-d02b5054-4794-415d-81cc-957b2a424896.png)

