### PR TITLE
Fix compilation

### DIFF
--- a/simulation/g4simulation/g4bwd/Makefile.am
+++ b/simulation/g4simulation/g4bwd/Makefile.am
@@ -33,10 +33,7 @@ libEICG4Bwd_la_LDFLAGS  = \
   -lg4detectors_io \
   -lphg4hit\
   -lgsl \
-  -lgslcblas \
-  -lg4eval_io \
-  -lg4eval \
-  -leiceval
+  -lgslcblas
 
 libEICG4Bwd_la_LIBADD = \
   -lphool \


### PR DESCRIPTION
Fix compilation dependency error for `simulation/g4simulation/g4bwd` , which does not need g4eval libs to work. 